### PR TITLE
feat: Add a SearchProducts function

### DIFF
--- a/data_operator.go
+++ b/data_operator.go
@@ -17,6 +17,7 @@ import "errors"
 type DataOperator interface {
 	// GetProduct will return a pointer to a Product, given a item code.
 	GetProduct(code string) (*Product, error)
+	SearchProducts(productSearch *ProductSearch) (*[]Product, error)
 }
 
 var (

--- a/product.go
+++ b/product.go
@@ -81,7 +81,7 @@ type Product struct {
 	IngredientsFromPalmOilNumber                int            `json:"ingredients_from_palm_oil_n"`
 	IngredientsFromPalmOilTags                  []interface{}  `json:"ingredients_from_palm_oil_tags"`
 	IngredientsIdsDebug                         []string       `json:"ingredients_ids_debug"`
-	IngredientsN                                string         `json:"ingredients_n"`
+	IngredientsN                                json.Number    `json:"ingredients_n"`
 	IngredientsNTags                            []string       `json:"ingredients_n_tags"`
 	IngredientsTags                             []string       `json:"ingredients_tags"`
 	IngredientsText                             string         `json:"ingredients_text"`
@@ -106,7 +106,7 @@ type Product struct {
 	LanguagesHierarchy                          []string       `json:"languages_hierarchy"`
 	LanguagesTags                               []string       `json:"languages_tags"`
 	Locale                                      string         `json:"lc"`
-	MaxImgId                                    string         `json:"max_imgid"`
+	MaxImgId                                    json.Number    `json:"max_imgid"`
 	NewAdditivesNumber                          int            `json:"new_additives_n"`
 	NoNutritionData                             interface{}    `json:"no_nutrition_data"`
 	NutrientLevels                              NutrientLevel  `json:"nutrient_levels"`

--- a/product_results.go
+++ b/product_results.go
@@ -1,0 +1,9 @@
+// Copyright © 2016 OpenFoodFacts. All rights reserved.
+// Use of this source code is governed by the MIT license which can be found in the LICENSE.txt file.
+
+package openfoodfacts
+
+type ProductResults struct {
+	Count          int   `json:"count"`
+	Products       *[]Product `json:"products"`
+}

--- a/product_search.go
+++ b/product_search.go
@@ -1,0 +1,11 @@
+// Copyright © 2016 OpenFoodFacts. All rights reserved.
+// Use of this source code is governed by the MIT license which can be found in the LICENSE.txt file.
+
+package openfoodfacts
+
+type ProductSearch struct {
+	SearchTerms string `url:"search_terms"`
+	Page int `url:"page"`
+	PageSize int `url:"page_size"`
+	SortBy string `url:"sort_by"`
+}

--- a/product_test.go
+++ b/product_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openfoodfacts/openfoodfacts-go"
 )
 
-func TestProduct(t *testing.T) {
+func TestGetProduct(t *testing.T) {
 	codes := [...]string{
 		"5201051001076",
 		"9300650658615",
@@ -64,5 +64,24 @@ func TestProduct(t *testing.T) {
 		if testing.Short() {
 			return
 		}
+	}
+}
+
+func TestSearchProducts(t *testing.T) {
+	api := openfoodfacts.NewHttpApiOperator("world", "", "")
+	api.(*openfoodfacts.HttpApi).Sandbox()
+
+	var productSeach = openfoodfacts.ProductSearch{"test", 1, 20, "name"}
+
+	products, err := api.SearchProducts(&productSeach)
+
+	if err != nil {
+		t.Error("Error during search of item", err)
+	} else if len(*products) == 0 {
+		t.Error("Error no result found")
+	}
+
+	if testing.Short() {
+		return
 	}
 }


### PR DESCRIPTION
Hello,

I added a search products function to the lib, based on https://en.wiki.openfoodfacts.org/API#Generic_Search.

For now it's just support `search_terms` with sorting and pagination. But I'll maybe add more fields from the  `product` struct in the future.