### PR TITLE
Fix IngredientsN "cannot unmarshal string into int" error

### DIFF
--- a/product.go
+++ b/product.go
@@ -3,7 +3,31 @@
 
 package openfoodfacts
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"bytes"
+)
+
+// FIXME: API returns IngredientsN as a string for some products
+type StringInt int
+
+func (f StringInt) MarshalJSON() ([]byte, error) {
+	return json.Marshal(int(f))
+}
+
+func (f *StringInt) UnmarshalJSON(data []byte) error {
+	var v int
+	if len(data) >= 2 && data[0] == '"' && data[len(data)-1] == '"' {
+		// Remove single set of matching quotes
+		data = data[1 : len(data)-1]
+	}
+	// And, optionally if you also then want to remove any whitespace:
+	data = bytes.TrimSpace(data)
+
+	err := json.Unmarshal(data, &v)
+	*f = StringInt(v)
+	return err
+}
 
 type Product struct {
 	Id                                          string         `json:"id"`
@@ -81,7 +105,7 @@ type Product struct {
 	IngredientsFromPalmOilNumber                int            `json:"ingredients_from_palm_oil_n"`
 	IngredientsFromPalmOilTags                  []interface{}  `json:"ingredients_from_palm_oil_tags"`
 	IngredientsIdsDebug                         []string       `json:"ingredients_ids_debug"`
-	IngredientsN                                int            `json:"ingredients_n,string"`
+	IngredientsN                                StringInt      `json:"ingredients_n"`
 	IngredientsNTags                            []string       `json:"ingredients_n_tags"`
 	IngredientsTags                             []string       `json:"ingredients_tags"`
 	IngredientsText                             string         `json:"ingredients_text"`

--- a/product.go
+++ b/product.go
@@ -81,7 +81,7 @@ type Product struct {
 	IngredientsFromPalmOilNumber                int            `json:"ingredients_from_palm_oil_n"`
 	IngredientsFromPalmOilTags                  []interface{}  `json:"ingredients_from_palm_oil_tags"`
 	IngredientsIdsDebug                         []string       `json:"ingredients_ids_debug"`
-	IngredientsN                                int            `json:"ingredients_n"`
+	IngredientsN                                int            `json:"ingredients_n,string"`
 	IngredientsNTags                            []string       `json:"ingredients_n_tags"`
 	IngredientsTags                             []string       `json:"ingredients_tags"`
 	IngredientsText                             string         `json:"ingredients_text"`

--- a/product.go
+++ b/product.go
@@ -5,29 +5,7 @@ package openfoodfacts
 
 import (
 	"encoding/json"
-	"bytes"
 )
-
-// FIXME: API returns IngredientsN as a string for some products
-type StringInt int
-
-func (f StringInt) MarshalJSON() ([]byte, error) {
-	return json.Marshal(int(f))
-}
-
-func (f *StringInt) UnmarshalJSON(data []byte) error {
-	var v int
-	if len(data) >= 2 && data[0] == '"' && data[len(data)-1] == '"' {
-		// Remove single set of matching quotes
-		data = data[1 : len(data)-1]
-	}
-	// And, optionally if you also then want to remove any whitespace:
-	data = bytes.TrimSpace(data)
-
-	err := json.Unmarshal(data, &v)
-	*f = StringInt(v)
-	return err
-}
 
 type Product struct {
 	Id                                          string         `json:"id"`
@@ -105,7 +83,7 @@ type Product struct {
 	IngredientsFromPalmOilNumber                int            `json:"ingredients_from_palm_oil_n"`
 	IngredientsFromPalmOilTags                  []interface{}  `json:"ingredients_from_palm_oil_tags"`
 	IngredientsIdsDebug                         []string       `json:"ingredients_ids_debug"`
-	IngredientsN                                StringInt      `json:"ingredients_n"`
+	IngredientsN                                json.Number    `json:"ingredients_n"`
 	IngredientsNTags                            []string       `json:"ingredients_n_tags"`
 	IngredientsTags                             []string       `json:"ingredients_tags"`
 	IngredientsText                             string         `json:"ingredients_text"`

--- a/product.go
+++ b/product.go
@@ -3,9 +3,7 @@
 
 package openfoodfacts
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
 
 type Product struct {
 	Id                                          string         `json:"id"`


### PR DESCRIPTION
`ingredients_n` appears to be returned by the API as a string, so on some products Go JSON serialiser fails with the following error:

```
json: cannot unmarshal string into Go struct field Product.product.ingredients_n of type int at:
  itives_old_tags":["en:e160c"],"ingredients_n":"11"⚠️ ,"code":"42503705580
```
This seems like an easy fix, however I'm not sure if the fact that API returns a string here is a problem in itself.