### PR TITLE
Added parameter to set HTTP client timeout

### DIFF
--- a/client.go
+++ b/client.go
@@ -130,7 +130,7 @@ func (h *Client) Sandbox() {
 
 // Timeout configures the HTTP client timeout. As the net/http specifies a 0 timeout means no timeout.
 func (h *Client) Timeout(timeout time.Duration) {
-	h.client = &http.Client{Timeout: timeout}
+	h.client.Timeout = timeout
 }
 
 // newRequest is an internal function to setup the request based on the given

--- a/client.go
+++ b/client.go
@@ -59,7 +59,7 @@ func NewClient(locale, username, password string) Client {
 		username: username,
 		password: password,
 		live:     true,
-		client:   http.DefaultClient,
+		client:   &http.Client{},
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -34,7 +34,7 @@ type Client struct {
 	username string
 	password string
 	live     bool
-	timeout  time.Duration
+	client   *http.Client
 }
 
 // NewClient returns a Client that is capable of talking to the official OpenFoodFacts database via
@@ -59,7 +59,7 @@ func NewClient(locale, username, password string) Client {
 		username: username,
 		password: password,
 		live:     true,
-		timeout:  0,
+		client:   http.DefaultClient,
 	}
 }
 
@@ -70,7 +70,7 @@ func NewClient(locale, username, password string) Client {
 func (h *Client) Product(code string) (*Product, error) {
 	request := h.newRequest("GET", "/api/v0/product/%s.json", code)
 
-	resp, err := (&http.Client{Timeout: h.timeout}).Do(request)
+	resp, err := h.client.Do(request)
 
 	if err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func (h *Client) Sandbox() {
 
 // Timeout configures the HTTP client timeout. As the net/http specifies a 0 timeout means no timeout.
 func (h *Client) Timeout(timeout time.Duration) {
-	h.timeout = timeout
+	h.client = &http.Client{Timeout: timeout}
 }
 
 // newRequest is an internal function to setup the request based on the given

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,10 @@
 
 package openfoodfacts
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // You can use the Client.Product method to retrieve a Product by barcode.
 func ExampleClient_Product() {
@@ -18,6 +21,12 @@ func ExampleClient_Product() {
 func ExampleClient_Sandbox() {
 	api := NewClient("world", "", "")
 	api.Sandbox() // Enable test mode
+}
+
+// This will set a timeout for the http client
+func ExampleClient_Timeout() {
+	api := NewClient("world", "", "")
+	api.Timeout(10 * time.Second) // Set http client timeout
 }
 
 // Create a Client to retrieve and modify database items.


### PR DESCRIPTION
Adds a parameter to the client to set the HTTP client timeout. More info on Issue https://github.com/openfoodfacts/openfoodfacts-go/issues/33

Closes #33.