### PR TITLE
fix: process IngredientsN as string or int

### DIFF
--- a/product.go
+++ b/product.go
@@ -81,7 +81,7 @@ type Product struct {
 	IngredientsFromPalmOilNumber                int            `json:"ingredients_from_palm_oil_n"`
 	IngredientsFromPalmOilTags                  []interface{}  `json:"ingredients_from_palm_oil_tags"`
 	IngredientsIdsDebug                         []string       `json:"ingredients_ids_debug"`
-	IngredientsN                                int            `json:"ingredients_n"`
+	IngredientsN                                json.Number    `json:"ingredients_n"`
 	IngredientsNTags                            []string       `json:"ingredients_n_tags"`
 	IngredientsTags                             []string       `json:"ingredients_tags"`
 	IngredientsText                             string         `json:"ingredients_text"`

--- a/product_test.go
+++ b/product_test.go
@@ -90,11 +90,11 @@ func TestProduct_Unmarshalling(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			productFile, err := os.Open(tc.fixture)
-
 			if err != nil {
 				t.Error("Error when opening test file", tc.fixture)
 				return
 			}
+			defer productFile.Close()
 
 			byteProducts, err := ioutil.ReadAll(productFile)
 			if err != nil {

--- a/product_test.go
+++ b/product_test.go
@@ -4,7 +4,10 @@
 package openfoodfacts_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -63,5 +66,48 @@ func TestProduct(t *testing.T) {
 		if testing.Short() {
 			return
 		}
+	}
+}
+
+func TestProduct_Unmarshalling(t *testing.T) {
+	cases := []struct {
+		fixture   string
+		returnErr bool
+		name      string
+	}{
+		{
+			fixture:   "testdata/product/ingredients_n_as_int.json",
+			returnErr: false,
+			name:      "UnmarshallingIntIngredientNAsInt",
+		},
+		{
+			fixture:   "testdata/product/ingredients_n_as_string.json",
+			returnErr: false,
+			name:      "UnmarshallingIntIngredientNAsString",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			productFile, err := os.Open(tc.fixture)
+
+			if err != nil {
+				t.Error("Error when opening test file", tc.fixture)
+				return
+			}
+
+			byteProducts, err := ioutil.ReadAll(productFile)
+			if err != nil {
+				t.Error("Error when reading test data", tc.fixture)
+				return
+			}
+
+			var pr openfoodfacts.ProductResult
+			err = json.Unmarshal(byteProducts, &pr)
+			if err != nil {
+				t.Error("Error when unmarshalling test data", tc.fixture)
+				return
+			}
+		})
 	}
 }

--- a/testdata/product/ingredients_n_as_int.json
+++ b/testdata/product/ingredients_n_as_int.json
@@ -1,0 +1,10 @@
+{
+    "code": "4388858946739",
+    "product": {
+        "_id": "4388858946739",
+        "id": "4388858946739",
+        "ingredients_n": 1
+    },
+    "status": 1,
+    "status_verbose": "product found"
+}

--- a/testdata/product/ingredients_n_as_string.json
+++ b/testdata/product/ingredients_n_as_string.json
@@ -1,0 +1,10 @@
+{
+    "code": "4388858946739",
+    "product": {
+        "_id": "4388858946739",
+        "id": "4388858946739",
+        "ingredients_n": "1"
+}, 
+    "status": 1,
+    "status_verbose": "product found"
+}


### PR DESCRIPTION
Hi there, 

Since I plan to add some new fields to the Product structs, here's my proposal to fix the unmarshalling error that occurred when `IngredientsN` is provided as a string. 

I've used the same solution as in #29 but also added specific unit tests using a testdata folder as suggested by @sbinet. 

Feel free to disregard this pull request if you prefer to merge #29, I won't mind :slightly_smiling_face: 