### PR TITLE
chore: switch product_test to use test data only

### DIFF
--- a/product.go
+++ b/product.go
@@ -130,7 +130,7 @@ type Product struct {
 	PurchasePlaces                              string         `json:"purchase_places"`
 	PurchasePlacesTags                          []interface{}  `json:"purchase_places_tags"`
 	Quantity                                    string         `json:"quantity"`
-	Rev                                         string         `json:"rev"`
+	Rev                                         json.Number    `json:"rev"`
 	ScansNumber                                 int            `json:"scans_n"`
 	ServingQuantity                             json.Number    `json:"serving_quantity"`
 	ServingSize                                 string         `json:"serving_size"`

--- a/product_test.go
+++ b/product_test.go
@@ -5,69 +5,12 @@ package openfoodfacts_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/openfoodfacts/openfoodfacts-go"
 )
-
-func TestProduct(t *testing.T) {
-	codes := [...]string{
-		"5201051001076",
-		"9300650658615",
-		"9310155100335",
-		"9300601768226",
-		"22007377",
-		"3222473161867",
-		"3242272260059",
-		"0737628064502",
-		"5410228196693",
-		"5015821151720",
-		"5601077161035",
-		"3596710352418",
-		"8992696419766",
-		"3551100749018",
-		"5449000179661",
-		"3502110000880",
-		"8712000031312",
-		"6194002510064",
-		"3800020430781",
-		"5050854517631",
-		"5054070608074",
-		"8424259826051",
-		"5010251168577",
-		"4388858946739",
-		"4000539770708",
-		"3560070976867",
-		"0849092103196",
-		"7640101710236",
-		"3245412470929",
-		"3033610048398",
-		"0812133010036",
-		"8585002476821",
-		"3560070805259",
-	}
-
-	api := openfoodfacts.NewClient("world", "", "")
-	api.Sandbox()
-
-	for _, code := range codes {
-		product, err := api.Product(code)
-
-		if err != nil {
-			t.Error("Error during fetching of item", code, err)
-		} else if strings.TrimLeft(product.Code, "0") != strings.TrimLeft(code, "0") {
-			t.Error("Wrong or different code in retrieved item, expected", code, "got", product.Code, "for item", code, "\n", fmt.Sprintf("%+v", product))
-		}
-
-		if testing.Short() {
-			return
-		}
-	}
-}
 
 func TestProduct_Unmarshalling(t *testing.T) {
 	cases := []struct {
@@ -75,16 +18,41 @@ func TestProduct_Unmarshalling(t *testing.T) {
 		returnErr bool
 		name      string
 	}{
-		{
-			fixture:   "testdata/product/ingredients_n_as_int.json",
-			returnErr: false,
-			name:      "UnmarshallingIntIngredientNAsInt",
-		},
-		{
-			fixture:   "testdata/product/ingredients_n_as_string.json",
-			returnErr: false,
-			name:      "UnmarshallingIntIngredientNAsString",
-		},
+		{"testdata/product/5201051001076.json", false, "Unmarshalling_5201051001076"},
+		{"testdata/product/9300601768226.json", false, "Unmarshalling_9300601768226"},
+		{"testdata/product/9300650658615.json", false, "Unmarshalling_9300650658615"},
+		{"testdata/product/9310155100335.json", false, "Unmarshalling_9310155100335"},
+		{"testdata/product/22007377.json", false, "Unmarshalling_22007377"},
+		{"testdata/product/3222473161867.json", false, "Unmarshalling_3222473161867"},
+		{"testdata/product/3242272260059.json", false, "Unmarshalling_3242272260059"},
+		{"testdata/product/0737628064502.json", false, "Unmarshalling_0737628064502"},
+		{"testdata/product/5410228196693.json", false, "Unmarshalling_5410228196693"},
+		{"testdata/product/5015821151720.json", false, "Unmarshalling_5015821151720"},
+		{"testdata/product/5601077161035.json", false, "Unmarshalling_5601077161035"},
+		{"testdata/product/3596710352418.json", false, "Unmarshalling_3596710352418"},
+		{"testdata/product/8992696419766.json", false, "Unmarshalling_8992696419766"},
+		{"testdata/product/3551100749018.json", false, "Unmarshalling_3551100749018"},
+		{"testdata/product/5449000179661.json", false, "Unmarshalling_5449000179661"},
+		{"testdata/product/3502110000880.json", false, "Unmarshalling_3502110000880"},
+		{"testdata/product/8712000031312.json", false, "Unmarshalling_8712000031312"},
+		{"testdata/product/6194002510064.json", false, "Unmarshalling_6194002510064"},
+		{"testdata/product/3800020430781.json", false, "Unmarshalling_3800020430781"},
+		{"testdata/product/5050854517631.json", false, "Unmarshalling_5050854517631"},
+		{"testdata/product/5054070608074.json", false, "Unmarshalling_5054070608074"},
+		{"testdata/product/8424259826051.json", false, "Unmarshalling_8424259826051"},
+		{"testdata/product/5010251168577.json", false, "Unmarshalling_5010251168577"},
+		{"testdata/product/4388858946739.json", false, "Unmarshalling_4388858946739"},
+		{"testdata/product/4000539770708.json", false, "Unmarshalling_4000539770708"},
+		{"testdata/product/3560070976867.json", false, "Unmarshalling_3560070976867"},
+		{"testdata/product/0849092103196.json", false, "Unmarshalling_0849092103196"},
+		{"testdata/product/7640101710236.json", false, "Unmarshalling_7640101710236"},
+		{"testdata/product/3245412470929.json", false, "Unmarshalling_3245412470929"},
+		{"testdata/product/3033610048398.json", false, "Unmarshalling_3033610048398"},
+		{"testdata/product/0812133010036.json", false, "Unmarshalling_0812133010036"},
+		{"testdata/product/8585002476821.json", false, "Unmarshalling_8585002476821"},
+		{"testdata/product/3560070805259.json", false, "Unmarshalling_3560070805259"},
+		{"testdata/product/ingredients_n_as_int.json", false, "Unmarshalling_IntIngredientNAsInt"},
+		{"testdata/product/ingredients_n_as_string.json", false, "Unmarshalling_IntIngredientNAsString"},
 	}
 
 	for _, tc := range cases {

--- a/testdata/product/0737628064502.json
+++ b/testdata/product/0737628064502.json
@@ -1,0 +1,1357 @@
+{
+    "status": 1,
+    "code": "0737628064502",
+    "product": {
+        "lc": "en",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "traces_debug_tags": [],
+        "popularity_tags": [
+            "bottom-25-percent-scans-2019",
+            "bottom-20-percent-scans-2019",
+            "top-85-percent-scans-2019",
+            "top-90-percent-scans-2019",
+            "top-50000-it-scans-2019",
+            "top-100000-it-scans-2019",
+            "top-country-it-scans-2019",
+            "top-100000-scans-2020",
+            "at-least-5-scans-2020",
+            "top-75-percent-scans-2020",
+            "top-80-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-10-by-scans-2020",
+            "top-50-by-scans-2020",
+            "top-100-by-scans-2020",
+            "top-500-by-scans-2020",
+            "top-1000-by-scans-2020",
+            "top-5000-by-scans-2020",
+            "top-10000-by-scans-2020",
+            "top-50000-by-scans-2020",
+            "top-100000-by-scans-2020",
+            "top-country-by-scans-2020",
+            "top-5000-ca-scans-2020",
+            "top-10000-ca-scans-2020",
+            "top-50000-ca-scans-2020",
+            "top-100000-ca-scans-2020",
+            "top-50000-be-scans-2020",
+            "top-100000-be-scans-2020"
+        ],
+        "categories_tags": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:cereals-and-potatoes",
+            "en:cereals-and-their-products",
+            "en:noodles",
+            "en:rice-noodles"
+        ],
+        "traces_hierarchy": [
+            "en:peanuts"
+        ],
+        "categories_imported": "Plant-based foods and beverages, Plant-based foods, Cereals and potatoes, Cereals and their products, Noodles",
+        "informers": [
+            "andre",
+            "manu1400",
+            "thierrym"
+        ],
+        "allergens_hierarchy": [],
+        "generic_name": "Rice Noodles",
+        "origins_tags": [
+            "en:thailand"
+        ],
+        "languages_hierarchy": [
+            "en:english"
+        ],
+        "last_image_t": 1345799925,
+        "emb_codes_20141016": "",
+        "additives_n": 1,
+        "pnns_groups_2_tags": [
+            "cereals",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "andre",
+            "thierrym",
+            "usda-ndb-import",
+            "smartchef",
+            "org-database-usda"
+        ],
+        "ingredients_text_with_allergens_en": "Noodle: rice, water. seasoning packet: peanut, sugar, hydrolyzed soy protein, green onion, corn maltodextrin, spice (including paprika), citric acid, sea salt, extractives of paprika (color), silicon dioxide (added to make free flowing), yeast extract.",
+        "sortkey": 1587581231,
+        "product_name_en_debug_tags": [],
+        "categories_old": "Plant-based foods and beverages, Plant-based foods, Cereals and potatoes, Cereals and their products, Noodles, Rice Noodles",
+        "categories_properties": {},
+        "completeness": 0.8,
+        "labels_tags": [
+            "en:gluten-free"
+        ],
+        "traces_from_user": "(en) en:peanuts",
+        "informers_tags": [
+            "andre",
+            "manu1400",
+            "thierrym",
+            "upcbot",
+            "smartchef",
+            "org-database-usda"
+        ],
+        "nutrition_grades_tags": [
+            "c"
+        ],
+        "generic_name_en_debug_tags": [],
+        "lang": "en",
+        "vitamins_tags": [],
+        "origins_lc": "en",
+        "interface_version_modified": "20120622",
+        "product_name_en_imported": "Thai peanut noodle kit includes stir-fry rice noodles & thai peanut seasoning",
+        "ingredients_text_en_debug_tags": [],
+        "additives_tags": [
+            "en:e330"
+        ],
+        "unique_scans_n": 5,
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/073/762/806/4502/nutrition_en.12.400.jpg",
+        "stores_debug_tags": [],
+        "generic_name_en": "Rice Noodles",
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:france",
+            "en:united-states"
+        ],
+        "nova_group_debug": " -- ingredients/en:sugar : 3 -- ingredients/en:colour : 4",
+        "traces_tags": [
+            "en:peanuts"
+        ],
+        "nova_groups": "4",
+        "packaging_tags": [
+            "cellophane",
+            "carton"
+        ],
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/073/762/806/4502/front_en.6.100.jpg",
+        "nutrient_levels": {
+            "sugars": "high",
+            "salt": "moderate",
+            "fat": "moderate",
+            "saturated-fat": "moderate"
+        },
+        "ingredients_analysis_tags": [
+            "en:palm-oil-content-unknown",
+            "en:vegan-status-unknown",
+            "en:vegetarian-status-unknown"
+        ],
+        "created_t": 1345799269,
+        "nutriscore_data": {
+            "proteins": 9.62,
+            "negative_points": 10,
+            "sugars_points": 2,
+            "score": 4,
+            "sodium_value": 288,
+            "positive_points": 6,
+            "is_water": 0,
+            "saturated_fat_value": 1.9,
+            "proteins_points": 5,
+            "saturated_fat_points": 1,
+            "saturated_fat_ratio": 24.9674902470741,
+            "proteins_value": 9.62,
+            "saturated_fat_ratio_points": 3,
+            "fiber_points": 1,
+            "grade": "c",
+            "is_cheese": 0,
+            "energy": 1611,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 1.9,
+            "energy_points": 4,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 3,
+            "is_fat": 0,
+            "energy_value": 1611,
+            "is_beverage": 0,
+            "fiber_value": 1.9,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 25,
+            "sugars_value": 13.46,
+            "saturated_fat": 1.92,
+            "sodium": 288,
+            "sugars": 13.46
+        },
+        "nova_group": 4,
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "c",
+        "data_sources_imported": "Databases, database-usda",
+        "scans_n": 10,
+        "purchase_places_debug_tags": [],
+        "nucleotides_tags": [],
+        "images": {
+            "front_en": {
+                "rev": "6",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 289
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 72
+                    },
+                    "full": {
+                        "h": 1812,
+                        "w": 1311
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 145
+                    }
+                },
+                "normalize": null,
+                "geometry": "0x0--4--4",
+                "imgid": "2"
+            },
+            "nutrition": {
+                "rev": "12",
+                "white_magic": null,
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 216
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 54
+                    },
+                    "full": {
+                        "h": 1611,
+                        "w": 870
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 108
+                    }
+                },
+                "geometry": "0x0--4--4",
+                "imgid": "5"
+            },
+            "ingredients": {
+                "rev": "10",
+                "white_magic": null,
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 289,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 72,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 927,
+                        "w": 1281
+                    },
+                    "200": {
+                        "h": 145,
+                        "w": 200
+                    }
+                },
+                "geometry": "0x0--3--3",
+                "imgid": "4"
+            },
+            "3": {
+                "uploaded_t": 1345799558,
+                "uploader": "andre",
+                "sizes": {
+                    "400": {
+                        "h": 289,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 72,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 927,
+                        "w": 1281
+                    }
+                }
+            },
+            "nutrition_en": {
+                "rev": "12",
+                "white_magic": null,
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 216
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 54
+                    },
+                    "full": {
+                        "h": 1611,
+                        "w": 870
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 108
+                    }
+                },
+                "geometry": "0x0--4--4",
+                "imgid": "5"
+            },
+            "ingredients_en": {
+                "rev": "10",
+                "white_magic": null,
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 289,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 72,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 927,
+                        "w": 1281
+                    },
+                    "200": {
+                        "h": 145,
+                        "w": 200
+                    }
+                },
+                "geometry": "0x0--3--3",
+                "imgid": "4"
+            },
+            "1": {
+                "uploaded_t": 1345799270,
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 284,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 71,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1089,
+                        "w": 1536
+                    }
+                }
+            },
+            "4": {
+                "uploaded_t": 1345799666,
+                "uploader": "andre",
+                "sizes": {
+                    "400": {
+                        "h": 289,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 72,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 927,
+                        "w": 1281
+                    }
+                }
+            },
+            "front": {
+                "rev": "6",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 289
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 72
+                    },
+                    "full": {
+                        "h": 1812,
+                        "w": 1311
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 145
+                    }
+                },
+                "normalize": null,
+                "geometry": "0x0--4--4",
+                "imgid": "2"
+            },
+            "5": {
+                "uploaded_t": 1345799925,
+                "uploader": "andre",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 216
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 54
+                    },
+                    "full": {
+                        "h": 1611,
+                        "w": 870
+                    }
+                }
+            },
+            "2": {
+                "uploaded_t": 1345799309,
+                "uploader": "andre",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 289
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 72
+                    },
+                    "full": {
+                        "h": 1812,
+                        "w": 1311
+                    }
+                }
+            }
+        },
+        "ingredients_n": 18,
+        "editors_tags": [
+            "manu1400",
+            "upcbot",
+            "smartchef",
+            "openfoodfacts-contributors",
+            "usda-ndb-import",
+            "org-database-usda",
+            "andre",
+            "thierrym"
+        ],
+        "manufacturing_places_debug_tags": [],
+        "countries_lc": "en",
+        "allergens_tags": [],
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "completed_t": 1355184837,
+        "emb_codes_debug_tags": [],
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "code": "0737628064502",
+        "manufacturing_places": "",
+        "codes_tags": [
+            "code-13",
+            "0737628064xxx",
+            "073762806xxxx",
+            "07376280xxxxx",
+            "0737628xxxxxx",
+            "073762xxxxxxx",
+            "07376xxxxxxxx",
+            "0737xxxxxxxxx",
+            "073xxxxxxxxxx",
+            "07xxxxxxxxxxx",
+            "0xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "org-database-usda",
+        "labels": "Gluten-free",
+        "entry_dates_tags": [
+            "2012-08-24",
+            "2012-08",
+            "2012"
+        ],
+        "last_edit_dates_tags": [
+            "2020-04-22",
+            "2020-04",
+            "2020"
+        ],
+        "creator": "openfoodfacts-contributors",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "kit",
+            "plant-based",
+            "thai",
+            "food",
+            "and",
+            "simply",
+            "gluten-free",
+            "beverage",
+            "noodle",
+            "cereal",
+            "peanut",
+            "thailand",
+            "their",
+            "stir-fry",
+            "rice",
+            "potatoe",
+            "include",
+            "asia",
+            "seasoning",
+            "kitchen",
+            "product"
+        ],
+        "amino_acids_tags": [],
+        "countries_imported": "United States",
+        "link": "",
+        "ingredients_debug": [
+            "RICE NOODLES ",
+            "(",
+            "(",
+            null,
+            null,
+            "RICE",
+            ",",
+            null,
+            null,
+            null,
+            " WATER)",
+            ",",
+            null,
+            null,
+            null,
+            " SEASONING PACKET ",
+            "(",
+            "(",
+            null,
+            null,
+            "PEANUT",
+            ",",
+            null,
+            null,
+            null,
+            " SUGAR",
+            ",",
+            null,
+            null,
+            null,
+            " SALT",
+            ",",
+            null,
+            null,
+            null,
+            " CORN STARCH",
+            ",",
+            null,
+            null,
+            null,
+            " SPICES ",
+            "[",
+            "[",
+            null,
+            null,
+            "CHILI",
+            ",",
+            null,
+            null,
+            null,
+            " CINNAMON",
+            ",",
+            null,
+            null,
+            null,
+            " PEPPER",
+            ",",
+            null,
+            null,
+            null,
+            " CUMIN",
+            ",",
+            null,
+            null,
+            null,
+            " CLOVE]",
+            ",",
+            null,
+            null,
+            null,
+            " HYDRDLYZED SOY PROTEIN",
+            ",",
+            null,
+            null,
+            null,
+            " GREEN ONIONS",
+            ",",
+            null,
+            null,
+            null,
+            " CITRIC ACID",
+            ",",
+            null,
+            null,
+            null,
+            " PEANUT OIL",
+            ",",
+            null,
+            null,
+            null,
+            " SESAME OIL",
+            ",",
+            null,
+            null,
+            null,
+            " ",
+            ":",
+            ":",
+            null,
+            null,
+            " NATURAL FLAVOR ",
+            ":",
+            ":",
+            null,
+            null,
+            " )."
+        ],
+        "labels_lc": "en",
+        "languages_codes": {
+            "en": 6
+        },
+        "packaging": "Cellophane,Carton",
+        "ingredients_text_en_imported": "Noodle: rice, water. seasoning packet: peanut, sugar, hydrolyzed soy protein, green onion, corn maltodextrin, spice (including paprika), citric acid, sea salt, extractives of paprika (color), silicon dioxide (added to make free flowing), yeast extract.",
+        "packaging_debug_tags": [],
+        "ingredients_text_en": "Noodle: rice, water. seasoning packet: peanut, sugar, hydrolyzed soy protein, green onion, corn maltodextrin, spice (including paprika), citric acid, sea salt, extractives of paprika (color), silicon dioxide (added to make free flowing), yeast extract.",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/073/762/806/4502/front_en.6.400.jpg",
+        "popularity_key": 19900000005,
+        "last_image_dates_tags": [
+            "2012-08-24",
+            "2012-08",
+            "2012"
+        ],
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/073/762/806/4502/front_en.6.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [
+            "en:nutrition-value-very-high-for-category-sugars"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-not-computed"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "openfoodfacts-contributors",
+            "andre"
+        ],
+        "debug_param_sorted_langs": [
+            "en"
+        ],
+        "last_modified_t": 1587581231,
+        "ingredients": [
+            {
+                "percent_max": 100,
+                "id": "en:noodle",
+                "text": "Noodle",
+                "percent_estimate": 53.8461538461538,
+                "percent_min": 7.69230769230769
+            },
+            {
+                "percent_max": 50,
+                "id": "en:water",
+                "percent_estimate": 23.0769230769231,
+                "percent_min": 0,
+                "text": "water",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 33.3333333333333,
+                "id": "en:seasoning packet",
+                "percent_estimate": 11.5384615384615,
+                "percent_min": 0,
+                "text": "seasoning packet"
+            },
+            {
+                "percent_max": 25,
+                "id": "en:sugar",
+                "percent_estimate": 5.76923076923077,
+                "percent_min": 0,
+                "text": "sugar",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 20,
+                "id": "en:hydrolysed-soy-protein",
+                "percent_min": 0,
+                "percent_estimate": 2.88461538461539,
+                "text": "hydrolyzed soy protein",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 16.6666666666667,
+                "id": "en:green-onion",
+                "text": "green onion",
+                "percent_min": 0,
+                "percent_estimate": 1.44230769230769,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 14.2857142857143,
+                "id": "en:corn-maltodextrin",
+                "percent_estimate": 0.721153846153847,
+                "percent_min": 0,
+                "text": "corn maltodextrin",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": 0,
+                "percent_estimate": 0.36057692307692,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": 12.5,
+                "id": "en:spice",
+                "text": "spice"
+            },
+            {
+                "percent_max": 11.1111111111111,
+                "id": "en:e330",
+                "percent_estimate": 0.18028846153846,
+                "percent_min": 0,
+                "text": "citric acid",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 10,
+                "id": "en:sea-salt",
+                "text": "sea salt",
+                "percent_min": 0,
+                "percent_estimate": 0.0901442307692264,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": 0,
+                "percent_estimate": 0.0450721153846132,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": 9.09090909090909,
+                "id": "en:paprika",
+                "processing": "en:extract",
+                "text": "paprika"
+            },
+            {
+                "percent_min": 0,
+                "percent_estimate": 0.0225360576923066,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": 8.33333333333333,
+                "id": "en:e551",
+                "text": "silicon dioxide"
+            },
+            {
+                "percent_max": 7.69230769230769,
+                "id": "en:yeast-extract",
+                "percent_min": 0,
+                "percent_estimate": 0.0225360576923066,
+                "text": "yeast extract",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            }
+        ],
+        "nutriscore_grade": "c",
+        "countries": "France, United States",
+        "stores": "",
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "other_nutritional_substances_tags": [],
+        "cities_tags": [],
+        "brands": "Thai Kitchen,Simply Asia",
+        "categories": "Plant-based foods and beverages, Plant-based foods, Cereals and potatoes, Cereals and their products, Noodles, Rice Noodles",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "ingredients_text_with_allergens": "Noodle: rice, water. seasoning packet: peanut, sugar, hydrolyzed soy protein, green onion, corn maltodextrin, spice (including paprika), citric acid, sea salt, extractives of paprika (color), silicon dioxide (added to make free flowing), yeast extract.",
+        "nutrition_grades": "c",
+        "nutrient_levels_tags": [
+            "en:fat-in-moderate-quantity",
+            "en:saturated-fat-in-moderate-quantity",
+            "en:sugars-in-high-quantity",
+            "en:salt-in-moderate-quantity"
+        ],
+        "nutrition_data_per_imported": "100g",
+        "nutrition_data_prepared_per_imported": "100g",
+        "known_ingredients_n": 29,
+        "minerals_prev_tags": [],
+        "brand_owner_imported": "Simply Asia Foods, Inc.",
+        "product_name": "Thai peanut noodle kit includes stir-fry rice noodles & thai peanut seasoning",
+        "serving_size_debug_tags": [],
+        "brand_owner": "Simply Asia Foods, Inc.",
+        "ingredients_text": "Noodle: rice, water. seasoning packet: peanut, sugar, hydrolyzed soy protein, green onion, corn maltodextrin, spice (including paprika), citric acid, sea salt, extractives of paprika (color), silicon dioxide (added to make free flowing), yeast extract.",
+        "origins": "Thailand",
+        "languages_tags": [
+            "en:english",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "sources_fields": {
+            "org-database-usda": {
+                "fdc_id": "628190",
+                "publication_date": "2019-12-06T00:00:00Z",
+                "modified_date": "2019-09-25T00:00:00Z",
+                "fdc_data_source": "LI",
+                "fdc_category": "All Noodles",
+                "available_date": "2019-09-25T00:00:00Z"
+            }
+        },
+        "lang_debug_tags": [],
+        "serving_quantity": 52,
+        "allergens": "",
+        "serving_size_imported": "0.333 PACKAGE (52 g)",
+        "categories_lc": "en",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/073/762/806/4502/ingredients_en.10.100.jpg",
+        "photographers": [
+            "andre"
+        ],
+        "ecoscore_data": {
+            "missing_agribalyse_match_warning": 1,
+            "status": "unknown",
+            "agribalyse": {
+                "warning": "missing_agribalyse_match"
+            },
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_es": 4,
+                    "transportation_value_be": 2,
+                    "transportation_value_ch": 1,
+                    "transportation_score_be": 12,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:thailand",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_score": 0,
+                    "epi_value": -5,
+                    "transportation_score_ch": 9,
+                    "transportation_score_ie": 0,
+                    "value_nl": -3,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 2,
+                    "value_be": -3,
+                    "value_es": -1,
+                    "transportation_value_ie": 0,
+                    "transportation_score_it": 16,
+                    "transportation_score_de": 12,
+                    "origins_from_origins_field": [
+                        "en:thailand"
+                    ],
+                    "transportation_score_fr": 0,
+                    "transportation_value_nl": 2,
+                    "transportation_value_lu": 0,
+                    "value_ch": -4,
+                    "transportation_score_es": 25,
+                    "transportation_value_it": 2,
+                    "value_de": -3,
+                    "value_it": -3,
+                    "transportation_score_lu": 3,
+                    "transportation_score_nl": 12,
+                    "value_lu": -5
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:unknown",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "score": 0,
+                    "warning": "unscored_shape"
+                },
+                "threatened_species": {}
+            },
+            "missing": {
+                "agb_category": 1,
+                "packagings": 1,
+                "labels": 1
+            }
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/073/762/806/4502/nutrition_en.12.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/073/762/806/4502/nutrition_en.12.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/073/762/806/4502/nutrition_en.12.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/073/762/806/4502/ingredients_en.10.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/073/762/806/4502/ingredients_en.10.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/073/762/806/4502/ingredients_en.10.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/073/762/806/4502/front_en.6.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/073/762/806/4502/front_en.6.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/073/762/806/4502/front_en.6.200.jpg"
+                }
+            }
+        },
+        "origins_old": "Thailand",
+        "rev": 19,
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "org-database-usda",
+        "additives_prev_original_tags": [
+            "en:e330"
+        ],
+        "ingredients_tags": [
+            "en:noodle",
+            "en:dough",
+            "en:water",
+            "en:seasoning-packet",
+            "en:sugar",
+            "en:hydrolysed-soy-protein",
+            "en:protein",
+            "en:vegetable-protein",
+            "en:hydrolysed-vegetable-protein",
+            "en:soy-protein",
+            "en:green-onion",
+            "en:vegetable",
+            "en:root-vegetable",
+            "en:onion",
+            "en:corn-maltodextrin",
+            "en:maltodextrins",
+            "en:spice",
+            "en:e330",
+            "en:sea-salt",
+            "en:salt",
+            "en:paprika",
+            "en:seed",
+            "en:pepper",
+            "en:e551",
+            "en:yeast-extract",
+            "en:yeast",
+            "en:rice",
+            "en:peanut",
+            "en:nut",
+            "en:colour",
+            "en:added-to-make-free-flowing"
+        ],
+        "data_sources_tags": [
+            "databases",
+            "database-usda"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/073/762/806/4502/nutrition_en.12.100.jpg",
+        "labels_prev_tags": [
+            "en:gluten-free"
+        ],
+        "product_name_en": "Thai peanut noodle kit includes stir-fry rice noodles & thai peanut seasoning",
+        "ingredients_from_palm_oil_tags": [],
+        "nutrition_data_prepared_per_debug_tags": [],
+        "categories_hierarchy": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:cereals-and-potatoes",
+            "en:cereals-and-their-products",
+            "en:noodles",
+            "en:Rice Noodles"
+        ],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "unknown",
+        "labels_prev_hierarchy": [
+            "en:gluten-free"
+        ],
+        "languages": {
+            "en:english": 6
+        },
+        "nutrition_data": "on",
+        "ingredients_percent_analysis": 1,
+        "purchase_places": "",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-unknown",
+            "agribalyse-unknown"
+        ],
+        "id": "737628064502",
+        "sources": [
+            {
+                "import_t": 1489067409,
+                "id": "usda-ndb",
+                "fields": [
+                    "brands",
+                    "countries"
+                ],
+                "url": "https://api.nal.usda.gov/ndb/reports/?ndbno=45108002&type=f&format=json&api_key=DEMO_KEY",
+                "images": []
+            },
+            {
+                "import_t": 1587581231,
+                "fields": [
+                    "product_name_en",
+                    "categories",
+                    "brand_owner",
+                    "data_sources",
+                    "nutrition_data_per",
+                    "serving_size",
+                    "ingredients_text_en",
+                    "nutrients.calcium_unit",
+                    "nutrients.calcium_value",
+                    "nutrients.carbohydrates_value",
+                    "nutrients.cholesterol_unit",
+                    "nutrients.cholesterol_value",
+                    "nutrients.energy_value",
+                    "nutrients.energy-kcal_value",
+                    "nutrients.fat_value",
+                    "nutrients.fiber_value",
+                    "nutrients.iron_unit",
+                    "nutrients.iron_value",
+                    "nutrients.proteins_value",
+                    "nutrients.salt_unit",
+                    "nutrients.salt_value",
+                    "nutrients.saturated-fat_value",
+                    "nutrients.sugars_value",
+                    "nutrients.trans-fat_unit",
+                    "nutrients.trans-fat_value",
+                    "nutrients.vitamin-a_unit",
+                    "nutrients.vitamin-a_value",
+                    "nutrients.vitamin-c_unit",
+                    "nutrients.vitamin-c_value"
+                ],
+                "id": "database-usda",
+                "manufacturer": null,
+                "url": null,
+                "name": "database-usda",
+                "images": []
+            }
+        ],
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Cereals and potatoes",
+        "checkers": [],
+        "nutrition_data_prepared": "",
+        "allergens_from_user": "(en) ",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/073/762/806/4502/ingredients_en.10.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:nutrition-value-very-high-for-category-sugars"
+        ],
+        "additives_old_tags": [
+            "en:e330",
+            "en:e551"
+        ],
+        "origins_hierarchy": [
+            "en:thailand"
+        ],
+        "labels_hierarchy": [
+            "en:gluten-free"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "ecoscore_tags": [
+            "unknown"
+        ],
+        "lc_imported": "en",
+        "pnns_groups_2": "Cereals",
+        "nutrition_score_beverage": 0,
+        "complete": 1,
+        "product_quantity": 155,
+        "new_additives_n": 1,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/073/762/806/4502/front_en.6.100.jpg",
+        "ingredients_text_debug": "RICE NOODLES (RICE, WATER), SEASONING PACKET (PEANUT, SUGAR, SALT, CORN STARCH, SPICES [CHILI, CINNAMON, PEPPER, CUMIN, CLOVE], HYDRDLYZED SOY PROTEIN, GREEN ONIONS, CITRIC ACID, PEANUT OIL, SESAME OIL, : NATURAL FLAVOR : ).",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/073/762/806/4502/front_en.6.400.jpg",
+        "_id": "0737628064502",
+        "countries_tags": [
+            "en:france",
+            "en:united-states"
+        ],
+        "ingredients_hierarchy": [
+            "en:noodle",
+            "en:dough",
+            "en:water",
+            "en:seasoning packet",
+            "en:sugar",
+            "en:hydrolysed-soy-protein",
+            "en:protein",
+            "en:vegetable-protein",
+            "en:hydrolysed-vegetable-protein",
+            "en:soy-protein",
+            "en:green-onion",
+            "en:vegetable",
+            "en:root-vegetable",
+            "en:onion",
+            "en:corn-maltodextrin",
+            "en:maltodextrins",
+            "en:spice",
+            "en:e330",
+            "en:sea-salt",
+            "en:salt",
+            "en:paprika",
+            "en:seed",
+            "en:pepper",
+            "en:e551",
+            "en:yeast-extract",
+            "en:yeast",
+            "en:rice",
+            "en:peanut",
+            "en:nut",
+            "en:colour",
+            "en:added to make free flowing"
+        ],
+        "serving_size": "0.333 PACKAGE (52 g)",
+        "additives_original_tags": [
+            "en:e330"
+        ],
+        "stores_tags": [],
+        "nutriscore_score": 4,
+        "compared_to_category": "en:noodles",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "correctors": [
+            "andre",
+            "thierrym"
+        ],
+        "expiration_date_debug_tags": [],
+        "ingredients_n_tags": [
+            "18",
+            "11-20"
+        ],
+        "pnns_groups_1_tags": [
+            "cereals-and-potatoes",
+            "known"
+        ],
+        "additives_old_n": 2,
+        "packagings": [
+            {
+                "shape": "en:unknown",
+                "material": "en:unknown"
+            }
+        ],
+        "quantity": "155 g",
+        "data_quality_errors_tags": [],
+        "brands_tags": [
+            "thai-kitchen",
+            "simply-asia"
+        ],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "link_debug_tags": [],
+        "ingredients_ids_debug": [
+            "rice-noodles",
+            "rice",
+            "water",
+            "seasoning-packet",
+            "peanut",
+            "sugar",
+            "salt",
+            "corn-starch",
+            "spices",
+            "chili",
+            "cinnamon",
+            "pepper",
+            "cumin",
+            "clove",
+            "hydrdlyzed-soy-protein",
+            "green-onions",
+            "citric-acid",
+            "peanut-oil",
+            "sesame-oil",
+            "natural-flavor"
+        ],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [
+            "en:noodle",
+            "en:water",
+            "en:seasoning packet",
+            "en:sugar",
+            "en:hydrolysed-soy-protein",
+            "en:green-onion",
+            "en:corn-maltodextrin",
+            "en:spice",
+            "en:e330",
+            "en:sea-salt",
+            "en:paprika",
+            "en:e551",
+            "en:yeast-extract",
+            "en:rice",
+            "en:peanut",
+            "en:paprika",
+            "en:colour",
+            "en:added to make free flowing"
+        ],
+        "traces": "en:peanuts",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "data_sources": "Databases, database-usda",
+        "unknown_ingredients_n": 2,
+        "manufacturing_places_tags": [],
+        "quantity_debug_tags": [],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "max_imgid": "5",
+        "emb_codes": "",
+        "nutrition_data_per_debug_tags": [],
+        "editors": [
+            "",
+            "thierrym",
+            "manu1400",
+            "andre",
+            "upcbot"
+        ],
+        "nutriscore_score_opposite": -4,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/073/762/806/4502/front_en.6.200.jpg",
+        "brands_debug_tags": [],
+        "nutriments": {
+            "iron_serving": 0.000359,
+            "cholesterol": 0,
+            "carbohydrates_unit": "g",
+            "iron": 0.00069,
+            "trans-fat_unit": "g",
+            "saturated-fat_serving": 0.998,
+            "sugars_100g": 13.46,
+            "energy-kcal": 385,
+            "vitamin-c_100g": 0,
+            "sodium_value": 288,
+            "proteins_serving": 5,
+            "nova-group_serving": 4,
+            "salt_100g": 0.72,
+            "iron_100g": 0.00069,
+            "energy_unit": "kcal",
+            "calcium_unit": "mg",
+            "sugars_unit": "g",
+            "salt": 0.72,
+            "vitamin-a_100g": 0.0001155,
+            "fiber_100g": 1.9,
+            "energy-kcal_100g": 385,
+            "iron_value": 0.69,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "saturated-fat": 1.92,
+            "fat_value": 7.69,
+            "trans-fat": 0,
+            "fiber": 1.9,
+            "nova-group_100g": 4,
+            "cholesterol_value": 0,
+            "vitamin-a_serving": 6.01e-05,
+            "energy_value": 385,
+            "fiber_value": 1.9,
+            "fiber_unit": "g",
+            "vitamin-a_unit": "IU",
+            "calcium_100g": 0.038,
+            "carbohydrates_serving": 37,
+            "sodium_unit": "mg",
+            "carbohydrates_100g": 71.15,
+            "cholesterol_unit": "mg",
+            "fat": 7.69,
+            "energy-kcal_unit": "kcal",
+            "trans-fat_100g": 0,
+            "proteins": 9.62,
+            "salt_serving": 0.374,
+            "energy_100g": 1611,
+            "vitamin-c_value": 0,
+            "cholesterol_100g": 0,
+            "sodium_100g": 0.288,
+            "nutrition-score-fr_100g": 4,
+            "salt_unit": "mg",
+            "proteins_unit": "g",
+            "carbohydrates_value": 71.15,
+            "vitamin-c": 0,
+            "sugars_serving": 7,
+            "trans-fat_value": 0,
+            "fat_unit": "g",
+            "salt_value": 720,
+            "fiber_serving": 0.988,
+            "proteins_value": 9.62,
+            "saturated-fat_100g": 1.92,
+            "fat_serving": 4,
+            "energy": 1611,
+            "nova-group": 4,
+            "calcium_value": 38,
+            "saturated-fat_value": 1.92,
+            "energy-kcal_value": 385,
+            "trans-fat_serving": 0,
+            "fat_100g": 7.69,
+            "energy_serving": 838,
+            "saturated-fat_unit": "g",
+            "sodium_serving": 0.15,
+            "calcium": 0.038,
+            "vitamin-c_serving": 0,
+            "vitamin-a_value": 385,
+            "vitamin-a": 0.0001155,
+            "sugars_value": 13.46,
+            "proteins_100g": 9.62,
+            "vitamin-c_unit": "mg",
+            "nutrition-score-fr": 4,
+            "sodium": 0.288,
+            "calcium_serving": 0.0198,
+            "iron_unit": "mg",
+            "sugars": 13.46,
+            "carbohydrates": 71.15,
+            "energy-kcal_serving": 200,
+            "cholesterol_serving": 0
+        },
+        "purchase_places_tags": [],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/073/762/806/4502/ingredients_en.10.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/073/762/806/4502/nutrition_en.12.200.jpg",
+        "additives_tags_n": null
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/0812133010036.json
+++ b/testdata/product/0812133010036.json
@@ -1,0 +1,558 @@
+{
+    "status": 1,
+    "code": "0812133010036",
+    "product": {
+        "lc": "en",
+        "traces_from_ingredients": "",
+        "category_properties": {
+            "ciqual_food_name:fr": "Vin -aliment moyen-",
+            "ciqual_food_name:en": "Wine -average-"
+        },
+        "categories_tags": [
+            "en:beverages",
+            "en:alcoholic-beverages",
+            "en:wines",
+            "en:wines-from-france",
+            "en:bordeaux"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "origins_tags": [],
+        "generic_name": "",
+        "languages_hierarchy": [
+            "en:english"
+        ],
+        "last_image_t": 1421775471,
+        "emb_codes_20141016": "",
+        "pnns_groups_2_tags": [
+            "alcoholic-beverages",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "teolemon",
+            "bdwyer"
+        ],
+        "ingredients_text_with_allergens_en": "",
+        "sortkey": 1546194105,
+        "categories_old": "Beverages, Alcoholic beverages, Wines, Wines from France, Bordeaux",
+        "categories_properties": {
+            "ciqual_food_code:en": "5210",
+            "agribalyse_proxy_food_code:en": "5200"
+        },
+        "completeness": 0.566666666666667,
+        "traces_from_user": "(en) ",
+        "labels_tags": [
+            "fr:deconseille-aux-femmes-enceintes"
+        ],
+        "nutrition_grades_tags": [
+            "not-applicable"
+        ],
+        "informers_tags": [
+            "tacinte",
+            "teolemon",
+            "bdwyer"
+        ],
+        "lang": "en",
+        "vitamins_tags": [],
+        "origins_lc": "en",
+        "interface_version_modified": "20150316.jqm2",
+        "additives_tags": [],
+        "generic_name_en": "",
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:united-states"
+        ],
+        "nova_group_debug": "no nova group when the product does not have ingredients",
+        "traces_tags": [],
+        "packaging_tags": [
+            "bottle"
+        ],
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/081/213/301/0036/front_en.5.100.jpg",
+        "nutrient_levels": {},
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "created_t": 1421775451,
+        "amino_acids_prev_tags": [],
+        "nucleotides_tags": [],
+        "images": {
+            "front_en": {
+                "rev": "5",
+                "white_magic": "false",
+                "geometry": "674x2630-696-40",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 103
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 26
+                    },
+                    "full": {
+                        "h": 2630,
+                        "w": 674
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 51
+                    }
+                },
+                "normalize": "false",
+                "imgid": "2"
+            },
+            "1": {
+                "uploaded_t": 1421775451,
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 297
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 74
+                    },
+                    "full": {
+                        "h": 2697,
+                        "w": 2000
+                    }
+                }
+            },
+            "front": {
+                "rev": "5",
+                "white_magic": "false",
+                "geometry": "674x2630-696-40",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 103
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 26
+                    },
+                    "full": {
+                        "h": 2630,
+                        "w": 674
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 51
+                    }
+                },
+                "normalize": "false",
+                "imgid": "2"
+            },
+            "2": {
+                "uploaded_t": 1421775471,
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 297
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 74
+                    },
+                    "full": {
+                        "h": 2697,
+                        "w": 2000
+                    }
+                }
+            }
+        },
+        "editors_tags": [
+            "teolemon",
+            "tacinte",
+            "bdwyer"
+        ],
+        "countries_lc": "en",
+        "allergens_tags": [],
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "code": "0812133010036",
+        "manufacturing_places": "",
+        "codes_tags": [
+            "code-13",
+            "0812133010036",
+            "081213301003x",
+            "08121330100xx",
+            "0812133010xxx",
+            "081213301xxxx",
+            "08121330xxxxx",
+            "0812133xxxxxx",
+            "081213xxxxxxx",
+            "08121xxxxxxxx",
+            "0812xxxxxxxxx",
+            "081xxxxxxxxxx",
+            "08xxxxxxxxxxx",
+            "0xxxxxxxxxxxx"
+        ],
+        "labels": "fr:Déconseillé aux femmes enceintes",
+        "last_modified_by": "teolemon",
+        "last_edit_dates_tags": [
+            "2018-12-30",
+            "2018-12",
+            "2018"
+        ],
+        "entry_dates_tags": [
+            "2015-01-20",
+            "2015-01",
+            "2015"
+        ],
+        "creator": "tacinte",
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "deconseille",
+            "wine",
+            "le",
+            "aux",
+            "de",
+            "femme",
+            "bordeaux",
+            "from",
+            "beverage",
+            "enceinte",
+            "france",
+            "alcoholic",
+            "porte"
+        ],
+        "amino_acids_tags": [],
+        "link": "",
+        "ingredients_debug": [],
+        "languages_codes": {
+            "en": 2
+        },
+        "labels_lc": "en",
+        "packaging": "bottle",
+        "ingredients_text_en": "",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/081/213/301/0036/front_en.5.400.jpg",
+        "last_image_dates_tags": [
+            "2015-01-20",
+            "2015-01",
+            "2015"
+        ],
+        "popularity_key": 0,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/081/213/301/0036/front_en.5.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [
+            "en:serving-quantity-over-500g",
+            "en:alcoholic-beverages-category-without-alcohol-value"
+        ],
+        "labels_debug_tags": [
+            "added-fr-deconseille-aux-femmes-enceintes",
+            "removed-en-not-advised-for-pregnant-women"
+        ],
+        "misc_tags": [
+            "en:nutriscore-not-computed",
+            "en:nutriscore-not-applicable",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:categories-completed",
+            "en:brands-to-be-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "serving",
+        "ecoscore_score": 33,
+        "photographers_tags": [
+            "tacinte"
+        ],
+        "last_modified_t": 1546194105,
+        "ingredients": [],
+        "countries": "United States",
+        "stores": "",
+        "cities_tags": [],
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "wine-average"
+        ],
+        "brands": "",
+        "categories": "Beverages, Alcoholic beverages, Wines, Wines from France, Bordeaux",
+        "ingredients_text_with_allergens": "",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-to-be-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-to-be-completed, en:categories-completed, en:brands-to-be-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:photos-uploaded",
+        "nutrient_levels_tags": [],
+        "minerals_prev_tags": [],
+        "ingredients_text": "",
+        "product_name": "Les portes de Bordeaux",
+        "origins": "",
+        "languages_tags": [
+            "en:english",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "serving_quantity": 750,
+        "allergens": "",
+        "categories_lc": "en",
+        "ecoscore_data": {
+            "grade_be": "d",
+            "status": "known",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "transportation_score_lu": 0,
+                    "value_it": -5,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_ch": 0,
+                    "epi_value": -5,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 0,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:bottle",
+                            "material": "en:unknown",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "warning": "unspecified_material",
+                    "score": 0
+                },
+                "threatened_species": {
+                    "warning": "ingredients_missing"
+                }
+            },
+            "grade_fr": "d",
+            "score": 33,
+            "grade_de": "d",
+            "missing_data_warning": 1,
+            "grade_nl": "d",
+            "score_be": 28,
+            "agribalyse": {
+                "co2_transportation": "0.3049666",
+                "ef_distribution": "0.008830535799999999",
+                "name_fr": "Vin blanc 11°",
+                "score": 43,
+                "ef_agriculture": "0.087003491",
+                "ef_consumption": "0.0024293397",
+                "name_en": "Wine, white, 11°",
+                "co2_total": "1.1430841",
+                "ef_packaging": "0.051649676000000005",
+                "ef_processing": "0.01220053",
+                "is_beverage": 1,
+                "co2_processing": "0.035796377",
+                "dqr": "3.01",
+                "agribalyse_proxy_food_code": "5200",
+                "code": "5200",
+                "co2_consumption": "0.0047993021",
+                "co2_distribution": "0.028990393",
+                "ef_total": "0.18559681",
+                "co2_agriculture": "0.27162412",
+                "ef_transportation": "0.023478515999999998",
+                "co2_packaging": "0.49690685"
+            },
+            "grade_it": "d",
+            "score_nl": 28,
+            "score_ch": 28,
+            "grade_ie": "d",
+            "missing": {
+                "packagings": 1,
+                "labels": 1,
+                "ingredients": 1,
+                "origins": 1
+            },
+            "score_fr": 28,
+            "score_de": 28,
+            "score_lu": 28,
+            "score_ie": 28,
+            "score_it": 28,
+            "score_es": 28,
+            "grade": "d",
+            "grade_lu": "d",
+            "grade_es": "d",
+            "grade_ch": "d"
+        },
+        "selected_images": {
+            "front": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/081/213/301/0036/front_en.5.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/081/213/301/0036/front_en.5.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/081/213/301/0036/front_en.5.200.jpg"
+                }
+            }
+        },
+        "origins_old": "",
+        "rev": 11,
+        "last_editor": "teolemon",
+        "additives_prev_original_tags": [],
+        "ingredients_tags": [],
+        "labels_prev_tags": [
+            "en:not-advised-for-pregnant-women"
+        ],
+        "product_name_en": "Les portes de Bordeaux",
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:beverages",
+            "en:alcoholic-beverages",
+            "en:wines",
+            "en:wines-from-france",
+            "en:bordeaux"
+        ],
+        "ecoscore_grade": "d",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "labels_prev_hierarchy": [
+            "en:not-advised-for-pregnant-women"
+        ],
+        "languages": {
+            "en:english": 2
+        },
+        "ingredients_percent_analysis": 1,
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-5200",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-5210",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-5200"
+        ],
+        "purchase_places": "",
+        "id": "0812133010036",
+        "no_nutrition_data": "",
+        "allergens_from_user": "(en) ",
+        "additives_debug_tags": [],
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:serving-quantity-over-500g",
+            "en:alcoholic-beverages-category-without-alcohol-value"
+        ],
+        "additives_old_tags": [],
+        "labels_hierarchy": [
+            "fr:deconseille-aux-femmes-enceintes"
+        ],
+        "ecoscore_tags": [
+            "d"
+        ],
+        "origins_hierarchy": [],
+        "complete": 0,
+        "pnns_groups_2": "Alcoholic beverages",
+        "nutrition_score_beverage": 1,
+        "product_quantity": 750,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/081/213/301/0036/front_en.5.100.jpg",
+        "ingredients_text_debug": "",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/081/213/301/0036/front_en.5.400.jpg",
+        "_id": "0812133010036",
+        "countries_tags": [
+            "en:united-states"
+        ],
+        "ingredients_hierarchy": [],
+        "serving_size": "750 ML",
+        "stores_tags": [],
+        "additives_original_tags": [],
+        "compared_to_category": "en:bordeaux",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:categories-completed",
+            "en:brands-to-be-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "nutrition_score_debug": "no nutriscore for category en:alcoholic-beverages",
+        "packagings": [
+            {
+                "shape": "en:bottle"
+            }
+        ],
+        "data_quality_errors_tags": [],
+        "brands_tags": [],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "quantity": "750 ML",
+        "ingredients_ids_debug": [],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "ingredients_original_tags": [],
+        "manufacturing_places_tags": [],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "emb_codes": "",
+        "max_imgid": "2",
+        "editors": [
+            "tacinte",
+            "bdwyer",
+            "teolemon"
+        ],
+        "image_small_url": "https://static.openfoodfacts.net/images/products/081/213/301/0036/front_en.5.200.jpg",
+        "nutriments": {
+            "alcohol": 12,
+            "alcohol_100g": 12,
+            "alcohol_serving": 12,
+            "alcohol_unit": "% vol",
+            "alcohol_value": 12
+        },
+        "purchase_places_tags": [],
+        "additives_tags_n": null
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/0849092103196.json
+++ b/testdata/product/0849092103196.json
@@ -1,0 +1,962 @@
+{
+    "status": 1,
+    "code": "0849092103196",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "categories_tags": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:canned-foods",
+            "en:cereals-and-potatoes",
+            "en:fruits-and-vegetables-based-foods",
+            "en:canned-plant-based-foods",
+            "en:cereals-and-their-products",
+            "en:vegetables-based-foods",
+            "en:canned-vegetables",
+            "en:canned-cereals",
+            "en:canned-corn"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "origins_tags": [],
+        "product_name_fr": "Young Baby Corn Medium",
+        "generic_name": "",
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1439284860,
+        "additives_n": 1,
+        "emb_codes_20141016": "",
+        "carbon_footprint_from_known_ingredients_debug": "en:water 46% x 0.4 = 18.4 g - en:salt 1.85% x 0.5 = 0.925 g - ",
+        "pnns_groups_2_tags": [
+            "vegetables",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "tacite"
+        ],
+        "sortkey": 1450205588,
+        "categories_old": "Aliments et boissons à base de végétaux, Aliments d'origine végétale, Conserves, Céréales et pommes de terre, Aliments à base de fruits et de légumes, Aliments à base de plantes en conserve, Céréales et dérivés, Légumes et dérivés, Légumes en conserve, Céréales en conserve, Maïs en conserve",
+        "nutrition_score_warning_fruits_vegetables_nuts_from_category": "en:vegetables-based-foods",
+        "categories_properties": {
+            "agribalyse_proxy_food_code:en": "20066"
+        },
+        "completeness": 0.8,
+        "traces_from_user": "(fr) ",
+        "labels_tags": [],
+        "nutrition_grades_tags": [
+            "a"
+        ],
+        "informers_tags": [
+            "tacite"
+        ],
+        "lang": "fr",
+        "vitamins_tags": [],
+        "origins_lc": "fr",
+        "interface_version_modified": "20120622",
+        "additives_tags": [
+            "en:e330"
+        ],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/084/909/210/3196/nutrition_fr.6.400.jpg",
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "nova_group_debug": " -- ingredients/en:salt : 3",
+        "traces_tags": [],
+        "packaging_tags": [
+            "conserve"
+        ],
+        "nova_groups": "3",
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/084/909/210/3196/front_fr.5.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-content-unknown",
+            "en:vegan-status-unknown",
+            "en:vegetarian-status-unknown"
+        ],
+        "nutrient_levels": {
+            "salt": "moderate",
+            "sugars": "low",
+            "saturated-fat": "low",
+            "fat": "low"
+        },
+        "nutriscore_data": {
+            "proteins": 1.48,
+            "negative_points": 2,
+            "sugars_points": 0,
+            "score": -4,
+            "sodium_value": 181,
+            "positive_points": 6,
+            "saturated_fat_value": 0,
+            "is_water": 0,
+            "proteins_points": 0,
+            "saturated_fat_points": 0,
+            "saturated_fat_ratio": 0,
+            "proteins_value": 1.48,
+            "saturated_fat_ratio_points": 0,
+            "fiber_points": 1,
+            "grade": "a",
+            "is_cheese": 0,
+            "energy": 92.6,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 85,
+            "fiber": 1.48,
+            "energy_points": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 5,
+            "sodium_points": 2,
+            "is_fat": 0,
+            "energy_value": 92.6,
+            "is_beverage": 0,
+            "fiber_value": 1.48,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 85,
+            "saturated_fat_ratio_value": 0,
+            "sugars_value": 0,
+            "saturated_fat": 0,
+            "sodium": 181,
+            "sugars": 0
+        },
+        "created_t": 1439284854,
+        "nova_group": 3,
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "a",
+        "nucleotides_tags": [],
+        "images": {
+            "nutrition": {
+                "rev": "6",
+                "white_magic": "false",
+                "geometry": "1328x1116-883-1670",
+                "sizes": {
+                    "400": {
+                        "h": 336,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 84,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1116,
+                        "w": 1328
+                    },
+                    "200": {
+                        "h": 168,
+                        "w": 200
+                    }
+                },
+                "normalize": "false",
+                "imgid": "1"
+            },
+            "nutrition_fr": {
+                "rev": "6",
+                "white_magic": "false",
+                "geometry": "1328x1116-883-1670",
+                "sizes": {
+                    "400": {
+                        "h": 336,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 84,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1116,
+                        "w": 1328
+                    },
+                    "200": {
+                        "h": 168,
+                        "w": 200
+                    }
+                },
+                "normalize": "false",
+                "imgid": "1"
+            },
+            "ingredients": {
+                "rev": "7",
+                "white_magic": "false",
+                "geometry": "1487x319-790-1803",
+                "normalize": "false",
+                "sizes": {
+                    "400": {
+                        "h": 86,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 21,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 319,
+                        "w": 1487
+                    },
+                    "200": {
+                        "h": 43,
+                        "w": 200
+                    }
+                },
+                "imgid": "2"
+            },
+            "front_fr": {
+                "rev": "5",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 244
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 61
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 122
+                    },
+                    "full": {
+                        "h": 2896,
+                        "w": 1766
+                    }
+                },
+                "normalize": "false",
+                "geometry": "1766x2896-697-873",
+                "imgid": "3"
+            },
+            "3": {
+                "uploaded_t": "1433433382",
+                "uploader": "stephane",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 225
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 56
+                    },
+                    "full": {
+                        "h": 5312,
+                        "w": 2988
+                    }
+                }
+            },
+            "1": {
+                "uploaded_t": "1433433365",
+                "uploader": "stephane",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 225
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 56
+                    },
+                    "full": {
+                        "h": 5312,
+                        "w": 2988
+                    }
+                }
+            },
+            "front": {
+                "rev": "5",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 244
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 61
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 122
+                    },
+                    "full": {
+                        "h": 2896,
+                        "w": 1766
+                    }
+                },
+                "normalize": "false",
+                "geometry": "1766x2896-697-873",
+                "imgid": "3"
+            },
+            "2": {
+                "uploaded_t": "1433433373",
+                "uploader": "stephane",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 225
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 56
+                    },
+                    "full": {
+                        "h": 5312,
+                        "w": 2988
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "rev": "7",
+                "white_magic": "false",
+                "geometry": "1487x319-790-1803",
+                "normalize": "false",
+                "sizes": {
+                    "400": {
+                        "h": 86,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 21,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 319,
+                        "w": 1487
+                    },
+                    "200": {
+                        "h": 43,
+                        "w": 200
+                    }
+                },
+                "imgid": "2"
+            }
+        },
+        "ingredients_text_with_allergens_fr": "Jeunes épis de maïs 52%, eau 46%, sel 1,85%, acide citrique 0,5%.",
+        "ingredients_n": 4,
+        "editors_tags": [
+            "stephane",
+            "tacite"
+        ],
+        "allergens_tags": [],
+        "countries_lc": "fr",
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "completed_t": 1450205555,
+        "nova_groups_tags": [
+            "en:3-processed-foods"
+        ],
+        "code": "0849092103196",
+        "manufacturing_places": "",
+        "codes_tags": [
+            "code-13",
+            "0849092103196",
+            "084909210319x",
+            "08490921031xx",
+            "0849092103xxx",
+            "084909210xxxx",
+            "08490921xxxxx",
+            "0849092xxxxxx",
+            "084909xxxxxxx",
+            "08490xxxxxxxx",
+            "0849xxxxxxxxx",
+            "084xxxxxxxxxx",
+            "08xxxxxxxxxxx",
+            "0xxxxxxxxxxxx"
+        ],
+        "labels": "",
+        "last_modified_by": "tacite",
+        "last_edit_dates_tags": [
+            "2015-12-15",
+            "2015-12",
+            "2015"
+        ],
+        "entry_dates_tags": [
+            "2015-08-11",
+            "2015-08",
+            "2015"
+        ],
+        "creator": "tacite",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "plante",
+            "brand",
+            "baby",
+            "young",
+            "coq",
+            "corn",
+            "terre",
+            "conserve",
+            "medium",
+            "legume",
+            "boisson",
+            "marque",
+            "et",
+            "base",
+            "vegetale",
+            "fruit",
+            "cock",
+            "en",
+            "origine",
+            "mai",
+            "pomme",
+            "cereale",
+            "aliment",
+            "de",
+            "derive",
+            "vegetaux"
+        ],
+        "amino_acids_tags": [],
+        "link": "",
+        "ingredients_debug": [
+            "Jeunes épis de maïs 52%",
+            ",",
+            null,
+            null,
+            null,
+            " eau 46%",
+            ",",
+            null,
+            null,
+            null,
+            " sel 1",
+            ",",
+            null,
+            null,
+            null,
+            "85%",
+            ",",
+            null,
+            null,
+            null,
+            " acide citrique 0",
+            ",",
+            null,
+            null,
+            null,
+            "5%."
+        ],
+        "languages_codes": {
+            "fr": 5
+        },
+        "labels_lc": "fr",
+        "packaging": "Conserve",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/084/909/210/3196/front_fr.5.400.jpg",
+        "last_image_dates_tags": [
+            "2015-08-11",
+            "2015-08",
+            "2015"
+        ],
+        "popularity_key": 0,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/084/909/210/3196/front_fr.5.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [
+            "en:ingredients-percent-analysis-not-ok"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-from-category",
+            "en:nutrition-fruits-vegetables-nuts-from-category-en-vegetables-based-foods",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 85,
+        "countries_debug_tags": [],
+        "interface_version_created": "20150804",
+        "nutrition_data_per": "serving",
+        "ecoscore_score": 71,
+        "photographers_tags": [
+            "stephane"
+        ],
+        "last_modified_t": 1450205588,
+        "ingredients": [
+            {
+                "id": "fr:Jeunes épis de maïs",
+                "percent": "52",
+                "percent_estimate": "52",
+                "text": "Jeunes épis de maïs"
+            },
+            {
+                "id": "en:water",
+                "percent_estimate": "46",
+                "percent": "46",
+                "text": "eau",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "id": "en:salt",
+                "text": "sel",
+                "percent": "1.85",
+                "percent_estimate": "1.85",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "id": "en:e330",
+                "percent": "0.5",
+                "percent_estimate": 0.150000000000006,
+                "text": "acide citrique",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            }
+        ],
+        "nutriscore_grade": "a",
+        "stores": "",
+        "countries": "France",
+        "cities_tags": [],
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "brands": "Cock Brand,Cock,Marque Coq",
+        "categories": "Aliments et boissons à base de végétaux, Aliments d'origine végétale, Conserves, Céréales et pommes de terre, Aliments à base de fruits et de légumes, Aliments à base de plantes en conserve, Céréales et dérivés, Légumes et dérivés, Légumes en conserve, Céréales en conserve, Maïs en conserve",
+        "ingredients_text_with_allergens": "Jeunes épis de maïs 52%, eau 46%, sel 1,85%, acide citrique 0,5%.",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "nutrition_grades": "a",
+        "nutrient_levels_tags": [
+            "en:fat-in-low-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-low-quantity",
+            "en:salt-in-moderate-quantity"
+        ],
+        "known_ingredients_n": 3,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Jeunes épis de maïs 52%, eau 46%, sel 1,85%, acide citrique 0,5%.",
+        "product_name": "Young Baby Corn Medium",
+        "origins": "",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Jeunes épis de maïs 52%, eau 46%, sel 1,85%, acide citrique 0,5%.",
+        "categories_lc": "fr",
+        "serving_quantity": 135,
+        "allergens": "",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/084/909/210/3196/ingredients_fr.7.100.jpg",
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "b",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_value": -5,
+                    "transportation_score_ch": 0,
+                    "value_ie": -5,
+                    "transportation_value_de": 0,
+                    "value_fr": -5,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:food-can",
+                            "material": "en:unknown",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "warning": "unspecified_material",
+                    "score": 0
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "b",
+            "score": 71,
+            "grade_de": "b",
+            "missing_data_warning": 1,
+            "grade_nl": "b",
+            "score_be": 66,
+            "agribalyse": {
+                "co2_transportation": "0.22282157",
+                "ef_distribution": "0.0094527718",
+                "name_fr": "Maïs doux, appertisé, égoutté",
+                "agribalyse_food_code": "20066",
+                "score": 81,
+                "ef_consumption": "0.010168672",
+                "ef_agriculture": "0.12612637",
+                "name_en": "Sweet corn, canned, drained",
+                "ef_packaging": "0.034667415",
+                "co2_total": "1.2386257",
+                "ef_processing": "0.072287042",
+                "is_beverage": 0,
+                "code": "20066",
+                "co2_processing": "0.14730051",
+                "dqr": "2.49",
+                "agribalyse_proxy_food_code": "20066",
+                "co2_consumption": "0.23997673",
+                "ef_total": "0.27001849",
+                "co2_distribution": "0.030928649",
+                "co2_agriculture": "0.24744177",
+                "ef_transportation": "0.017316226",
+                "co2_packaging": "0.35015645"
+            },
+            "grade_it": "b",
+            "score_nl": 66,
+            "missing": {
+                "packagings": 1,
+                "labels": 1,
+                "origins": 1
+            },
+            "grade_ie": "b",
+            "score_ch": 66,
+            "score_de": 66,
+            "score_fr": 66,
+            "score_ie": 66,
+            "score_lu": 66,
+            "score_it": 66,
+            "score_es": 66,
+            "grade_es": "b",
+            "grade_ch": "b",
+            "grade": "b",
+            "grade_lu": "b"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/084/909/210/3196/nutrition_fr.6.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/084/909/210/3196/nutrition_fr.6.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/084/909/210/3196/nutrition_fr.6.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/084/909/210/3196/ingredients_fr.7.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/084/909/210/3196/ingredients_fr.7.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/084/909/210/3196/ingredients_fr.7.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/084/909/210/3196/front_fr.5.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/084/909/210/3196/front_fr.5.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/084/909/210/3196/front_fr.5.200.jpg"
+                }
+            }
+        },
+        "rev": 12,
+        "origins_old": "",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "tacite",
+        "additives_prev_original_tags": [
+            "en:e330"
+        ],
+        "ingredients_tags": [
+            "fr:jeunes-epis-de-mais",
+            "en:water",
+            "en:salt",
+            "en:e330"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/084/909/210/3196/nutrition_fr.6.100.jpg",
+        "labels_prev_tags": [],
+        "ingredients_from_palm_oil_tags": [],
+        "carbon_footprint_percent_of_known_ingredients": 47.85,
+        "categories_hierarchy": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:canned-foods",
+            "en:cereals-and-potatoes",
+            "en:fruits-and-vegetables-based-foods",
+            "en:canned-plant-based-foods",
+            "en:cereals-and-their-products",
+            "en:vegetables-based-foods",
+            "en:canned-vegetables",
+            "en:canned-cereals",
+            "en:canned-corn"
+        ],
+        "ecoscore_grade": "b",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "labels_prev_hierarchy": [],
+        "nutrition_data": "on",
+        "ingredients_percent_analysis": -1,
+        "languages": {
+            "en:french": 5
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-20066",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-unknown",
+            "agribalyse-known",
+            "agribalyse-20066"
+        ],
+        "purchase_places": "",
+        "id": "0849092103196",
+        "no_nutrition_data": null,
+        "pnns_groups_1": "Fruits and vegetables",
+        "allergens_from_user": "(fr) ",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/084/909/210/3196/ingredients_fr.7.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_from_category_value": 85,
+        "data_quality_tags": [
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish",
+            "en:ingredients-percent-analysis-not-ok"
+        ],
+        "additives_old_tags": [
+            "en:e330"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "ecoscore_tags": [
+            "b"
+        ],
+        "labels_hierarchy": [],
+        "origins_hierarchy": [],
+        "complete": 1,
+        "pnns_groups_2": "Vegetables",
+        "nutrition_score_beverage": 0,
+        "new_additives_n": 0,
+        "product_quantity": 425,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/084/909/210/3196/front_fr.5.100.jpg",
+        "ingredients_text_debug": "Jeunes épis de maïs 52%, eau 46%, sel 1,85%, acide citrique 0,5%.",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/084/909/210/3196/front_fr.5.400.jpg",
+        "_id": "0849092103196",
+        "countries_tags": [
+            "en:france"
+        ],
+        "ingredients_hierarchy": [
+            "fr:Jeunes épis de maïs",
+            "en:water",
+            "en:salt",
+            "en:e330"
+        ],
+        "serving_size": "serving",
+        "stores_tags": [],
+        "additives_original_tags": [
+            "en:e330"
+        ],
+        "nutriscore_score": -4,
+        "compared_to_category": "en:canned-corn",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "4",
+            "1-10"
+        ],
+        "pnns_groups_1_tags": [
+            "fruits-and-vegetables",
+            "known"
+        ],
+        "additives_old_n": 1,
+        "packagings": [
+            {
+                "shape": "en:food-can"
+            }
+        ],
+        "brands_tags": [
+            "cock-brand",
+            "cock",
+            "marque-coq"
+        ],
+        "data_quality_info_tags": [
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish"
+        ],
+        "data_quality_errors_tags": [],
+        "quantity": "425 g (230 g égoutté)",
+        "ingredients_ids_debug": [
+            "jeunes-epis-de-mais-52",
+            "eau-46",
+            "sel-1",
+            "85",
+            "acide-citrique-0",
+            "5"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "ingredients_original_tags": [
+            "fr:Jeunes épis de maïs",
+            "en:water",
+            "en:salt",
+            "en:e330"
+        ],
+        "unknown_ingredients_n": 1,
+        "manufacturing_places_tags": [],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "emb_codes": "",
+        "max_imgid": "3",
+        "editors": [
+            "tacite",
+            "stephane"
+        ],
+        "nutriscore_score_opposite": 4,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/084/909/210/3196/front_fr.5.200.jpg",
+        "generic_name_fr": "",
+        "nutriments": {
+            "iron_serving": 0.0036,
+            "iron": 0.0036,
+            "carbohydrates_unit": "g",
+            "cholesterol": 0,
+            "saturated-fat_serving": 0,
+            "energy-kj_100g": 92.6,
+            "vitamin-c_100g": 0.00222,
+            "sugars_100g": 0,
+            "proteins_serving": 2,
+            "sodium_value": 243.84,
+            "salt_100g": 0.452,
+            "nova-group_serving": 3,
+            "iron_100g": 0.00267,
+            "energy_unit": "kJ",
+            "energy-kj_serving": 125,
+            "sugars_unit": "g",
+            "calcium_unit": "% DV",
+            "energy-kj_unit": "kJ",
+            "salt": 0.6096,
+            "vitamin-c_label": "0",
+            "iron_label": "0",
+            "vitamin-a_100g": 0,
+            "fiber_100g": 1.48,
+            "iron_value": 20,
+            "saturated-fat": 0,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "fat_value": 0,
+            "fiber": 2,
+            "nova-group_100g": 3,
+            "cholesterol_value": 0,
+            "vitamin-a_serving": 0,
+            "energy_value": 125,
+            "carbon-footprint-from-known-ingredients_serving": 26.1,
+            "fiber_value": 2,
+            "fiber_unit": "g",
+            "vitamin-a_unit": "% DV",
+            "calcium_100g": 0.0296,
+            "sodium_unit": "mg",
+            "carbohydrates_serving": 5,
+            "carbohydrates_100g": 3.7,
+            "cholesterol_label": "0",
+            "cholesterol_unit": "mg",
+            "fat": 0,
+            "salt_serving": 0.6096,
+            "proteins": 2,
+            "energy_100g": 92.6,
+            "vitamin-c_value": 5,
+            "cholesterol_100g": 0,
+            "sodium_100g": 0.181,
+            "nutrition-score-fr_100g": -4,
+            "salt_unit": "mg",
+            "proteins_unit": "g",
+            "carbohydrates_value": 5,
+            "vitamin-c": 0.003,
+            "sugars_serving": 0,
+            "calcium_label": "0",
+            "fat_unit": "g",
+            "salt_value": 609.6,
+            "fiber_serving": 2,
+            "proteins_value": 2,
+            "saturated-fat_100g": 0,
+            "fat_serving": 0,
+            "carbon-footprint-from-known-ingredients_100g": 19.325,
+            "nova-group": 3,
+            "calcium_value": 4,
+            "energy": 125,
+            "vitamin-a_label": "0",
+            "saturated-fat_value": 0,
+            "fat_100g": 0,
+            "energy_serving": 125,
+            "saturated-fat_unit": "g",
+            "vitamin-c_serving": 0.003,
+            "calcium": 0.04,
+            "sodium_serving": 0.24384,
+            "vitamin-a_value": 0,
+            "energy-kj_value": 125,
+            "energy-kj": 125,
+            "carbon-footprint-from-known-ingredients_product": 82.1,
+            "vitamin-a": 0,
+            "vitamin-c_unit": "% DV",
+            "proteins_100g": 1.48,
+            "sugars_value": 0,
+            "nutrition-score-fr": -4,
+            "iron_unit": "% DV",
+            "calcium_serving": 0.04,
+            "sodium": 0.24384,
+            "sugars": 0,
+            "carbohydrates": 5,
+            "cholesterol_serving": 0
+        },
+        "purchase_places_tags": [],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/084/909/210/3196/ingredients_fr.7.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/084/909/210/3196/nutrition_fr.6.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/22007377.json
+++ b/testdata/product/22007377.json
@@ -1,0 +1,823 @@
+{
+    "status": 1,
+    "code": "22007377",
+    "product": {
+        "lc": "en",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "categories_tags": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:cereals-and-potatoes",
+            "en:seeds",
+            "en:cereals-and-their-products",
+            "en:cereal-grains",
+            "en:rices",
+            "en:asian-foods"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "origins_tags": [
+            "en:thailand"
+        ],
+        "generic_name": "",
+        "languages_hierarchy": [
+            "en:english"
+        ],
+        "last_image_t": 1463725186,
+        "additives_n": 0,
+        "pnns_groups_2_tags": [
+            "cereals",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "ingredients_text_with_allergens_en": "jasmine Rice",
+        "correctors_tags": [
+            "foodorigins"
+        ],
+        "sortkey": 1463886036,
+        "categories_old": "Plant-based foods and beverages, Plant-based foods, Cereals and potatoes, Seeds, Cereals and their products, Cereal grains, Rices, Asian Foods",
+        "categories_properties": {
+            "agribalyse_proxy_food_code:en": "9101"
+        },
+        "completeness": 0.9,
+        "traces_from_user": "(en) ",
+        "labels_tags": [
+            "en:gluten-free",
+            "en:no-preservatives"
+        ],
+        "nutrition_grades_tags": [
+            "b"
+        ],
+        "informers_tags": [
+            "foodorigins"
+        ],
+        "lang": "en",
+        "vitamins_tags": [],
+        "origins_lc": "en",
+        "interface_version_modified": "20120622",
+        "additives_tags": [],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/22007377/nutrition_en.15.400.jpg",
+        "generic_name_en": "",
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:australia"
+        ],
+        "nova_group_debug": "",
+        "traces_tags": [],
+        "packaging_tags": [
+            "plastic"
+        ],
+        "nova_groups": "1",
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/22007377/front_en.13.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-free",
+            "en:vegan",
+            "en:vegetarian"
+        ],
+        "nutrient_levels": {
+            "sugars": "low",
+            "salt": "low",
+            "fat": "low",
+            "saturated-fat": "low"
+        },
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "nutriscore_data": {
+            "proteins": 2,
+            "negative_points": 1,
+            "sugars_points": 0,
+            "sodium_value": 5.1,
+            "score": 0,
+            "positive_points": 1,
+            "saturated_fat_value": 0.1,
+            "is_water": 0,
+            "proteins_points": 1,
+            "saturated_fat_points": 0,
+            "saturated_fat_ratio": 100,
+            "proteins_value": 2,
+            "saturated_fat_ratio_points": 10,
+            "fiber_points": 0,
+            "grade": "b",
+            "is_cheese": 0,
+            "energy": 419,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 0,
+            "energy_points": 1,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 0,
+            "is_fat": 0,
+            "energy_value": 419,
+            "is_beverage": 0,
+            "fiber_value": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 100,
+            "sugars_value": 1,
+            "saturated_fat": 0.1,
+            "sodium": 5.08,
+            "sugars": 1
+        },
+        "created_t": 1424068037,
+        "nova_group": 1,
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "b",
+        "nucleotides_tags": [],
+        "images": {
+            "nutrition_en": {
+                "rev": "15",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 391,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 98,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 670,
+                        "w": 685
+                    },
+                    "200": {
+                        "h": 196,
+                        "w": 200
+                    }
+                },
+                "normalize": "true",
+                "geometry": "685x670-196-289",
+                "imgid": "3"
+            },
+            "front_en": {
+                "rev": "13",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 299
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 150
+                    },
+                    "full": {
+                        "h": 1450,
+                        "w": 1085
+                    }
+                },
+                "normalize": "true",
+                "geometry": "1085x1450-11-356",
+                "imgid": "2"
+            },
+            "ingredients_en": {
+                "rev": "14",
+                "white_magic": "false",
+                "normalize": "true",
+                "sizes": {
+                    "400": {
+                        "h": 154,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 38,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 77,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 275,
+                        "w": 715
+                    }
+                },
+                "geometry": "715x275-196-1307",
+                "imgid": "2"
+            },
+            "1": {
+                "uploaded_t": 1424068165,
+                "uploader": "foodorigins",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1125,
+                        "w": 2000
+                    }
+                }
+            },
+            "front": {
+                "rev": "9",
+                "white_magic": "false",
+                "geometry": "990x1370-71-435",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 289
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 72
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 145
+                    },
+                    "full": {
+                        "h": 1370,
+                        "w": 990
+                    }
+                },
+                "normalize": "true",
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": "1463725174",
+                "uploader": "foodorigins",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1125,
+                        "w": 2000
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": "1463725185",
+                "uploader": "foodorigins",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1125,
+                        "w": 2000
+                    }
+                }
+            }
+        },
+        "ingredients_n": 1,
+        "editors_tags": [
+            "foodorigins"
+        ],
+        "allergens_tags": [],
+        "countries_lc": "en",
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "completed_t": 1463886036,
+        "nova_groups_tags": [
+            "en:1-unprocessed-or-minimally-processed-foods"
+        ],
+        "code": "22007377",
+        "manufacturing_places": "Thailand",
+        "codes_tags": [
+            "code-8",
+            "22007377",
+            "2200737x",
+            "220073xx",
+            "22007xxx",
+            "2200xxxx",
+            "220xxxxx",
+            "22xxxxxx",
+            "2xxxxxxx"
+        ],
+        "labels": "Gluten-free, No preservatives",
+        "last_modified_by": "foodorigins",
+        "last_edit_dates_tags": [
+            "2016-05-22",
+            "2016-05",
+            "2016"
+        ],
+        "entry_dates_tags": [
+            "2015-02-16",
+            "2015-02",
+            "2015"
+        ],
+        "creator": "foodorigins",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "grain",
+            "thailand",
+            "no",
+            "imperial",
+            "seed",
+            "preservative",
+            "aldi",
+            "beverage",
+            "gluten-free",
+            "rice",
+            "plant-based",
+            "food",
+            "their",
+            "asian",
+            "potatoe",
+            "product",
+            "cereal",
+            "and",
+            "jasmine"
+        ],
+        "amino_acids_tags": [],
+        "link": "",
+        "ingredients_debug": [
+            "jasmine Rice"
+        ],
+        "languages_codes": {
+            "en": 5
+        },
+        "labels_lc": "en",
+        "packaging": "Plastic",
+        "ingredients_text_en": "jasmine Rice",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/22007377/front_en.13.400.jpg",
+        "popularity_key": 0,
+        "last_image_dates_tags": [
+            "2016-05-20",
+            "2016-05",
+            "2016"
+        ],
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/22007377/front_en.13.200.jpg",
+        "expiration_date": "04/April/2017",
+        "data_quality_warnings_tags": [
+            "en:nutrition-value-under-0-1-g-salt",
+            "en:nutrition-value-very-low-for-category-energy",
+            "en:nutrition-value-very-low-for-category-carbohydrates",
+            "en:nutrition-value-very-low-for-category-proteins"
+        ],
+        "misc_tags": [
+            "en:nutrition-no-fiber",
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-no-fiber-or-fruits-vegetables-nuts",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "debug_param_sorted_langs": [
+            "en"
+        ],
+        "ecoscore_score": 64,
+        "photographers_tags": [
+            "foodorigins"
+        ],
+        "last_modified_t": 1463886036,
+        "ingredients": [
+            {
+                "percent_max": 100,
+                "id": "en:thai-rice",
+                "text": "jasmine Rice",
+                "percent_estimate": 100,
+                "percent_min": 100,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            }
+        ],
+        "nutriscore_grade": "b",
+        "stores": "Aldi",
+        "countries": "Australia",
+        "cities_tags": [],
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "brands": "Imperial Grain,Aldi",
+        "categories": "Plant-based foods and beverages, Plant-based foods, Cereals and potatoes, Seeds, Cereals and their products, Cereal grains, Rices, Asian Foods",
+        "ingredients_text_with_allergens": "jasmine Rice",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "nutrition_grades": "b",
+        "nutrient_levels_tags": [
+            "en:fat-in-low-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-low-quantity",
+            "en:salt-in-low-quantity"
+        ],
+        "known_ingredients_n": 2,
+        "minerals_prev_tags": [],
+        "ingredients_text": "jasmine Rice",
+        "product_name": "Imperial Grain Jasmine Rice",
+        "origins": "Thailand",
+        "languages_tags": [
+            "en:english",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "categories_lc": "en",
+        "serving_quantity": 70,
+        "allergens": "",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/22007377/ingredients_en.14.100.jpg",
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "b",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_es": 4,
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 2,
+                    "transportation_value_ch": 1,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:thailand",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_be": 12,
+                    "epi_score": 0,
+                    "transportation_score_ch": 9,
+                    "epi_value": -5,
+                    "transportation_score_ie": 0,
+                    "value_nl": -3,
+                    "value_ie": -5,
+                    "transportation_value_de": 2,
+                    "value_fr": -5,
+                    "value_be": -3,
+                    "value_es": -1,
+                    "transportation_score_it": 16,
+                    "transportation_value_ie": 0,
+                    "transportation_score_de": 12,
+                    "transportation_score_fr": 0,
+                    "origins_from_origins_field": [
+                        "en:thailand"
+                    ],
+                    "transportation_value_lu": 0,
+                    "transportation_value_nl": 2,
+                    "value_ch": -4,
+                    "transportation_score_es": 25,
+                    "value_de": -3,
+                    "transportation_value_it": 2,
+                    "transportation_score_lu": 3,
+                    "value_it": -3,
+                    "value_lu": -5,
+                    "transportation_score_nl": 12
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:plastic",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": "0"
+                        }
+                    ],
+                    "warning": "unspecified_shape",
+                    "score": 0
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "c",
+            "score": 64,
+            "grade_de": "b",
+            "missing_data_warning": 1,
+            "grade_nl": "b",
+            "score_be": 61,
+            "agribalyse": {
+                "co2_transportation": "0.34443618",
+                "ef_distribution": "0.011252758",
+                "name_fr": "Riz blanc étuvé, cru",
+                "score": 74,
+                "ef_consumption": "0",
+                "ef_agriculture": "0.24879545",
+                "name_en": "Rice, parboiled, raw",
+                "ef_packaging": "0.019987624",
+                "co2_total": "2.1617032",
+                "ef_processing": "0",
+                "is_beverage": 0,
+                "code": "9101",
+                "dqr": "3.61",
+                "co2_processing": "0",
+                "agribalyse_proxy_food_code": "9101",
+                "co2_consumption": "0",
+                "ef_total": "0.31474413",
+                "co2_distribution": "0.030159429",
+                "co2_agriculture": "1.5176977",
+                "ef_transportation": "0.034708291",
+                "co2_packaging": "0.26940995"
+            },
+            "grade_it": "b",
+            "score_nl": 61,
+            "grade_ie": "c",
+            "missing": {
+                "packagings": 1,
+                "labels": 1
+            },
+            "score_ch": 60,
+            "score_de": 61,
+            "score_fr": 59,
+            "score_ie": 59,
+            "score_lu": 59,
+            "score_it": 61,
+            "score_es": 63,
+            "grade_es": "b",
+            "grade_ch": "b",
+            "grade": "b",
+            "grade_lu": "c"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/22007377/nutrition_en.15.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/22007377/nutrition_en.15.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/22007377/nutrition_en.15.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/22007377/ingredients_en.14.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/22007377/ingredients_en.14.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/22007377/ingredients_en.14.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/22007377/front_en.13.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/22007377/front_en.13.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/22007377/front_en.13.200.jpg"
+                }
+            }
+        },
+        "rev": 16,
+        "origins_old": "Thailand",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "foodorigins",
+        "additives_prev_original_tags": [],
+        "ingredients_tags": [
+            "en:thai-rice",
+            "en:rice"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/22007377/nutrition_en.15.100.jpg",
+        "labels_prev_tags": [
+            "en:gluten-free",
+            "en:no-preservatives"
+        ],
+        "product_name_en": "Imperial Grain Jasmine Rice",
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:cereals-and-potatoes",
+            "en:seeds",
+            "en:cereals-and-their-products",
+            "en:cereal-grains",
+            "en:rices",
+            "en:Asian Foods"
+        ],
+        "ecoscore_grade": "b",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "labels_prev_hierarchy": [
+            "en:gluten-free",
+            "en:no-preservatives"
+        ],
+        "nutrition_data": "on",
+        "ingredients_percent_analysis": 1,
+        "languages": {
+            "en:english": 5
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-9101",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-unknown",
+            "agribalyse-known",
+            "agribalyse-9101"
+        ],
+        "purchase_places": "Sydney,NSw,Australia",
+        "id": "22007377",
+        "no_nutrition_data": null,
+        "pnns_groups_1": "Cereals and potatoes",
+        "allergens_from_user": "(en) ",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/22007377/ingredients_en.14.400.jpg",
+        "nutrition_score_warning_no_fiber": 1,
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:nutrition-value-under-0-1-g-salt",
+            "en:nutrition-value-very-low-for-category-energy",
+            "en:nutrition-value-very-low-for-category-carbohydrates",
+            "en:nutrition-value-very-low-for-category-proteins"
+        ],
+        "additives_old_tags": [],
+        "ingredients_from_palm_oil_n": 0,
+        "ecoscore_tags": [
+            "b"
+        ],
+        "labels_hierarchy": [
+            "en:gluten-free",
+            "en:no-preservatives"
+        ],
+        "origins_hierarchy": [
+            "en:thailand"
+        ],
+        "complete": 1,
+        "pnns_groups_2": "Cereals",
+        "nutrition_score_beverage": 0,
+        "product_quantity": 1000,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/22007377/front_en.13.100.jpg",
+        "ingredients_text_debug": "jasmine Rice",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/22007377/front_en.13.400.jpg",
+        "_id": "22007377",
+        "countries_tags": [
+            "en:australia"
+        ],
+        "ingredients_hierarchy": [
+            "en:thai-rice",
+            "en:rice"
+        ],
+        "serving_size": "70g uncooked rice - 245g cooked rice",
+        "stores_tags": [
+            "aldi"
+        ],
+        "additives_original_tags": [],
+        "nutriscore_score": 0,
+        "compared_to_category": "en:rices",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "1",
+            "1-10"
+        ],
+        "pnns_groups_1_tags": [
+            "cereals-and-potatoes",
+            "known"
+        ],
+        "additives_old_n": 0,
+        "packagings": [
+            {
+                "material": "en:plastic"
+            }
+        ],
+        "brands_tags": [
+            "imperial-grain",
+            "aldi"
+        ],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "data_quality_errors_tags": [],
+        "quantity": "1kg",
+        "ingredients_ids_debug": [
+            "jasmine-rice"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "ingredients_original_tags": [
+            "en:thai-rice"
+        ],
+        "unknown_ingredients_n": 0,
+        "manufacturing_places_tags": [
+            "thailand"
+        ],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "emb_codes": "",
+        "max_imgid": "3",
+        "editors": [
+            "foodorigins"
+        ],
+        "nutriscore_score_opposite": 0,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/22007377/front_en.13.200.jpg",
+        "nutriments": {
+            "salt_serving": 0.00889,
+            "proteins": 2,
+            "energy_100g": 419,
+            "carbohydrates_unit": "g",
+            "saturated-fat_serving": 0.07,
+            "energy-kj_100g": 419,
+            "sodium_100g": 0.00508,
+            "sugars_100g": 1,
+            "proteins_serving": 1.4,
+            "sodium_value": 5.08,
+            "nova-group_serving": 1,
+            "salt_100g": 0.0127,
+            "energy_unit": "kJ",
+            "nutrition-score-fr_100g": 0,
+            "energy-kj_serving": 293,
+            "salt_unit": "mg",
+            "proteins_unit": "g",
+            "carbohydrates_value": 22.4,
+            "saturated-fat_modifier": ">",
+            "sugars_unit": "g",
+            "sugars_serving": 0.7,
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt": 0.0127,
+            "salt_value": 12.7,
+            "proteins_value": 2,
+            "saturated-fat_100g": 0.1,
+            "fat_serving": 0.07,
+            "saturated-fat": 0.1,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "fat_value": 0.1,
+            "nova-group": 1,
+            "energy": 419,
+            "saturated-fat_value": 0.1,
+            "sodium_modifier": ">",
+            "sugars_modifier": ">",
+            "nova-group_100g": 1,
+            "fat_100g": 0.1,
+            "energy_serving": 293,
+            "saturated-fat_unit": "g",
+            "energy_value": 419,
+            "sodium_serving": 0.00356,
+            "energy-kj_value": 419,
+            "energy-kj": 419,
+            "sugars_value": 1,
+            "proteins_100g": 2,
+            "salt_modifier": ">",
+            "nutrition-score-fr": 0,
+            "sodium_unit": "mg",
+            "carbohydrates_serving": 15.7,
+            "carbohydrates_100g": 22.4,
+            "sodium": 0.00508,
+            "sugars": 1,
+            "carbohydrates": 22.4,
+            "fat": 0.1
+        },
+        "purchase_places_tags": [
+            "sydney",
+            "nsw",
+            "australia"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/22007377/ingredients_en.14.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/22007377/nutrition_en.15.200.jpg",
+        "additives_tags_n": null
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/3033610048398.json
+++ b/testdata/product/3033610048398.json
@@ -1,0 +1,808 @@
+{
+    "status": 1,
+    "code": "3033610048398",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {
+            "ciqual_food_name:fr": "Foie gras, canard, bloc -aliment moyen-",
+            "ciqual_food_name:en": "Foie gras, block -average-"
+        },
+        "traces_debug_tags": [],
+        "categories_tags": [
+            "en:canned-foods",
+            "en:fish-and-meat-and-eggs",
+            "en:foies-gras",
+            "en:foies-gras-from-ducks",
+            "en:whole-foies-gras"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "informers": [],
+        "origins_tags": [
+            "en:france",
+            "fr:sud-ouest"
+        ],
+        "product_name_fr": "Pure Tradition foie gras de canard entier du sud-ouest",
+        "generic_name": "foie gras entier",
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1356982732,
+        "additives_n": 0,
+        "emb_codes_20141016": "FR 40.261.001 CE",
+        "pnns_groups_2_tags": [
+            "salty-and-fatty-products",
+            "known"
+        ],
+        "emb_codes_tags": [
+            "fr-40-261-001-ec"
+        ],
+        "correctors_tags": [
+            "jeanbono",
+            "jeremy64",
+            "sebleouf",
+            "moon-rabbit",
+            "roboto-app"
+        ],
+        "sortkey": 1582745476,
+        "categories_old": "Conserves, Poissons et viandes et oeufs, Foies gras, Foies gras de canard, Foies gras entiers",
+        "categories_properties": {
+            "ciqual_food_code:en": "8331",
+            "agribalyse_proxy_food_code:en": "40120"
+        },
+        "completeness": 0.9,
+        "traces_from_user": "(fr) ",
+        "labels_tags": [
+            "en:no-preservatives",
+            "en:pgi",
+            "en:without-sodium-nitrite",
+            "fr:canard-a-foie-gras-du-sud-ouest"
+        ],
+        "nutrition_grades_tags": [
+            "unknown"
+        ],
+        "informers_tags": [
+            "stephane",
+            "nash",
+            "jeanbono",
+            "jeremy64",
+            "sebleouf",
+            "moon-rabbit"
+        ],
+        "lang": "fr",
+        "vitamins_tags": [],
+        "origins_lc": "fr",
+        "interface_version_modified": "20150316.jqm2",
+        "additives_tags": [],
+        "unknown_nutrients_tags": [],
+        "stores_debug_tags": [],
+        "nova_group_debug": " -- ingredients/en:sugar : 3",
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "traces_tags": [],
+        "packaging_tags": [
+            "conserve",
+            "bocal",
+            "verre"
+        ],
+        "nova_groups": "3",
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/303/361/004/8398/front_fr.5.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-free",
+            "en:non-vegan",
+            "en:non-vegetarian"
+        ],
+        "nutrient_levels": {},
+        "created_t": 1356982680,
+        "nova_group": 3,
+        "amino_acids_prev_tags": [],
+        "nucleotides_tags": [],
+        "purchase_places_debug_tags": [],
+        "images": {
+            "1": {
+                "uploaded_t": 1356982681,
+                "uploader": "stephane",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 3264,
+                        "w": 2448
+                    }
+                }
+            },
+            "front": {
+                "rev": "5",
+                "white_magic": null,
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 308,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 77,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2285,
+                        "w": 2963
+                    },
+                    "200": {
+                        "h": 154,
+                        "w": 200
+                    }
+                },
+                "geometry": "2963x2285-301-97",
+                "imgid": "2"
+            },
+            "ingredients": {
+                "rev": "7",
+                "white_magic": null,
+                "normalize": null,
+                "sizes": {
+                    "400": {
+                        "h": 120,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 30,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 604,
+                        "w": 2007
+                    },
+                    "200": {
+                        "h": 60,
+                        "w": 200
+                    }
+                },
+                "geometry": "2007x604-106-399",
+                "imgid": "3"
+            },
+            "front_fr": {
+                "rev": "5",
+                "white_magic": null,
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 308,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 77,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2285,
+                        "w": 2963
+                    },
+                    "200": {
+                        "h": 154,
+                        "w": 200
+                    }
+                },
+                "geometry": "2963x2285-301-97",
+                "imgid": "2"
+            },
+            "2": {
+                "uploaded_t": 1356982698,
+                "uploader": "stephane",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 3264,
+                        "w": 2448
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": 1356982732,
+                "uploader": "stephane",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2448,
+                        "w": 3264
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "rev": "7",
+                "white_magic": null,
+                "normalize": null,
+                "sizes": {
+                    "400": {
+                        "h": 120,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 30,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 604,
+                        "w": 2007
+                    },
+                    "200": {
+                        "h": 60,
+                        "w": 200
+                    }
+                },
+                "geometry": "2007x604-106-399",
+                "imgid": "3"
+            }
+        },
+        "ingredients_text_with_allergens_fr": "Foie Gras de Canard du Sud-Ouest, sel, poivre, sucre.",
+        "ingredients_n": 4,
+        "manufacturing_places_debug_tags": [],
+        "editors_tags": [
+            "roboto-app",
+            "sebleouf",
+            "jeremy64",
+            "nash",
+            "moon-rabbit",
+            "stephane",
+            "jeanbono"
+        ],
+        "allergens_tags": [],
+        "countries_lc": "fr",
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "completed_t": 1392235138,
+        "nova_groups_tags": [
+            "en:3-processed-foods"
+        ],
+        "emb_codes_debug_tags": [],
+        "code": "3033610048398",
+        "manufacturing_places": "France",
+        "codes_tags": [
+            "code-13",
+            "3033610048xxx",
+            "303361004xxxx",
+            "30336100xxxxx",
+            "3033610xxxxxx",
+            "303361xxxxxxx",
+            "30336xxxxxxxx",
+            "3033xxxxxxxxx",
+            "303xxxxxxxxxx",
+            "30xxxxxxxxxxx",
+            "3xxxxxxxxxxxx"
+        ],
+        "labels": "PGI, Without sodium nitrite, fr:Canard à foie gras du Sud Ouest\n\n\n, en:no-preservatives",
+        "last_modified_by": "roboto-app",
+        "last_edit_dates_tags": [
+            "2020-02-26",
+            "2020-02",
+            "2020"
+        ],
+        "entry_dates_tags": [
+            "2012-12-31",
+            "2012-12",
+            "2012"
+        ],
+        "creator": "stephane",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "canard",
+            "de",
+            "no-preservative",
+            "sud-ouest",
+            "conserve",
+            "ouest",
+            "labeyrie",
+            "without",
+            "poisson",
+            "sud",
+            "nitrite",
+            "france",
+            "du",
+            "pure",
+            "pgi",
+            "et",
+            "foie",
+            "entier",
+            "viande",
+            "sodium",
+            "oeuf",
+            "gra",
+            "tradition"
+        ],
+        "amino_acids_tags": [],
+        "link": "",
+        "ingredients_debug": [
+            "Foie Gras de Canard du Sud-Ouest",
+            ",",
+            null,
+            null,
+            null,
+            " sel",
+            ",",
+            null,
+            null,
+            null,
+            " poivre",
+            ",",
+            null,
+            null,
+            null,
+            " sucre."
+        ],
+        "languages_codes": {
+            "fr": 5
+        },
+        "labels_lc": "en",
+        "packaging": "Conserve,Bocal,Verre",
+        "packaging_debug_tags": [],
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/303/361/004/8398/front_fr.5.400.jpg",
+        "last_image_dates_tags": [
+            "2012-12-31",
+            "2012-12",
+            "2012"
+        ],
+        "popularity_key": 0,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/303/361/004/8398/front_fr.5.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [],
+        "misc_tags": [
+            "en:nutriscore-not-computed",
+            "en:nutrition-not-enough-data-to-compute-nutrition-score",
+            "en:nutrition-no-saturated-fat",
+            "en:nutriscore-missing-nutrition-data",
+            "en:nutriscore-missing-nutrition-data-energy",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "generic_name_fr_debug_tags": [],
+        "ecoscore_score": 79,
+        "debug_param_sorted_langs": [
+            "fr"
+        ],
+        "photographers_tags": [
+            "stephane"
+        ],
+        "product_name_fr_debug_tags": [],
+        "last_modified_t": 1582745476,
+        "ingredients": [
+            {
+                "percent_max": 100,
+                "id": "fr:foie-gras-de-canard-du-sud-ouest",
+                "percent_min": 25,
+                "percent_estimate": 62.5,
+                "text": "Foie Gras de Canard du Sud-Ouest",
+                "vegan": "no",
+                "vegetarian": "no"
+            },
+            {
+                "percent_max": 50,
+                "id": "en:salt",
+                "text": "sel",
+                "percent_estimate": 18.75,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 33.3333333333333,
+                "id": "en:pepper",
+                "percent_estimate": 9.375,
+                "percent_min": 0,
+                "text": "poivre",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 25,
+                "id": "en:sugar",
+                "text": "sucre",
+                "percent_estimate": 9.375,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            }
+        ],
+        "stores": "",
+        "countries": "France",
+        "cities_tags": [
+            "saint-geours-de-maremne-landes-france"
+        ],
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "foie-gras-block-average"
+        ],
+        "brands": "Labeyrie",
+        "categories": "Conserves, Poissons et viandes et oeufs, Foies gras, Foies gras de canard, Foies gras entiers",
+        "ingredients_text_with_allergens": "Foie Gras de Canard du Sud-Ouest, sel, poivre, sucre.",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-to-be-completed, en:packaging-code-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "nutrient_levels_tags": [],
+        "known_ingredients_n": 9,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Foie Gras de Canard du Sud-Ouest, sel, poivre, sucre.",
+        "serving_size_debug_tags": [],
+        "product_name": "Pure Tradition foie gras de canard entier du sud-ouest",
+        "origins": "Sud-Ouest,France",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Foie Gras de Canard du Sud-Ouest, sel, poivre, sucre.",
+        "lang_debug_tags": [],
+        "categories_lc": "fr",
+        "allergens": "",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/303/361/004/8398/ingredients_fr.7.100.jpg",
+        "photographers": [
+            "stephane"
+        ],
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "a",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 15,
+                    "transportation_value_es": 6,
+                    "transportation_value_be": 13,
+                    "transportation_value_ch": 10,
+                    "transportation_score_be": 85,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:france",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_score": 93,
+                    "epi_value": 4,
+                    "transportation_score_ch": 69,
+                    "transportation_score_ie": 47,
+                    "value_nl": 16,
+                    "value_ie": 11,
+                    "value_fr": 19,
+                    "transportation_value_de": 9,
+                    "value_be": 17,
+                    "value_es": 10,
+                    "transportation_value_ie": 7,
+                    "transportation_score_it": 47,
+                    "transportation_score_de": 61,
+                    "origins_from_origins_field": [
+                        "en:france"
+                    ],
+                    "transportation_score_fr": 100,
+                    "transportation_value_nl": 12,
+                    "transportation_value_lu": 12,
+                    "value_ch": 14,
+                    "transportation_score_es": 37,
+                    "transportation_value_it": 7,
+                    "value_de": 13,
+                    "value_it": 11,
+                    "transportation_score_lu": 82,
+                    "transportation_score_nl": 77,
+                    "value_lu": 16
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:food-can",
+                            "material": "en:glass",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": "81"
+                        },
+                        {
+                            "shape": "en:jar",
+                            "material": "en:unknown",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "score": -19,
+                    "warning": "unscored_shape"
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "a",
+            "score": 79,
+            "grade_de": "a",
+            "missing_data_warning": 1,
+            "grade_nl": "a",
+            "score_be": 96,
+            "agribalyse": {
+                "co2_transportation": "0.19674011",
+                "ef_distribution": "0.0089437534",
+                "name_fr": "Foie, oie, cru",
+                "score": 89,
+                "ef_agriculture": "0.14660258999999998",
+                "ef_consumption": "0.0024293397",
+                "name_en": "Liver, goose, raw",
+                "co2_total": "1.563809",
+                "ef_packaging": "0.01768459",
+                "ef_processing": "0.016664930999999997",
+                "is_beverage": 0,
+                "dqr": "3.05",
+                "co2_processing": "0.23800367",
+                "agribalyse_proxy_food_code": "40120",
+                "code": "40120",
+                "co2_consumption": "0.0047993021",
+                "co2_distribution": "0.030308663",
+                "ef_total": "0.20736134",
+                "co2_agriculture": "0.80551469",
+                "ef_transportation": "0.015034638000000001",
+                "co2_packaging": "0.28844568"
+            },
+            "grade_it": "a",
+            "score_nl": 95,
+            "grade_ie": "a",
+            "missing": {
+                "packagings": 1,
+                "labels": 1
+            },
+            "score_ch": 93,
+            "score_de": 92,
+            "score_fr": 98,
+            "score_ie": 90,
+            "score_lu": 95,
+            "score_it": 90,
+            "score_es": 89,
+            "grade_ch": "a",
+            "grade_es": "a",
+            "grade": "b",
+            "grade_lu": "a"
+        },
+        "selected_images": {
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/303/361/004/8398/ingredients_fr.7.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/303/361/004/8398/ingredients_fr.7.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/303/361/004/8398/ingredients_fr.7.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/303/361/004/8398/front_fr.5.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/303/361/004/8398/front_fr.5.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/303/361/004/8398/front_fr.5.200.jpg"
+                }
+            }
+        },
+        "rev": 12,
+        "origins_old": "Sud-Ouest,France",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "roboto-app",
+        "additives_prev_original_tags": [],
+        "ingredients_tags": [
+            "fr:foie-gras-de-canard-du-sud-ouest",
+            "en:poultry",
+            "en:duck",
+            "en:duck-liver",
+            "en:duck-foie-gras",
+            "en:salt",
+            "en:pepper",
+            "en:seed",
+            "en:sugar"
+        ],
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:canned-foods",
+            "en:fish-and-meat-and-eggs",
+            "en:foies-gras",
+            "en:foies-gras-from-ducks",
+            "en:whole-foies-gras"
+        ],
+        "ecoscore_grade": "b",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ingredients_percent_analysis": 1,
+        "languages": {
+            "en:french": 5
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-40120",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-8331",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-40120"
+        ],
+        "purchase_places": "",
+        "id": "3033610048398",
+        "no_nutrition_data": "on",
+        "pnns_groups_1": "Salty snacks",
+        "allergens_from_user": "(fr) ",
+        "checkers": [],
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/303/361/004/8398/ingredients_fr.7.400.jpg",
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:no-nutrition-data"
+        ],
+        "additives_old_tags": [],
+        "ingredients_from_palm_oil_n": 0,
+        "ecoscore_tags": [
+            "b"
+        ],
+        "labels_hierarchy": [
+            "en:no-preservatives",
+            "en:pgi",
+            "en:without-sodium-nitrite",
+            "fr:Canard à foie gras du Sud Ouest"
+        ],
+        "origins_hierarchy": [
+            "en:france",
+            "fr:Sud-Ouest"
+        ],
+        "ingredients_text_fr_debug_tags": [],
+        "complete": 1,
+        "pnns_groups_2": "Salty and fatty products",
+        "nutrition_score_beverage": 0,
+        "new_additives_n": 0,
+        "product_quantity": 270,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/303/361/004/8398/front_fr.5.100.jpg",
+        "ingredients_text_debug": "Foie Gras de Canard du Sud-Ouest, sel, poivre, sucre.",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/303/361/004/8398/front_fr.5.400.jpg",
+        "_id": "3033610048398",
+        "countries_tags": [
+            "en:france"
+        ],
+        "ingredients_hierarchy": [
+            "fr:foie-gras-de-canard-du-sud-ouest",
+            "en:poultry",
+            "en:duck",
+            "en:duck-liver",
+            "en:duck-foie-gras",
+            "en:salt",
+            "en:pepper",
+            "en:seed",
+            "en:sugar"
+        ],
+        "stores_tags": [],
+        "additives_original_tags": [],
+        "compared_to_category": "en:whole-foies-gras",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "correctors": [],
+        "expiration_date_debug_tags": [],
+        "ingredients_n_tags": [
+            "4",
+            "1-10"
+        ],
+        "pnns_groups_1_tags": [
+            "salty-snacks",
+            "known"
+        ],
+        "nutrition_score_debug": "missing energy",
+        "additives_old_n": 0,
+        "packagings": [
+            {
+                "shape": "en:food-can",
+                "material": "en:glass"
+            },
+            {
+                "shape": "en:jar"
+            }
+        ],
+        "brands_tags": [
+            "labeyrie"
+        ],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:no-nutrition-data"
+        ],
+        "data_quality_errors_tags": [],
+        "quantity": "270 g",
+        "link_debug_tags": [],
+        "ingredients_ids_debug": [
+            "foie-gras-de-canard-du-sud-ouest",
+            "sel",
+            "poivre",
+            "sucre"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "ingredients_original_tags": [
+            "fr:foie-gras-de-canard-du-sud-ouest",
+            "en:salt",
+            "en:pepper",
+            "en:sugar"
+        ],
+        "unknown_ingredients_n": 0,
+        "manufacturing_places_tags": [
+            "france"
+        ],
+        "quantity_debug_tags": [],
+        "emb_codes_orig": "FR 40.261.001 EC",
+        "checkers_tags": [],
+        "emb_codes": "FR 40.261.001 EC",
+        "max_imgid": "3",
+        "editors": [
+            "jeanbono",
+            "nash",
+            "jeremy64",
+            "stephane"
+        ],
+        "nutrition_data_per_debug_tags": [],
+        "image_small_url": "https://static.openfoodfacts.net/images/products/303/361/004/8398/front_fr.5.200.jpg",
+        "brands_debug_tags": [],
+        "generic_name_fr": "foie gras entier",
+        "nutriments": {
+            "nova-group_serving": 3,
+            "nova-group": 3,
+            "nova-group_100g": 3,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0
+        },
+        "purchase_places_tags": [],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/303/361/004/8398/ingredients_fr.7.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/3222473161867.json
+++ b/testdata/product/3222473161867.json
@@ -1,0 +1,1418 @@
+{
+    "status": 1,
+    "code": "3222473161867",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "popularity_tags": [
+            "top-country-fr-scans-2019"
+        ],
+        "categories_tags": [
+            "en:meals",
+            "en:fresh-foods",
+            "en:fresh-meals",
+            "en:prepared-vegetables",
+            "en:starters",
+            "en:cold-starters",
+            "en:vegetables-macedoines"
+        ],
+        "traces_hierarchy": [
+            "en:celery",
+            "en:crustaceans",
+            "en:fish",
+            "en:gluten",
+            "en:milk",
+            "en:molluscs",
+            "en:nuts",
+            "en:sesame-seeds",
+            "en:soybeans"
+        ],
+        "allergens_hierarchy": [
+            "en:eggs",
+            "en:mustard"
+        ],
+        "generic_name": "Macédoine de légumes en sauce",
+        "product_name_fr": "Macédoine de Légumes - mayonnaise",
+        "origins_tags": [],
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1517606796,
+        "emb_codes_20141016": "EMB 22272E,EMB 22389B",
+        "additives_n": 3,
+        "pnns_groups_2_tags": [
+            "one-dish-meals",
+            "known"
+        ],
+        "allergens_lc": "fr",
+        "emb_codes_tags": [
+            "emb-22272e",
+            "emb-22389b"
+        ],
+        "correctors_tags": [
+            "sebleouf",
+            "jacob80",
+            "segundo",
+            "teolemon",
+            "tacite-mass-editor",
+            "yuka.Yi9nbk1mc25oTlV1dHZJdndDM1crZUpvN3M2blVFQ2RldHBNSUE9PQ",
+            "openfoodfacts-contributors",
+            "cyn",
+            "quechoisir"
+        ],
+        "sortkey": 1550239732,
+        "categories_old": "Plats préparés, Frais, Plats préparés frais, Légumes préparés, Entrées, Entrées froides, Macédoines de légumes préparées",
+        "categories_properties": {
+            "agribalyse_proxy_food_code:en": "20051"
+        },
+        "completeness": 0.9875,
+        "labels_tags": [
+            "en:2016-nutrition-labelling-experiment",
+            "en:green-dot",
+            "en:nutriscore-experiment",
+            "fr:eco-emballages"
+        ],
+        "traces_from_user": "(fr) en:celery,en:crustaceans,en:fish,en:gluten,en:milk,en:molluscs,en:nuts,en:sesame-seeds,en:soybeans",
+        "informers_tags": [
+            "sebleouf",
+            "jacob80",
+            "segundo",
+            "openfoodfacts-contributors",
+            "cyn"
+        ],
+        "nutrition_grades_tags": [
+            "a"
+        ],
+        "lang": "fr",
+        "vitamins_tags": [],
+        "origins_lc": "fr",
+        "interface_version_modified": "20150316.jqm2",
+        "additives_tags": [
+            "en:e14xx",
+            "en:e412",
+            "en:e415"
+        ],
+        "unique_scans_n": 1,
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/322/247/316/1867/nutrition_fr.36.400.jpg",
+        "unknown_nutrients_tags": [],
+        "nova_group_debug": " -- categories/en:meals : 3 -- additives/en:e412 : 4",
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "traces_tags": [
+            "en:celery",
+            "en:crustaceans",
+            "en:fish",
+            "en:gluten",
+            "en:milk",
+            "en:molluscs",
+            "en:nuts",
+            "en:sesame-seeds",
+            "en:soybeans"
+        ],
+        "nova_groups": "4",
+        "packaging_tags": [
+            "frais",
+            "barquette",
+            "plastique",
+            "sous-atmosphere-protectrice"
+        ],
+        "allergens_from_ingredients": "moutarde, moutarde, jaune d'œuf",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/322/247/316/1867/front_fr.6.100.jpg",
+        "nutrient_levels": {
+            "salt": "moderate",
+            "sugars": "low",
+            "saturated-fat": "low",
+            "fat": "moderate"
+        },
+        "ingredients_analysis_tags": [
+            "en:palm-oil-content-unknown",
+            "en:non-vegan",
+            "en:vegetarian-status-unknown"
+        ],
+        "created_t": 1388414195,
+        "nutriscore_data": {
+            "proteins": 2.7,
+            "negative_points": 5,
+            "sugars_points": 0,
+            "score": -2,
+            "sodium_value": 404,
+            "positive_points": 7,
+            "saturated_fat_value": 0.5,
+            "is_water": 0,
+            "proteins_points": 1,
+            "saturated_fat_points": 0,
+            "saturated_fat_ratio": 8.33333333333333,
+            "proteins_value": 2.7,
+            "saturated_fat_ratio_points": 0,
+            "fiber_points": 4,
+            "grade": "a",
+            "is_cheese": 0,
+            "energy": 389,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 80,
+            "fiber": 4.5,
+            "energy_points": 1,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 2,
+            "sodium_points": 4,
+            "is_fat": 0,
+            "energy_value": 389,
+            "is_beverage": 0,
+            "fiber_value": 4.5,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 80,
+            "saturated_fat_ratio_value": 8.3,
+            "sugars_value": 1.2,
+            "saturated_fat": 0.5,
+            "sodium": 404,
+            "sugars": 1.2
+        },
+        "nova_group": 4,
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "a",
+        "scans_n": 2,
+        "nucleotides_tags": [],
+        "ingredients_text_with_allergens_fr": "Macédoine de légumes 80 % (carotte - haricot vert - petits pois - navet - flageolet), eau - huile de colza - <span class=\"allergen\">moutarde</span> (eau - graines de <span class=\"allergen\">moutarde</span> - vinaigre d'alcool - sel) - vinaigre d'alcool - sel - <span class=\"allergen\">jaune d'œuf</span> - amidon transformé de pomme de terre - épaississants : gomme xanthane - gomme guar - sucre.",
+        "images": {
+            "nutrition": {
+                "rev": "18",
+                "white_magic": "false",
+                "geometry": "820x945-44-278",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 347
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 87
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 174
+                    },
+                    "full": {
+                        "h": 945,
+                        "w": 820
+                    }
+                },
+                "normalize": "false",
+                "imgid": "3"
+            },
+            "nutrition_fr": {
+                "y1": null,
+                "y2": null,
+                "rev": "36",
+                "x2": null,
+                "x1": null,
+                "white_magic": "0",
+                "ocr": 1,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 334
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 84
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 167
+                    },
+                    "full": {
+                        "h": 1360,
+                        "w": 1136
+                    }
+                },
+                "angle": null,
+                "orientation": "0",
+                "geometry": "0x0-0-0",
+                "normalize": "0",
+                "imgid": "11"
+            },
+            "11": {
+                "uploaded_t": "1517606791",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 334
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 84
+                    },
+                    "full": {
+                        "h": 1360,
+                        "w": 1136
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": "1442944711",
+                "uploader": "segundo",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "6": {
+                "uploaded_t": "1480343385",
+                "uploader": "teolemon",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2160,
+                        "w": 3840
+                    }
+                }
+            },
+            "9": {
+                "uploaded_t": "1480343385",
+                "uploader": "teolemon",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2160,
+                        "w": 3840
+                    }
+                }
+            },
+            "front": {
+                "rev": "6",
+                "white_magic": null,
+                "geometry": "1545x1395-340-105",
+                "normalize": null,
+                "sizes": {
+                    "400": {
+                        "h": 361,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 90,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 181,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 1395,
+                        "w": 1545
+                    }
+                },
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": 1389369035,
+                "uploader": "sebleouf",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "ingredients": {
+                "rev": "21",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 102,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 25,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 400,
+                        "w": 1575
+                    },
+                    "200": {
+                        "h": 51,
+                        "w": 200
+                    }
+                },
+                "normalize": "false",
+                "geometry": "1575x400-345-754",
+                "imgid": "2"
+            },
+            "front_fr": {
+                "rev": "6",
+                "white_magic": null,
+                "geometry": "1545x1395-340-105",
+                "normalize": null,
+                "sizes": {
+                    "400": {
+                        "h": 361,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 90,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 181,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 1395,
+                        "w": 1545
+                    }
+                },
+                "imgid": "1"
+            },
+            "12": {
+                "uploaded_t": "1517606794",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 214,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 54,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2390,
+                        "w": 4461
+                    }
+                }
+            },
+            "7": {
+                "uploaded_t": "1480343385",
+                "uploader": "teolemon",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2160,
+                        "w": 3840
+                    }
+                }
+            },
+            "10": {
+                "uploaded_t": "1517606101",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 222,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1140,
+                        "w": 2050
+                    }
+                }
+            },
+            "1": {
+                "uploaded_t": 1389368988,
+                "uploader": "sebleouf",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "4": {
+                "uploaded_t": "1442944767",
+                "uploader": "segundo",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "8": {
+                "uploaded_t": "1480343385",
+                "uploader": "teolemon",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2160,
+                        "w": 3840
+                    }
+                }
+            },
+            "5": {
+                "uploaded_t": "1480343385",
+                "uploader": "teolemon",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2160,
+                        "w": 3840
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "y1": null,
+                "y2": null,
+                "rev": "38",
+                "x2": null,
+                "white_magic": "0",
+                "x1": null,
+                "ocr": 1,
+                "sizes": {
+                    "400": {
+                        "h": 214,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 54,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 107,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 2390,
+                        "w": 4461
+                    }
+                },
+                "angle": null,
+                "orientation": null,
+                "geometry": "0x0-0-0",
+                "normalize": "0",
+                "imgid": "12"
+            }
+        },
+        "ingredients_n": 21,
+        "editors_tags": [
+            "quechoisir",
+            "sebleouf",
+            "cyn",
+            "tacite-mass-editor",
+            "teolemon",
+            "openfoodfacts-contributors",
+            "segundo",
+            "jacob80",
+            "yuka.Yi9nbk1mc25oTlV1dHZJdndDM1crZUpvN3M2blVFQ2RldHBNSUE9PQ",
+            "kiliweb"
+        ],
+        "countries_lc": "fr",
+        "traces_lc": "fr",
+        "allergens_tags": [
+            "en:eggs",
+            "en:mustard"
+        ],
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "code": "3222473161867",
+        "manufacturing_places": "Jean Stalaven (Filiale Euralis Coop) - ZI de Bellevue - 22200 Saint-Agathon (Site fermé depuis le 26/10/2012),Jean Stalaven (Filiale Euralis Coop) - ZA du Moulin à Vent - 22120 Yffiniac,Côtes-d'Armor,Bretagne,France",
+        "codes_tags": [
+            "code-13",
+            "3222473161xxx",
+            "322247316xxxx",
+            "32224731xxxxx",
+            "3222473xxxxxx",
+            "322247xxxxxxx",
+            "32224xxxxxxxx",
+            "3222xxxxxxxxx",
+            "322xxxxxxxxxx",
+            "32xxxxxxxxxxx",
+            "3xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "quechoisir",
+        "labels": "Expérimentation Nutriscore, Experimentation Etiquetage Nutritionnel 2016, Point Vert, Eco-Emballages",
+        "entry_dates_tags": [
+            "2013-12-30",
+            "2013-12",
+            "2013"
+        ],
+        "last_edit_dates_tags": [
+            "2021-02-23",
+            "2021-02",
+            "2021"
+        ],
+        "creator": "sebleouf",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "point",
+            "nutriscore",
+            "legume",
+            "casino",
+            "sauce",
+            "etiquetage",
+            "preparee",
+            "eco-emballage",
+            "froide",
+            "experimentation",
+            "de",
+            "groupe",
+            "plat",
+            "2016",
+            "prepare",
+            "macedoine",
+            "frai",
+            "nutritionnel",
+            "en",
+            "mayonnaise",
+            "entree",
+            "vert"
+        ],
+        "amino_acids_tags": [],
+        "link": "http://www.casinodrive.fr/ecommerce/affichageDetailProduit/WE80205/F-47224-snacking-et-entrees/P-59149-casino-salade-macedoine-de-legumes",
+        "ingredients_debug": [
+            "Macédoine de légumes 80 % ",
+            "(",
+            "(",
+            null,
+            null,
+            "carotte",
+            ",",
+            null,
+            null,
+            null,
+            " haricot vert",
+            ",",
+            null,
+            null,
+            null,
+            " petits pois",
+            ",",
+            null,
+            null,
+            null,
+            " navet",
+            ",",
+            null,
+            null,
+            null,
+            " flageolet)",
+            ",",
+            null,
+            null,
+            null,
+            " eau",
+            ",",
+            null,
+            null,
+            null,
+            " huile de colza",
+            ",",
+            null,
+            null,
+            null,
+            " moutarde ",
+            "(",
+            "(",
+            null,
+            null,
+            "eau",
+            ",",
+            null,
+            null,
+            null,
+            " graines de _moutarde_",
+            ",",
+            null,
+            null,
+            null,
+            " vinaigre d'alcool",
+            ",",
+            null,
+            null,
+            null,
+            " sel",
+            ",",
+            null,
+            null,
+            null,
+            " acide citrique",
+            ",",
+            null,
+            null,
+            null,
+            " disulfite de potassium)",
+            ",",
+            null,
+            null,
+            null,
+            " vinaigre d'alcool",
+            ",",
+            null,
+            null,
+            null,
+            " sel",
+            ",",
+            null,
+            null,
+            null,
+            " jaune d'_œuf_",
+            ",",
+            null,
+            null,
+            null,
+            " gomme xanthane",
+            ",",
+            null,
+            null,
+            null,
+            " gomme guar",
+            ",",
+            null,
+            null,
+            null,
+            " sucre",
+            ",",
+            null,
+            null,
+            null,
+            " amidon transformé de pomme de terre."
+        ],
+        "labels_lc": "fr",
+        "languages_codes": {
+            "fr": 6
+        },
+        "packaging": "Frais,Barquette,Plastique,Sous atmosphère protectrice",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/322/247/316/1867/front_fr.6.400.jpg",
+        "popularity_key": 1,
+        "last_image_dates_tags": [
+            "2018-02-02",
+            "2018-02",
+            "2018"
+        ],
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/322/247/316/1867/front_fr.6.200.jpg",
+        "expiration_date": "28/12/2013",
+        "labels_debug_tags": [
+            "added-en-2016-nutrition-labelling-experiment",
+            "added-en-nutriscore-experiment",
+            "removed-fr-experimentation-etiquetage-nutritionnel-2016",
+            "removed-fr-experimentation-nutriscore"
+        ],
+        "data_quality_warnings_tags": [
+            "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-not-computed"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 80,
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "sebleouf",
+            "segundo",
+            "teolemon",
+            "kiliweb"
+        ],
+        "debug_param_sorted_langs": [
+            "fr"
+        ],
+        "last_modified_t": 1614039059,
+        "ingredients": [
+            {
+                "percent_max": "80",
+                "id": "fr:Macédoine de légumes",
+                "percent": "80",
+                "percent_min": "80",
+                "percent_estimate": "80",
+                "text": "Macédoine de légumes"
+            },
+            {
+                "percent_max": 20,
+                "id": "en:water",
+                "percent_estimate": 11,
+                "percent_min": 2,
+                "text": "eau",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": 0,
+                "percent_estimate": 4.5,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "from_palm_oil": "no",
+                "percent_max": 18,
+                "id": "en:colza-oil",
+                "text": "huile de colza"
+            },
+            {
+                "percent_estimate": 2.25,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": 9,
+                "id": "en:mustard",
+                "text": "moutarde"
+            },
+            {
+                "percent_max": 6,
+                "id": "en:alcohol-vinegar",
+                "text": "vinaigre d'alcool",
+                "percent_min": 0,
+                "percent_estimate": 1.125,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 4.5,
+                "id": "en:salt",
+                "percent_estimate": 0.5625,
+                "percent_min": 0,
+                "text": "sel",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 3.6,
+                "id": "en:egg-yolk",
+                "percent_min": 0,
+                "percent_estimate": 0.28125,
+                "text": "jaune d'œuf",
+                "vegan": "no",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 3,
+                "id": "en:e1404",
+                "percent_estimate": 0.140625,
+                "percent_min": 0,
+                "text": "amidon transformé de pomme de terre",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 2.57142857142857,
+                "id": "en:thickener",
+                "percent_min": 0,
+                "percent_estimate": 0.0703125,
+                "text": "épaississants"
+            },
+            {
+                "percent_max": 2.25,
+                "id": "en:e412",
+                "percent_estimate": 0.03515625,
+                "percent_min": 0,
+                "text": "gomme guar",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 2,
+                "id": "en:sugar",
+                "percent_estimate": 0.03515625,
+                "percent_min": 0,
+                "text": "sucre",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            }
+        ],
+        "nutriscore_grade": "a",
+        "product_name_debug_tags": [],
+        "countries": "France",
+        "stores": "Casino",
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "other_nutritional_substances_tags": [],
+        "cities_tags": [
+            "saint-agathon-cotes-d-armor-france",
+            "yffiniac-cotes-d-armor-france"
+        ],
+        "brands": "Casino,Groupe Casino",
+        "categories": "Plats préparés, Frais, Plats préparés frais, Légumes préparés, Entrées, Entrées froides, en:prepared-vegetables-macedoines",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-completed, en:characteristics-to-be-completed, en:origins-to-be-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:packaging-photo-to-be-selected, en:nutrition-photo-selected, en:ingredients-photo-selected, en:front-photo-selected, en:photos-uploaded",
+        "ingredients_text_with_allergens": "Macédoine de légumes 80 % (carotte - haricot vert - petits pois - navet - flageolet), eau - huile de colza - <span class=\"allergen\">moutarde</span> (eau - graines de <span class=\"allergen\">moutarde</span> - vinaigre d'alcool - sel) - vinaigre d'alcool - sel - <span class=\"allergen\">jaune d'œuf</span> - amidon transformé de pomme de terre - épaississants : gomme xanthane - gomme guar - sucre.",
+        "nutrition_grades": "a",
+        "nutrient_levels_tags": [
+            "en:fat-in-moderate-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-low-quantity",
+            "en:salt-in-moderate-quantity"
+        ],
+        "known_ingredients_n": 27,
+        "minerals_prev_tags": [],
+        "product_name": "Macédoine de Légumes - mayonnaise",
+        "ingredients_text": "Macédoine de légumes 80 % (carotte - haricot vert - petits pois - navet - flageolet), eau - huile de colza - moutarde (eau - graines de moutarde - vinaigre d'alcool - sel) - vinaigre d'alcool - sel - jaune d'œuf - amidon transformé de pomme de terre - épaississants : gomme xanthane - gomme guar - sucre.",
+        "origins": "",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Macédoine de légumes 80 % (carotte - haricot vert - petits pois - navet - flageolet), eau - huile de colza - moutarde (eau - graines de moutarde - vinaigre d'alcool - sel) - vinaigre d'alcool - sel - jaune d'œuf - amidon transformé de pomme de terre - épaississants : gomme xanthane - gomme guar - sucre.",
+        "allergens": "en:eggs,en:mustard",
+        "categories_lc": "fr",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/322/247/316/1867/ingredients_fr.38.100.jpg",
+        "ecoscore_data": {
+            "agribalyse": {
+                "warning": "missing_agribalyse_match"
+            },
+            "missing_agribalyse_match_warning": 1,
+            "status": "unknown",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_value": -5,
+                    "transportation_score_ch": 0,
+                    "value_ie": -5,
+                    "transportation_value_de": 0,
+                    "value_fr": -5,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:tray",
+                            "material": "en:plastic",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": "0"
+                        }
+                    ],
+                    "score": 0
+                },
+                "threatened_species": {}
+            },
+            "missing": {
+                "agb_category": 1,
+                "labels": 1,
+                "origins": 1
+            }
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/322/247/316/1867/nutrition_fr.36.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/322/247/316/1867/nutrition_fr.36.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/322/247/316/1867/nutrition_fr.36.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/322/247/316/1867/ingredients_fr.38.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/322/247/316/1867/ingredients_fr.38.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/322/247/316/1867/ingredients_fr.38.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/322/247/316/1867/front_fr.6.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/322/247/316/1867/front_fr.6.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/322/247/316/1867/front_fr.6.200.jpg"
+                }
+            }
+        },
+        "origins_old": "",
+        "rev": 40,
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "quechoisir",
+        "additives_prev_original_tags": [
+            "en:e330",
+            "en:e224",
+            "en:e415",
+            "en:e412"
+        ],
+        "data_sources_tags": [
+            "app-yuka",
+            "apps"
+        ],
+        "ingredients_tags": [
+            "fr:macedoine-de-legumes",
+            "en:water",
+            "en:colza-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:rapeseed-oil",
+            "en:mustard",
+            "en:spice",
+            "en:alcohol-vinegar",
+            "en:vinegar",
+            "en:salt",
+            "en:egg-yolk",
+            "en:egg",
+            "en:e1404",
+            "en:thickener",
+            "en:e412",
+            "en:sugar",
+            "en:carrot",
+            "en:vegetable",
+            "en:root-vegetable",
+            "en:green-bean",
+            "en:legume",
+            "en:beans",
+            "en:green-peas",
+            "en:turnip",
+            "en:flageolets",
+            "en:mustard-seed",
+            "en:e415"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/322/247/316/1867/nutrition_fr.36.100.jpg",
+        "labels_prev_tags": [
+            "en:green-dot",
+            "fr:eco-emballages",
+            "fr:experimentation-etiquetage-nutritionnel-2016",
+            "fr:experimentation-nutriscore"
+        ],
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:meals",
+            "en:fresh-foods",
+            "en:fresh-meals",
+            "en:prepared-vegetables",
+            "en:starters",
+            "en:cold-starters",
+            "en:vegetables-macedoines"
+        ],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "unknown",
+        "labels_prev_hierarchy": [
+            "en:green-dot",
+            "fr:Eco-Emballages",
+            "fr:Experimentation Etiquetage Nutritionnel 2016",
+            "fr:Expérimentation Nutriscore"
+        ],
+        "languages": {
+            "en:french": 6
+        },
+        "ingredients_percent_analysis": 1,
+        "nutrition_data": "on",
+        "purchase_places": "Lyon,France,Paris",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-20051",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-unknown",
+            "agribalyse-known",
+            "agribalyse-20051"
+        ],
+        "id": "3222473161867",
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Composite foods",
+        "nutrition_data_prepared": "",
+        "allergens_from_user": "(fr) en:eggs,en:mustard",
+        "additives_debug_tags": [
+            "en-e14xx-added"
+        ],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/322/247/316/1867/ingredients_fr.38.400.jpg",
+        "data_quality_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown"
+        ],
+        "additives_old_tags": [
+            "en:e415",
+            "en:e412"
+        ],
+        "origins_hierarchy": [],
+        "labels_hierarchy": [
+            "en:2016-nutrition-labelling-experiment",
+            "en:green-dot",
+            "en:nutriscore-experiment",
+            "fr:Eco-Emballages"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "ecoscore_tags": [
+            "unknown"
+        ],
+        "pnns_groups_2": "One-dish meals",
+        "nutrition_score_beverage": 0,
+        "complete": 0,
+        "product_quantity": "300",
+        "new_additives_n": 4,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/322/247/316/1867/front_fr.6.100.jpg",
+        "ingredients_text_debug": "Macédoine de légumes 80 % (carotte, haricot vert, petits pois, navet, flageolet), eau, huile de colza, moutarde (eau, graines de _moutarde_, vinaigre d'alcool, sel, acide citrique, disulfite de potassium), vinaigre d'alcool, sel, jaune d'_œuf_, gomme xanthane, gomme guar, sucre, amidon transformé de pomme de terre.",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/322/247/316/1867/front_fr.6.400.jpg",
+        "_id": "3222473161867",
+        "countries_tags": [
+            "en:france"
+        ],
+        "ingredients_hierarchy": [
+            "fr:Macédoine de légumes",
+            "en:water",
+            "en:colza-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:rapeseed-oil",
+            "en:mustard",
+            "en:spice",
+            "en:alcohol-vinegar",
+            "en:vinegar",
+            "en:salt",
+            "en:egg-yolk",
+            "en:egg",
+            "en:e1404",
+            "en:thickener",
+            "en:e412",
+            "en:sugar",
+            "en:carrot",
+            "en:vegetable",
+            "en:root-vegetable",
+            "en:green-bean",
+            "en:legume",
+            "en:beans",
+            "en:green-peas",
+            "en:turnip",
+            "en:flageolets",
+            "en:mustard-seed",
+            "en:e415"
+        ],
+        "additives_original_tags": [
+            "en:e14xx",
+            "en:e415",
+            "en:e412"
+        ],
+        "stores_tags": [
+            "casino"
+        ],
+        "nutriscore_score": -2,
+        "compared_to_category": "en:prepared-vegetables-macedoines",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "21",
+            "21-30"
+        ],
+        "pnns_groups_1_tags": [
+            "composite-foods",
+            "known"
+        ],
+        "additives_old_n": 2,
+        "packagings": [
+            {
+                "shape": "en:tray",
+                "material": "en:plastic"
+            }
+        ],
+        "quantity": "300 g",
+        "data_quality_errors_tags": [],
+        "brands_tags": [
+            "casino",
+            "groupe-casino"
+        ],
+        "data_quality_info_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "ingredients_ids_debug": [
+            "macedoine-de-legumes-80",
+            "carotte",
+            "haricot-vert",
+            "petits-pois",
+            "navet",
+            "flageolet",
+            "eau",
+            "huile-de-colza",
+            "moutarde",
+            "eau",
+            "graines-de-moutarde",
+            "vinaigre-d-alcool",
+            "sel",
+            "acide-citrique",
+            "disulfite-de-potassium",
+            "vinaigre-d-alcool",
+            "sel",
+            "jaune-d-oeuf",
+            "gomme-xanthane",
+            "gomme-guar",
+            "sucre",
+            "amidon-transforme-de-pomme-de-terre"
+        ],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [
+            "fr:Macédoine de légumes",
+            "en:water",
+            "en:colza-oil",
+            "en:mustard",
+            "en:alcohol-vinegar",
+            "en:salt",
+            "en:egg-yolk",
+            "en:e1404",
+            "en:thickener",
+            "en:e412",
+            "en:sugar",
+            "en:carrot",
+            "en:green-bean",
+            "en:green-peas",
+            "en:turnip",
+            "en:flageolets",
+            "en:water",
+            "en:mustard-seed",
+            "en:alcohol-vinegar",
+            "en:salt",
+            "en:e415"
+        ],
+        "traces": "en:celery,en:crustaceans,en:fish,en:gluten,en:milk,en:molluscs,en:nuts,en:sesame-seeds,en:soybeans",
+        "data_sources": "App - yuka, Apps",
+        "unknown_ingredients_n": 1,
+        "manufacturing_places_tags": [
+            "jean-stalaven-filiale-euralis-coop-zi-de-bellevue-22200-saint-agathon-site-ferme-depuis-le-26-10-2012",
+            "jean-stalaven-filiale-euralis-coop-za-du-moulin-a-vent-22120-yffiniac",
+            "cotes-d-armor",
+            "bretagne",
+            "france"
+        ],
+        "emb_codes_orig": "EMB 22272E,EMB 22389B",
+        "checkers_tags": [],
+        "forest_footprint_data": {
+            "footprint_per_kg": 0.000223125,
+            "ingredients": [
+                {
+                    "type": {
+                        "deforestation_risk": "0.68",
+                        "soy_feed_factor": "0.035",
+                        "name": "Oeufs Importés",
+                        "soy_yield": "0.3"
+                    },
+                    "processing_factor": "1",
+                    "percent_estimate": 0.28125,
+                    "percent": 0.28125,
+                    "tag_type": "ingredients",
+                    "conditions_tags": [],
+                    "matching_tag_id": "en:egg",
+                    "tag_id": "en:egg-yolk",
+                    "footprint_per_kg": 0.000223125
+                }
+            ],
+            "grade": "a"
+        },
+        "max_imgid": "12",
+        "emb_codes": "EMB 22272E,EMB 22389B",
+        "editors": [
+            "segundo",
+            "sebleouf",
+            "jacob80"
+        ],
+        "nutriscore_score_opposite": 2,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/322/247/316/1867/front_fr.6.200.jpg",
+        "generic_name_fr": "Macédoine de légumes en sauce",
+        "nutriments": {
+            "proteins": 2.7,
+            "energy_100g": 389,
+            "carbohydrates_unit": "g",
+            "sodium_100g": 0.404,
+            "energy-kcal": 93,
+            "sugars_100g": 1.2,
+            "sodium_value": 0.404,
+            "nova-group_serving": 4,
+            "salt_100g": 1.01,
+            "nutrition-score-fr_100g": -2,
+            "fruits-vegetables-nuts_100g": 80,
+            "energy_unit": "kcal",
+            "salt_unit": "g",
+            "carbohydrates_value": 4.7,
+            "proteins_unit": "g",
+            "sugars_unit": "g",
+            "fat_unit": "g",
+            "salt": 1.01,
+            "fruits-vegetables-nuts_value": 80,
+            "salt_value": 1.01,
+            "fruits-vegetables-nuts_label": "0",
+            "fruits-vegetables-nuts_serving": 80,
+            "proteins_value": 2.7,
+            "saturated-fat_100g": 0.5,
+            "energy-kcal_100g": 93,
+            "fiber_100g": 4.5,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 16,
+            "saturated-fat": 0.5,
+            "fat_value": 6,
+            "nova-group": 4,
+            "energy": 389,
+            "fiber": 4.5,
+            "saturated-fat_value": 0.5,
+            "energy-kcal_value": 93,
+            "nova-group_100g": 4,
+            "fat_100g": 6,
+            "saturated-fat_unit": "g",
+            "fruits-vegetables-nuts": 80,
+            "energy_value": 93,
+            "fiber_value": 4.5,
+            "fiber_unit": "g",
+            "sugars_value": 1.2,
+            "proteins_100g": 2.7,
+            "nutrition-score-fr": -2,
+            "sodium_unit": "g",
+            "carbohydrates_100g": 4.7,
+            "sodium": 0.404,
+            "fruits-vegetables-nuts_unit": "g",
+            "sugars": 1.2,
+            "carbohydrates": 4.7,
+            "fat": 6,
+            "energy-kcal_unit": "kcal"
+        },
+        "purchase_places_tags": [
+            "lyon",
+            "france",
+            "paris"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/322/247/316/1867/ingredients_fr.38.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/322/247/316/1867/nutrition_fr.36.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/3242272260059.json
+++ b/testdata/product/3242272260059.json
@@ -1,0 +1,1855 @@
+{
+    "status": 1,
+    "code": "3242272260059",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "popularity_tags": [
+            "top-5000-scans-2019",
+            "top-10000-scans-2019",
+            "top-50000-scans-2019",
+            "top-100000-scans-2019",
+            "at-least-5-scans-2019",
+            "at-least-10-scans-2019",
+            "top-75-percent-scans-2019",
+            "top-80-percent-scans-2019",
+            "top-85-percent-scans-2019",
+            "top-90-percent-scans-2019",
+            "top-5000-fr-scans-2019",
+            "top-10000-fr-scans-2019",
+            "top-50000-fr-scans-2019",
+            "top-100000-fr-scans-2019",
+            "top-country-fr-scans-2019",
+            "at-least-5-fr-scans-2019",
+            "at-least-10-fr-scans-2019",
+            "top-50000-ch-scans-2019",
+            "top-100000-ch-scans-2019",
+            "top-10000-scans-2020",
+            "top-50000-scans-2020",
+            "top-100000-scans-2020",
+            "at-least-5-scans-2020",
+            "at-least-10-scans-2020",
+            "top-75-percent-scans-2020",
+            "top-80-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-5000-fr-scans-2020",
+            "top-10000-fr-scans-2020",
+            "top-50000-fr-scans-2020",
+            "top-100000-fr-scans-2020",
+            "top-country-fr-scans-2020",
+            "at-least-5-fr-scans-2020",
+            "at-least-10-fr-scans-2020",
+            "top-10000-mx-scans-2020",
+            "top-50000-mx-scans-2020",
+            "top-100000-mx-scans-2020"
+        ],
+        "categories_tags": [
+            "en:meals",
+            "en:pasta-dishes",
+            "en:instant-pasta",
+            "en:microwave-meals",
+            "en:carbonara-style-pasta",
+            "en:pots"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [
+            "en:eggs",
+            "en:gluten",
+            "en:milk"
+        ],
+        "generic_name": "Radiatori cuits 51% accompagnés d'une sauce à la carbonara",
+        "product_name_fr": "XtremBox - Radiatori Carbonara",
+        "origins_tags": [],
+        "teams_tags": [
+            "chocolatine",
+            "la-robe-est-bleue"
+        ],
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1615806314,
+        "emb_codes_20141016": "FR 85.217.007 CE",
+        "additives_n": 4,
+        "allergens_lc": "fr",
+        "pnns_groups_2_tags": [
+            "one-dish-meals",
+            "known"
+        ],
+        "emb_codes_tags": [
+            "fr-85-217-007-ec"
+        ],
+        "correctors_tags": [
+            "phoenix",
+            "tacite",
+            "tacinte",
+            "date-limite-app",
+            "yuka.Yjc0T0c2SXNqZGNLbHM4WndTSGYvOUZSeUlEM2UzcTFHclVESWc9PQ",
+            "openfoodfacts-contributors",
+            "yuka.ZnBvY0xMMDRoUDBvaGZkdTN6WDQ4Y05INnJLRlFFcTdlOVk2SVE9PQ",
+            "yuka.VkkwNkhmOCtnZjhGb2M4andBR0orZW9sbXNhYlEyV3BjTm9wSVE9PQ",
+            "yuka.WnFzQUtQOEYvZGNRaWRnMDUwNlBvSW9xbkpxSFpFNndGdW80SVE9PQ",
+            "syl44",
+            "yuka.V0p3UERxWXZqZDR0cGNBWjh3SHMrZWhsM00rSFlXeVZFTlZLSUE9PQ",
+            "yuka.WVlVTVRxc2Z1ZkF6cXNZYzBERFErdXBhK1o3NVpYT1pNTmd2SVE9PQ",
+            "yuka.YXJFZVA0QTdocVJWaHM5bitUei94WTllM0lDYlEzRytNZmdWSVE9PQ",
+            "sodebo",
+            "magasins-u",
+            "tivoch",
+            "roboto-app",
+            "moon-rabbit",
+            "teolemon",
+            "kiliweb"
+        ],
+        "sortkey": 1603469498,
+        "categories_old": "Plats préparés, Plats à base de pâtes, Plats préparés à réchauffer au micro-ondes, Pâtes à la carbonara, Pâtes instantanées, Box",
+        "completeness": 0.9875,
+        "categories_properties": {
+            "ciqual_food_code:en": "25135",
+            "agribalyse_food_code:en": "25135"
+        },
+        "labels_tags": [
+            "en:2016-nutrition-labelling-experiment",
+            "en:nutriscore",
+            "en:nutriscore-experiment",
+            "en:nutriscore-experiment-grade-b",
+            "en:nutriscore-grade-c"
+        ],
+        "traces_from_user": "(fr) ",
+        "informers_tags": [
+            "phoenix",
+            "tacite",
+            "tacinte",
+            "yuka.VkkwNkhmOCtnZjhGb2M4andBR0orZW9sbXNhYlEyV3BjTm9wSVE9PQ",
+            "syl44",
+            "kiliweb",
+            "tivoch",
+            "moon-rabbit"
+        ],
+        "nutrition_grades_tags": [
+            "c"
+        ],
+        "vitamins_tags": [],
+        "lang": "fr",
+        "origins_lc": "fr",
+        "interface_version_modified": "20150316.jqm2",
+        "unique_scans_n": 72,
+        "additives_tags": [
+            "en:e202",
+            "en:e250",
+            "en:e262",
+            "en:e262i",
+            "en:e316"
+        ],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/324/227/226/0059/nutrition_fr.84.400.jpg",
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "nova_group_debug": " -- categories/en:meals : 3 -- ingredients/en:glucose-syrup : 4",
+        "obsolete_since_date": "",
+        "traces_tags": [],
+        "packaging_text": "",
+        "nova_groups": "4",
+        "packaging_tags": [
+            "emballage-carton",
+            "boite-plastique",
+            "opercule-plastique",
+            "fourchette-plastique"
+        ],
+        "allergens_from_ingredients": "oeuf, lait écrémé, lactose",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/324/227/226/0059/front_fr.82.100.jpg",
+        "nutrient_levels": {
+            "sugars": "low",
+            "salt": "moderate",
+            "fat": "moderate",
+            "saturated-fat": "moderate"
+        },
+        "ingredients_analysis_tags": [
+            "en:palm-oil-content-unknown",
+            "en:non-vegan",
+            "en:non-vegetarian"
+        ],
+        "created_t": 1439317051,
+        "nutriscore_data": {
+            "proteins": 7,
+            "negative_points": 8,
+            "sugars_points": 0,
+            "sodium_value": 308,
+            "score": 3,
+            "positive_points": 5,
+            "saturated_fat_value": 3.6,
+            "is_water": 0,
+            "proteins_points": 4,
+            "saturated_fat_points": 3,
+            "saturated_fat_ratio": 47.3684210526316,
+            "proteins_value": 7,
+            "saturated_fat_ratio_points": 7,
+            "fiber_points": 1,
+            "grade": "c",
+            "is_cheese": 0,
+            "energy": 761,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 1.7,
+            "energy_points": 2,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 3,
+            "is_fat": 0,
+            "energy_value": 761,
+            "is_beverage": 0,
+            "fiber_value": 1.7,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 47.4,
+            "sugars_value": 1.2,
+            "saturated_fat": 3.6,
+            "sodium": 308,
+            "sugars": 1.2
+        },
+        "amino_acids_prev_tags": [],
+        "nova_group": 4,
+        "nutrition_grade_fr": "c",
+        "scans_n": 101,
+        "nucleotides_tags": [],
+        "ingredients_text_with_allergens_fr": "Radiatori cuits (semoule de blé dur, eau, <span class=\"allergen\">oeuf</span>, sel), poitrine de porc, crème fraîche légère, <span class=\"allergen\">lait écrémé</span>, eau, fromage à päte pressée cuite, fécule de manioc, <span class=\"allergen\">lactose</span>, dextrose, sirop de glucose, conservateurs E202, E262i, E250, antioxydant: E316, sel, arômes naturels, arôme de fumée, poivre. Informations en gras destinées aux personnes allergiques. Porc:Origine UE",
+        "images": {
+            "18": {
+                "uploaded_t": "1585079933",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 161,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 40,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 823,
+                        "w": 2050
+                    }
+                }
+            },
+            "nutrition_fr": {
+                "y1": "-1",
+                "y2": "-1",
+                "rev": "84",
+                "x2": "-1",
+                "white_magic": null,
+                "x1": "-1",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 150
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 900
+                    }
+                },
+                "coordinates_image_size": "full",
+                "angle": 0,
+                "geometry": "0x0--1--1",
+                "normalize": null,
+                "imgid": "20"
+            },
+            "nutrition": {
+                "rev": "8",
+                "white_magic": "false",
+                "normalize": "false",
+                "sizes": {
+                    "400": {
+                        "h": 209,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 52,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 105,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 985,
+                        "w": 1885
+                    }
+                },
+                "geometry": "1885x985-56-59",
+                "imgid": "2"
+            },
+            "11": {
+                "uploaded_t": "1528455152",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 181,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 45,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1017,
+                        "w": 2248
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": "1439317086",
+                "uploader": "phoenix",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "15": {
+                "uploaded_t": 1568226971,
+                "uploader": "moon-rabbit",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 3264,
+                        "w": 2448
+                    }
+                }
+            },
+            "6": {
+                "uploaded_t": "1474915619",
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 4160,
+                        "w": 3120
+                    }
+                }
+            },
+            "19": {
+                "uploaded_t": 1615806306,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 351
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 88
+                    },
+                    "full": {
+                        "h": 1024,
+                        "w": 898
+                    }
+                }
+            },
+            "9": {
+                "uploaded_t": "1522833923",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 144,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 36,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 954,
+                        "w": 2651
+                    }
+                }
+            },
+            "20": {
+                "uploaded_t": 1615806314,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 900
+                    }
+                }
+            },
+            "17": {
+                "uploaded_t": "1585079933",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 375
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 94
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 1125
+                    }
+                }
+            },
+            "2": {
+                "uploaded_t": "1439317069",
+                "uploader": "phoenix",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "14": {
+                "uploaded_t": 1568226950,
+                "uploader": "moon-rabbit",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 335
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 84
+                    },
+                    "full": {
+                        "h": 2921,
+                        "w": 2448
+                    }
+                }
+            },
+            "front_fr": {
+                "y1": "-1",
+                "rev": "82",
+                "y2": "-1",
+                "x2": "-1",
+                "x1": "-1",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 351
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 88
+                    },
+                    "full": {
+                        "h": 1024,
+                        "w": 898
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 175
+                    }
+                },
+                "coordinates_image_size": "full",
+                "angle": 0,
+                "normalize": null,
+                "geometry": "0x0--1--1",
+                "imgid": "19"
+            },
+            "12": {
+                "uploaded_t": 1530626099,
+                "uploader": "sodebo",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 3600,
+                        "w": 3600
+                    }
+                }
+            },
+            "7": {
+                "uploaded_t": "1474915620",
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 4160,
+                        "w": 3120
+                    }
+                }
+            },
+            "10": {
+                "uploaded_t": "1527764381",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 204,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 51,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 947,
+                        "w": 1858
+                    }
+                }
+            },
+            "16": {
+                "uploaded_t": 1580580734,
+                "uploader": "date-limite-app",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 335
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 84
+                    },
+                    "full": {
+                        "h": 400,
+                        "w": 335
+                    }
+                }
+            },
+            "13": {
+                "uploaded_t": 1563566140,
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 3648,
+                        "w": 2736
+                    }
+                }
+            },
+            "1": {
+                "uploaded_t": "1439317051",
+                "uploader": "phoenix",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2666,
+                        "w": 2000
+                    }
+                }
+            },
+            "4": {
+                "uploaded_t": "1474915612",
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 4160,
+                        "w": 3120
+                    }
+                }
+            },
+            "5": {
+                "uploaded_t": "1474915615",
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 4160,
+                        "w": 3120
+                    }
+                }
+            },
+            "8": {
+                "uploaded_t": "1515937549",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 228,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 57,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1354,
+                        "w": 2376
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "y1": "166.78016662597656",
+                "rev": "63",
+                "y2": "257.45008850097656",
+                "x2": "229.45001220703125",
+                "x1": "52.110015869140625",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 205,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 51,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 102,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 740,
+                        "w": 1447
+                    }
+                },
+                "angle": "0",
+                "normalize": "false",
+                "geometry": "1447x740-425-1360",
+                "imgid": "15"
+            }
+        },
+        "ingredients_n": 25,
+        "editors_tags": [
+            "tivoch",
+            "yuka.sY2b0xO6T85zoF3NwEKvlksaeOjSrin8NDXQx2fVm-izIJrRQ49y29X_L6s",
+            "syl44",
+            "sodebo",
+            "tacite",
+            "magasins-u",
+            "yuka.V0p3UERxWXZqZDR0cGNBWjh3SHMrZWhsM00rSFlXeVZFTlZLSUE9PQ",
+            "roboto-app",
+            "openfoodfacts-contributors",
+            "moon-rabbit",
+            "tacinte",
+            "yuka.VkkwNkhmOCtnZjhGb2M4andBR0orZW9sbXNhYlEyV3BjTm9wSVE9PQ",
+            "yuka.WnFzQUtQOEYvZGNRaWRnMDUwNlBvSW9xbkpxSFpFNndGdW80SVE9PQ",
+            "teolemon",
+            "yuka.YXJFZVA0QTdocVJWaHM5bitUei94WTllM0lDYlEzRytNZmdWSVE9PQ",
+            "phoenix",
+            "date-limite-app",
+            "yuka.WVlVTVRxc2Z1ZkF6cXNZYzBERFErdXBhK1o3NVpYT1pNTmd2SVE9PQ",
+            "quechoisir",
+            "kiliweb",
+            "yuka.ZnBvY0xMMDRoUDBvaGZkdTN6WDQ4Y05INnJLRlFFcTdlOVk2SVE9PQ",
+            "yuka.Yjc0T0c2SXNqZGNLbHM4WndTSGYvOUZSeUlEM2UzcTFHclVESWc9PQ"
+        ],
+        "countries_lc": "fr",
+        "allergens_tags": [
+            "en:eggs",
+            "en:gluten",
+            "en:milk"
+        ],
+        "traces_lc": "fr",
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "environment_impact_level_tags": [],
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "manufacturing_places": "",
+        "code": "3242272260059",
+        "codes_tags": [
+            "code-13",
+            "3242272260xxx",
+            "324227226xxxx",
+            "32422722xxxxx",
+            "3242272xxxxxx",
+            "324227xxxxxxx",
+            "32422xxxxxxxx",
+            "3242xxxxxxxxx",
+            "324xxxxxxxxxx",
+            "32xxxxxxxxxxx",
+            "3xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "kiliweb",
+        "labels": "Experimentation Etiquetage Nutritionnel 2016,Nutriscore,Expérimentation Nutriscore,Expérimentation Nutriscore B,Nutriscore C",
+        "entry_dates_tags": [
+            "2015-08-11",
+            "2015-08",
+            "2015"
+        ],
+        "last_edit_dates_tags": [
+            "2021-03-15",
+            "2021-03",
+            "2021"
+        ],
+        "creator": "phoenix",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "etiquetage",
+            "micro-onde",
+            "prepare",
+            "xtrem",
+            "box",
+            "instantanee",
+            "de",
+            "une",
+            "la",
+            "rechauffer",
+            "51",
+            "nutriscore",
+            "carbonara",
+            "au",
+            "plat",
+            "cuit",
+            "accompagne",
+            "sodebo",
+            "xtrembox",
+            "pasta",
+            "pate",
+            "experimentation",
+            "base",
+            "nutritionnel",
+            "2016",
+            "radiatori",
+            "sauce"
+        ],
+        "link": "",
+        "ingredients_debug": [
+            "Radiatori cuits ",
+            "(",
+            "(",
+            null,
+            null,
+            "51%) accompagnés d'une sauce à la carbonara.Semoule de blé dur",
+            ",",
+            null,
+            null,
+            null,
+            " eau",
+            ",",
+            null,
+            null,
+            null,
+            " lardon cuit fumé 20% ",
+            "(",
+            "(",
+            null,
+            null,
+            "poitrine de porc",
+            ",",
+            null,
+            null,
+            null,
+            " eau",
+            ",",
+            null,
+            null,
+            null,
+            " sel",
+            ",",
+            null,
+            null,
+            null,
+            " sirop de glucose",
+            ",",
+            null,
+            null,
+            null,
+            " dextrose",
+            ",",
+            null,
+            null,
+            null,
+            " arôme naturel",
+            ",",
+            null,
+            null,
+            null,
+            " lactose",
+            ",",
+            null,
+            null,
+            null,
+            " arôme de fumée",
+            ",",
+            null,
+            null,
+            null,
+            " antioxydant ",
+            ":",
+            ":",
+            null,
+            null,
+            "  ",
+            " - ",
+            " - ",
+            " - ",
+            null,
+            "e316",
+            " - ",
+            " - ",
+            " - ",
+            null,
+            "",
+            ",",
+            null,
+            null,
+            null,
+            " conservateur ",
+            ":",
+            ":",
+            null,
+            null,
+            "  ",
+            " - ",
+            " - ",
+            " - ",
+            null,
+            "e250",
+            " - ",
+            " - ",
+            " - ",
+            null,
+            ")",
+            ",",
+            null,
+            null,
+            null,
+            " crème fraîche légère 15%",
+            ",",
+            null,
+            null,
+            null,
+            " lait écrémé",
+            ",",
+            null,
+            null,
+            null,
+            " œuf",
+            ",",
+            null,
+            null,
+            null,
+            " amidon de riz",
+            ",",
+            null,
+            null,
+            null,
+            " fromage à pâte pressée cuite",
+            ",",
+            null,
+            null,
+            null,
+            " arôme naturel",
+            ",",
+            null,
+            null,
+            null,
+            " sel",
+            ",",
+            null,
+            null,
+            null,
+            " poivre",
+            ",",
+            null,
+            null,
+            null,
+            " conservateurs ",
+            ":",
+            ":",
+            null,
+            null,
+            "  ",
+            " - ",
+            " - ",
+            " - ",
+            null,
+            "e202",
+            " - ",
+            " - ",
+            " - ",
+            null,
+            "",
+            ",",
+            null,
+            null,
+            null,
+            " ",
+            " - ",
+            " - ",
+            " - ",
+            null,
+            "e262i",
+            " - ",
+            " - ",
+            " - ",
+            null,
+            "",
+            ".\n",
+            null,
+            null,
+            null,
+            " Porc ",
+            ":",
+            ":",
+            null,
+            null,
+            " Origine UE"
+        ],
+        "labels_lc": "fr",
+        "languages_codes": {
+            "fr": 6
+        },
+        "packaging": "emballage carton,boite plastique,opercule plastique,fourchette plastique",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/324/227/226/0059/front_fr.82.400.jpg",
+        "last_image_dates_tags": [
+            "2021-03-15",
+            "2021-03",
+            "2021"
+        ],
+        "popularity_key": 19990000084,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/324/227/226/0059/front_fr.82.200.jpg",
+        "expiration_date": "03/09/2015",
+        "origins_fr": "",
+        "data_quality_warnings_tags": [
+            "en:quantity-not-recognized",
+            "en:serving-quantity-defined-but-quantity-undefined",
+            "en:ecoscore-packaging-unspecified-shape",
+            "en:ecoscore-production-system-no-label"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed",
+            "en:forest-footprint-computed",
+            "en:forest-footprint-a"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "phoenix",
+            "tacinte",
+            "kiliweb",
+            "sodebo",
+            "openfoodfacts-contributors",
+            "moon-rabbit",
+            "date-limite-app"
+        ],
+        "debug_param_sorted_langs": [
+            "fr"
+        ],
+        "ecoscore_score": 56,
+        "last_modified_t": 1615806314,
+        "ingredients": [
+            {
+                "percent_max": 100,
+                "id": "fr:Radiatori cuits",
+                "text": "Radiatori cuits",
+                "percent_estimate": 52.6315789473684,
+                "percent_min": 5.26315789473684
+            },
+            {
+                "percent_max": 50,
+                "id": "en:pork-breast",
+                "text": "poitrine de porc",
+                "percent_min": 0,
+                "percent_estimate": 23.6842105263158,
+                "vegan": "no",
+                "vegetarian": "no"
+            },
+            {
+                "percent_max": 33.3333333333333,
+                "id": "en:light-cream",
+                "text": "crème fraîche légère",
+                "percent_estimate": 11.8421052631579,
+                "percent_min": 0,
+                "vegan": "no",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 25,
+                "id": "en:skimmed-milk",
+                "text": "lait écrémé",
+                "percent_min": 0,
+                "percent_estimate": 5.92105263157895,
+                "vegan": "no",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 20,
+                "id": "en:water",
+                "percent_min": 0,
+                "percent_estimate": 2.96052631578947,
+                "text": "eau",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 16.6666666666667,
+                "id": "fr:fromage-a-pate-pressee-cuite",
+                "text": "fromage à päte pressée cuite",
+                "percent_estimate": 1.48026315789474,
+                "percent_min": 0,
+                "vegan": "no",
+                "vegetarian": "maybe"
+            },
+            {
+                "percent_max": 14.2857142857143,
+                "id": "en:tapioca-starch",
+                "text": "fécule de manioc",
+                "percent_min": 0,
+                "percent_estimate": 0.74013157894737,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 12.5,
+                "id": "en:lactose",
+                "percent_min": 0,
+                "percent_estimate": 0.370065789473685,
+                "text": "lactose",
+                "vegan": "no",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 11.1111111111111,
+                "id": "en:dextrose",
+                "percent_min": 0,
+                "percent_estimate": 0.185032894736842,
+                "text": "dextrose",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 10,
+                "id": "en:glucose-syrup",
+                "text": "sirop de glucose",
+                "percent_estimate": 0.0925164473684248,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 9.09090909090909,
+                "id": "en:preservative",
+                "text": "conservateurs",
+                "percent_min": 0,
+                "percent_estimate": 0.0462582236842124
+            },
+            {
+                "percent_max": 8.33333333333333,
+                "id": "en:e262i",
+                "text": "e262i",
+                "percent_min": 0,
+                "percent_estimate": 0.0231291118421098,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 7.69230769230769,
+                "id": "en:e250",
+                "text": "e250",
+                "percent_min": 0,
+                "percent_estimate": 0.0115645559210549,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 7.14285714285714,
+                "id": "en:antioxidant",
+                "text": "antioxydant",
+                "percent_estimate": 0.00578227796052744,
+                "percent_min": 0
+            },
+            {
+                "percent_max": 6.66666666666667,
+                "id": "en:salt",
+                "text": "sel",
+                "percent_estimate": 0.00289113898026017,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 6.25,
+                "id": "en:natural-flavouring",
+                "percent_estimate": 0.00144556949013008,
+                "percent_min": 0,
+                "text": "arômes naturels",
+                "vegan": "maybe",
+                "vegetarian": "maybe"
+            },
+            {
+                "percent_max": 5.88235294117647,
+                "id": "en:smoke-flavouring",
+                "text": "arôme de fumée",
+                "percent_estimate": 0.000722784745065042,
+                "percent_min": 0,
+                "vegan": "maybe",
+                "vegetarian": "maybe"
+            },
+            {
+                "percent_max": 5.55555555555556,
+                "id": "en:pepper",
+                "text": "poivre",
+                "percent_estimate": 0.000361392372532521,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": 0,
+                "percent_estimate": 0.000361392372525415,
+                "vegan": "no",
+                "origins": "en:european-union",
+                "vegetarian": "no",
+                "percent_max": 5.26315789473684,
+                "id": "en:pork",
+                "text": "Porc"
+            }
+        ],
+        "packaging_text_fr": "",
+        "nutriscore_grade": "c",
+        "product_name_debug_tags": [],
+        "countries": "France",
+        "stores": "Carrefour,Casino,Magasins U",
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "cities_tags": [
+            "saint-georges-de-montaigu-vendee-france"
+        ],
+        "brands": "Sodebo,pasta xtrem",
+        "obsolete": "",
+        "categories": "Plats préparés, Plats à base de pâtes, Plats préparés à réchauffer au micro-ondes, Pâtes à la carbonara, Pâtes instantanées, Box",
+        "environment_impact_level": "",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-completed, en:characteristics-to-be-completed, en:origins-to-be-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:packaging-photo-to-be-selected, en:nutrition-photo-selected, en:ingredients-photo-selected, en:front-photo-selected, en:photos-uploaded",
+        "ingredients_text_with_allergens": "Radiatori cuits (semoule de blé dur, eau, <span class=\"allergen\">oeuf</span>, sel), poitrine de porc, crème fraîche légère, <span class=\"allergen\">lait écrémé</span>, eau, fromage à päte pressée cuite, fécule de manioc, <span class=\"allergen\">lactose</span>, dextrose, sirop de glucose, conservateurs E202, E262i, E250, antioxydant: E316, sel, arômes naturels, arôme de fumée, poivre. Informations en gras destinées aux personnes allergiques. Porc:Origine UE",
+        "nutrition_grades": "c",
+        "nutrient_levels_tags": [
+            "en:fat-in-moderate-quantity",
+            "en:saturated-fat-in-moderate-quantity",
+            "en:sugars-in-low-quantity",
+            "en:salt-in-moderate-quantity"
+        ],
+        "known_ingredients_n": 39,
+        "minerals_prev_tags": [],
+        "product_name": "XtremBox - Radiatori Carbonara",
+        "ingredients_text": "Radiatori cuits (semoule de blé dur, eau, oeuf, sel), poitrine de porc, crème fraîche légère, lait écrémé, eau, fromage à päte pressée cuite, fécule de manioc, lactose, dextrose, sirop de glucose, conservateurs E202, E262i, E250, antioxydant: E316, sel, arômes naturels, arôme de fumée, poivre. Informations en gras destinées aux personnes allergiques. Porc:Origine UE",
+        "origins": "",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Radiatori cuits (semoule de blé dur, eau, oeuf, sel), poitrine de porc, crème fraîche légère, lait écrémé, eau, fromage à päte pressée cuite, fécule de manioc, lactose, dextrose, sirop de glucose, conservateurs E202, E262i, E250, antioxydant: E316, sel, arômes naturels, arôme de fumée, poivre. Informations en gras destinées aux personnes allergiques. Porc:Origine UE",
+        "allergens": "en:eggs,en:gluten,en:milk",
+        "serving_quantity": "400",
+        "categories_lc": "fr",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/324/227/226/0059/ingredients_fr.63.100.jpg",
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "c",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:fork",
+                            "material": "en:plastic",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": "0.2",
+                            "ecoscore_material_score": "0"
+                        },
+                        {
+                            "shape": "en:seal",
+                            "material": "en:plastic",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": "0.1",
+                            "ecoscore_material_score": "0"
+                        },
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:cardboard",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": "92"
+                        },
+                        {
+                            "shape": "en:box",
+                            "material": "en:plastic",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": "0"
+                        }
+                    ],
+                    "score": -38,
+                    "warning": "unspecified_shape"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_value": -5,
+                    "transportation_score_ch": 0,
+                    "value_ie": -5,
+                    "transportation_value_de": 0,
+                    "value_fr": -5,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "value_lu": -5,
+                    "transportation_score_nl": 0
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "c",
+            "score": 56,
+            "grade_de": "c",
+            "missing_data_warning": 1,
+            "grade_nl": "c",
+            "score_be": 51,
+            "agribalyse": {
+                "co2_transportation": "0.21803178",
+                "ef_distribution": "0.0089786658",
+                "name_fr": "Pâtes à la carbonara (spaghetti, tagliatelles…)",
+                "agribalyse_food_code": "25135",
+                "score": 66,
+                "ef_consumption": "0.0064417627",
+                "ef_agriculture": "0.25187293",
+                "name_en": "Carbonara-style pasta (spaghetti, tagliatelle…)",
+                "ef_packaging": "0.016118590000000002",
+                "co2_total": "2.721967",
+                "ef_processing": "0.07507507399999999",
+                "is_beverage": 0,
+                "code": "25135",
+                "co2_processing": "0.51297947",
+                "dqr": "2.43",
+                "co2_consumption": "0.012726077",
+                "ef_total": "0.37543476000000003",
+                "co2_distribution": "0.030685111",
+                "co2_agriculture": "1.7351836",
+                "ef_transportation": "0.016946191",
+                "co2_packaging": "0.21221738"
+            },
+            "grade_it": "c",
+            "score_nl": 51,
+            "missing": {
+                "packagings": 1,
+                "labels": 1,
+                "origins": 1
+            },
+            "grade_ie": "c",
+            "score_ch": 51,
+            "score_de": 51,
+            "score_fr": 51,
+            "score_ie": 51,
+            "score_lu": 51,
+            "score_it": 51,
+            "score_es": 51,
+            "grade_ch": "c",
+            "grade_es": "c",
+            "grade": "c",
+            "grade_lu": "c"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/227/226/0059/nutrition_fr.84.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/227/226/0059/nutrition_fr.84.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/227/226/0059/nutrition_fr.84.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/227/226/0059/ingredients_fr.63.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/227/226/0059/ingredients_fr.63.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/227/226/0059/ingredients_fr.63.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/227/226/0059/front_fr.82.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/227/226/0059/front_fr.82.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/227/226/0059/front_fr.82.200.jpg"
+                }
+            }
+        },
+        "origins_old": "",
+        "rev": 84,
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "kiliweb",
+        "additives_prev_original_tags": [
+            "en:e316",
+            "en:e250",
+            "en:e202",
+            "en:e262"
+        ],
+        "ingredients_tags": [
+            "fr:radiatori-cuits",
+            "en:pork-breast",
+            "en:animal",
+            "en:meat",
+            "en:pork",
+            "en:pork-meat",
+            "en:breast",
+            "en:light-cream",
+            "en:dairy",
+            "en:cream",
+            "en:skimmed-milk",
+            "en:milk",
+            "en:water",
+            "fr:fromage-a-pate-pressee-cuite",
+            "en:cheese",
+            "en:tapioca-starch",
+            "en:starch",
+            "en:lactose",
+            "en:dextrose",
+            "en:glucose",
+            "en:glucose-syrup",
+            "en:preservative",
+            "en:e262i",
+            "en:e262",
+            "en:e250",
+            "en:antioxidant",
+            "en:salt",
+            "en:natural-flavouring",
+            "en:flavouring",
+            "en:smoke-flavouring",
+            "en:pepper",
+            "en:seed",
+            "en:durum-wheat-semolina",
+            "en:cereal",
+            "en:wheat",
+            "en:durum-wheat",
+            "en:semolina",
+            "en:egg",
+            "en:e202",
+            "en:e316"
+        ],
+        "data_sources_tags": [
+            "producer-sodebo",
+            "producers",
+            "app-yuka",
+            "apps"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/324/227/226/0059/nutrition_fr.84.100.jpg",
+        "ingredients_from_palm_oil_tags": [],
+        "carbon_footprint_percent_of_known_ingredients": 35,
+        "categories_hierarchy": [
+            "en:meals",
+            "en:pasta-dishes",
+            "en:instant-pasta",
+            "en:microwave-meals",
+            "en:carbonara-style-pasta",
+            "en:pots"
+        ],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "c",
+        "languages": {
+            "en:french": 6
+        },
+        "nutrition_data": "on",
+        "purchase_places": "Rennes,France,Paris,Maison-Laffitte",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-25135",
+            "agribalyse-food-code-known",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-25135",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-25135"
+        ],
+        "id": "3242272260059",
+        "sources": [
+            {
+                "import_t": 1530626107,
+                "id": "sodebo",
+                "fields": [
+                    "product_name_fr",
+                    "quantity",
+                    "brands",
+                    "serving_size",
+                    "ingredients_text_fr"
+                ],
+                "url": "https://www.sodebo.com/",
+                "manufacturer": 1,
+                "name": "Sodebo",
+                "images": []
+            }
+        ],
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Composite foods",
+        "allergens_from_user": "(fr) en:eggs,en:gluten,en:milk",
+        "nutrition_data_prepared": "",
+        "additives_debug_tags": [
+            "en-e262i-added"
+        ],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/324/227/226/0059/ingredients_fr.63.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:quantity-not-recognized",
+            "en:serving-quantity-defined-but-quantity-undefined",
+            "en:ecoscore-packaging-unspecified-shape",
+            "en:ecoscore-production-system-no-label"
+        ],
+        "additives_old_tags": [
+            "en:e202",
+            "en:e250",
+            "en:e316"
+        ],
+        "origins_hierarchy": [],
+        "labels_hierarchy": [
+            "en:2016-nutrition-labelling-experiment",
+            "en:nutriscore",
+            "en:nutriscore-experiment",
+            "en:nutriscore-experiment-grade-b",
+            "en:nutriscore-grade-c"
+        ],
+        "ecoscore_tags": [
+            "c"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "nutrition_score_beverage": 0,
+        "pnns_groups_2": "One-dish meals",
+        "complete": 0,
+        "new_additives_n": 5,
+        "teams": "chocolatine,la-robe-est-bleue",
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/324/227/226/0059/front_fr.82.100.jpg",
+        "ingredients_text_debug": "Radiatori cuits (51%) accompagnés d'une sauce à la carbonara.Semoule de blé dur, eau, lardon cuit fumé 20% (poitrine de porc, eau, sel, sirop de glucose, dextrose, arôme naturel, lactose, arôme de fumée, antioxydant :   - e316 - , conservateur :   - e250 - ), crème fraîche légère 15%, lait écrémé, œuf, amidon de riz, fromage à pâte pressée cuite, arôme naturel, sel, poivre, conservateurs :   - e202 - ,  - e262i - .\n Porc : Origine UE",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/324/227/226/0059/front_fr.82.400.jpg",
+        "_id": "3242272260059",
+        "countries_tags": [
+            "en:france"
+        ],
+        "serving_size": "400g",
+        "ingredients_hierarchy": [
+            "fr:Radiatori cuits",
+            "en:pork-breast",
+            "en:animal",
+            "en:meat",
+            "en:pork",
+            "en:pork-meat",
+            "en:breast",
+            "en:light-cream",
+            "en:dairy",
+            "en:cream",
+            "en:skimmed-milk",
+            "en:milk",
+            "en:water",
+            "fr:fromage-a-pate-pressee-cuite",
+            "en:cheese",
+            "en:tapioca-starch",
+            "en:starch",
+            "en:lactose",
+            "en:dextrose",
+            "en:glucose",
+            "en:glucose-syrup",
+            "en:preservative",
+            "en:e262i",
+            "en:e262",
+            "en:e250",
+            "en:antioxidant",
+            "en:salt",
+            "en:natural-flavouring",
+            "en:flavouring",
+            "en:smoke-flavouring",
+            "en:pepper",
+            "en:seed",
+            "en:durum-wheat-semolina",
+            "en:cereal",
+            "en:wheat",
+            "en:durum-wheat",
+            "en:semolina",
+            "en:egg",
+            "en:e202",
+            "en:e316"
+        ],
+        "additives_original_tags": [
+            "en:e202",
+            "en:e262i",
+            "en:e250",
+            "en:e316"
+        ],
+        "stores_tags": [
+            "carrefour",
+            "casino",
+            "magasins-u"
+        ],
+        "nutriscore_score": 3,
+        "compared_to_category": "en:pots",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "25",
+            "21-30"
+        ],
+        "pnns_groups_1_tags": [
+            "composite-foods",
+            "known"
+        ],
+        "additives_old_n": 3,
+        "packagings": [
+            {
+                "shape": "en:fork",
+                "material": "en:plastic"
+            },
+            {
+                "shape": "en:seal",
+                "material": "en:plastic"
+            },
+            {
+                "material": "en:cardboard"
+            },
+            {
+                "shape": "en:box",
+                "material": "en:plastic"
+            }
+        ],
+        "quantity": "400     g",
+        "data_quality_errors_tags": [],
+        "data_quality_info_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "brands_tags": [
+            "sodebo",
+            "pasta-xtrem"
+        ],
+        "ingredients_ids_debug": [
+            "radiatori-cuits",
+            "51-accompagnes-d-une-sauce-a-la-carbonara-semoule-de-ble-dur",
+            "eau",
+            "lardon-cuit-fume-20",
+            "poitrine-de-porc",
+            "eau",
+            "sel",
+            "sirop-de-glucose",
+            "dextrose",
+            "arome-naturel",
+            "lactose",
+            "arome-de-fumee",
+            "antioxydant",
+            "e316",
+            "conservateur",
+            "e250",
+            "creme-fraiche-legere-15",
+            "lait-ecreme",
+            "oeuf",
+            "amidon-de-riz",
+            "fromage-a-pate-pressee-cuite",
+            "arome-naturel",
+            "sel",
+            "poivre",
+            "conservateurs",
+            "e202",
+            "e262i",
+            "porc",
+            "origine-ue"
+        ],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [
+            "fr:Radiatori cuits",
+            "en:pork-breast",
+            "en:light-cream",
+            "en:skimmed-milk",
+            "en:water",
+            "fr:fromage-a-pate-pressee-cuite",
+            "en:tapioca-starch",
+            "en:lactose",
+            "en:dextrose",
+            "en:glucose-syrup",
+            "en:preservative",
+            "en:e262i",
+            "en:e250",
+            "en:antioxidant",
+            "en:salt",
+            "en:natural-flavouring",
+            "en:smoke-flavouring",
+            "en:pepper",
+            "en:pork",
+            "en:durum-wheat-semolina",
+            "en:water",
+            "en:egg",
+            "en:salt",
+            "en:e202",
+            "en:e316"
+        ],
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "traces": "",
+        "data_sources": "Producer - Sodebo, Producers, App - yuka, Apps",
+        "unknown_ingredients_n": 1,
+        "manufacturing_places_tags": [],
+        "emb_codes_orig": "FR 85.217.007 CE",
+        "checkers_tags": [],
+        "forest_footprint_data": {
+            "footprint_per_kg": 0.00508881578947369,
+            "ingredients": [
+                {
+                    "processing_factor": "1",
+                    "type": {
+                        "deforestation_risk": "0.68",
+                        "soy_feed_factor": "0.035",
+                        "name": "Oeufs Importés",
+                        "soy_yield": "0.3"
+                    },
+                    "conditions_tags": [],
+                    "tag_type": "ingredients",
+                    "percent": 6.41447368421053,
+                    "percent_estimate": 6.41447368421053,
+                    "matching_tag_id": "en:egg",
+                    "tag_id": "en:egg",
+                    "footprint_per_kg": 0.00508881578947369
+                }
+            ],
+            "grade": "a"
+        },
+        "max_imgid": "20",
+        "emb_codes": "FR 85.217.007 EC",
+        "editors": [
+            "tacite",
+            "phoenix"
+        ],
+        "nutriscore_score_opposite": -3,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/324/227/226/0059/front_fr.82.200.jpg",
+        "generic_name_fr": "Radiatori cuits 51% accompagnés d'une sauce à la carbonara",
+        "nutriments": {
+            "salt_serving": 3.08,
+            "proteins": 7,
+            "energy_100g": 761,
+            "carbohydrates_unit": "g",
+            "energy-kj_100g": 761,
+            "saturated-fat_serving": 14.4,
+            "sodium_100g": 0.308,
+            "sugars_100g": 1.2,
+            "proteins_serving": 28,
+            "sodium_value": 0.308,
+            "nova-group_serving": 4,
+            "salt_100g": 0.77,
+            "nutrition-score-fr_100g": 3,
+            "energy_unit": "kJ",
+            "salt_unit": "g",
+            "energy-kj_serving": 3040,
+            "carbohydrates_value": 20,
+            "proteins_unit": "g",
+            "sugars_unit": "g",
+            "sugars_serving": 4.8,
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt": 0.77,
+            "salt_value": 0.77,
+            "fiber_serving": 6.8,
+            "proteins_value": 7,
+            "saturated-fat_100g": 3.6,
+            "fiber_100g": 1.7,
+            "fat_serving": 30.4,
+            "nutrition-score-fr_unit": "g",
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "saturated-fat": 3.6,
+            "fat_value": 7.6,
+            "nova-group": 4,
+            "energy": 761,
+            "fiber": 1.7,
+            "saturated-fat_value": 3.6,
+            "nova-group_100g": 4,
+            "energy_serving": 3040,
+            "fat_100g": 7.6,
+            "saturated-fat_unit": "g",
+            "sodium_serving": 1.23,
+            "energy_value": 761,
+            "carbon-footprint-from-known-ingredients_serving": 700,
+            "energy-kj_value": 761,
+            "fiber_value": 1.7,
+            "fiber_unit": "g",
+            "energy-kj": 761,
+            "sugars_value": 1.2,
+            "proteins_100g": 7,
+            "nutrition-score-fr": 3,
+            "carbohydrates_serving": 80,
+            "sodium_unit": "g",
+            "carbohydrates_100g": 20,
+            "sodium": 0.308,
+            "nutrition-score-fr_value": 3,
+            "sugars": 1.2,
+            "carbohydrates": 20,
+            "fat": 7.6
+        },
+        "purchase_places_tags": [
+            "rennes",
+            "france",
+            "paris",
+            "maison-laffitte"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/324/227/226/0059/ingredients_fr.63.200.jpg",
+        "debug_tags": [
+            "43"
+        ],
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/324/227/226/0059/nutrition_fr.84.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/3245412470929.json
+++ b/testdata/product/3245412470929.json
@@ -1,0 +1,1600 @@
+{
+    "status": 1,
+    "code": "3245412470929",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {
+            "ciqual_food_name:fr": "Gratin de pâtes",
+            "ciqual_food_name:en": "Pasta au gratin -oven grilled-"
+        },
+        "traces_debug_tags": [],
+        "categories_tags": [
+            "en:meals",
+            "en:pasta-dishes",
+            "en:gratins",
+            "en:meals-with-fish",
+            "en:microwave-meals",
+            "en:meals-with-tuna",
+            "en:pasta-gratin",
+            "fr:macaroni-prepares"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [
+            "en:fish",
+            "en:gluten",
+            "en:milk"
+        ],
+        "origins_tags": [],
+        "product_name_fr": "Gratin de macaroni aux légumes et au thon A l'emmental râpé",
+        "generic_name": "",
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1450535827,
+        "additives_n": 2,
+        "emb_codes_20141016": "EMB 84007W,FR 84.007.020 CE",
+        "carbon_footprint_from_known_ingredients_debug": "en:chopped-tomatoes 23% x 0.5 = 11.5 g - en:tuna 15% x 4 = 60 g - en:pre-fried-onions 3.4% x 0.6 = 2.04 g - en:onion 3.2% x 0.6 = 1.92 g - en:grilled-aubergines 2% x 6.2 = 12.4 g - en:grilled-courgette 2% x 0.7 = 1.4 g - en:extra-virgin-olive-oil 2% x 2.6 = 5.2 g - en:garlic-paste 1.6% x 0.3 = 0.48 g - en:crushed-peeled-tomato 18% x 1.4 = 25.2 g - ",
+        "pnns_groups_2_tags": [
+            "one-dish-meals",
+            "known"
+        ],
+        "emb_codes_tags": [
+            "emb-84007w",
+            "fr-84-007-020-ec"
+        ],
+        "correctors_tags": [
+            "segundo",
+            "phoenix",
+            "moon-rabbit",
+            "roboto-app"
+        ],
+        "sortkey": 1582759842,
+        "categories_old": "Plats préparés, Plats à base de pâtes, Gratins, Plats préparés au poisson, Plats préparés à réchauffer au micro-ondes, Plats au thon, Gratins de pâtes, Macaroni préparés",
+        "categories_properties": {
+            "ciqual_food_code:en": "25122",
+            "agribalyse_food_code:en": "25122"
+        },
+        "completeness": 1,
+        "traces_from_user": "(fr) ",
+        "labels_tags": [
+            "en:no-artificial-flavors",
+            "en:green-dot",
+            "en:made-in-france",
+            "en:no-artificial-colors",
+            "en:no-colorings",
+            "en:no-flavour-enhancer"
+        ],
+        "nutrition_grades_tags": [
+            "b"
+        ],
+        "informers_tags": [
+            "phoenix",
+            "segundo",
+            "moon-rabbit"
+        ],
+        "lang": "fr",
+        "vitamins_tags": [],
+        "origins_lc": "fr",
+        "interface_version_modified": "20150316.jqm2",
+        "additives_tags": [
+            "en:e160c",
+            "en:e415"
+        ],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/324/541/247/0929/nutrition_fr.9.400.jpg",
+        "unknown_nutrients_tags": [],
+        "stores_debug_tags": [],
+        "nova_group_debug": " -- categories/en:meals : 3 -- additives/en:e160c : 4",
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "traces_tags": [],
+        "packaging_tags": [
+            "barquette",
+            "film",
+            "plastique",
+            "etui",
+            "carton"
+        ],
+        "nova_groups": "4",
+        "allergens_from_ingredients": "blé, thon, emmental, blé, thon",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/324/541/247/0929/front_fr.7.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-content-unknown",
+            "en:non-vegan",
+            "en:non-vegetarian"
+        ],
+        "nutrient_levels": {
+            "salt": "moderate",
+            "sugars": "low",
+            "saturated-fat": "low",
+            "fat": "moderate"
+        },
+        "nutriscore_data": {
+            "proteins": 7.2,
+            "negative_points": 6,
+            "sugars_points": 0,
+            "sodium_value": 396,
+            "score": 1,
+            "positive_points": 5,
+            "saturated_fat_value": 1.2,
+            "is_water": 0,
+            "proteins_points": 4,
+            "saturated_fat_points": 1,
+            "saturated_fat_ratio": 24.4897959183673,
+            "proteins_value": 7.2,
+            "saturated_fat_ratio_points": 3,
+            "fiber_points": 1,
+            "grade": "b",
+            "is_cheese": 0,
+            "energy": 557,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 39.2,
+            "fiber": 1.3,
+            "energy_points": 1,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 4,
+            "is_fat": 0,
+            "energy_value": 557,
+            "is_beverage": 0,
+            "fiber_value": 1.3,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 39.2,
+            "saturated_fat_ratio_value": 24.5,
+            "sugars_value": 2.7,
+            "saturated_fat": 1.2,
+            "sodium": 396,
+            "sugars": 2.7
+        },
+        "created_t": 1450535773,
+        "nova_group": 4,
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "b",
+        "nucleotides_tags": [],
+        "purchase_places_debug_tags": [],
+        "images": {
+            "nutrition": {
+                "rev": "9",
+                "white_magic": "false",
+                "geometry": "1145x645-154-160",
+                "normalize": "false",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 113,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 645,
+                        "w": 1145
+                    }
+                },
+                "imgid": "4"
+            },
+            "nutrition_fr": {
+                "rev": "9",
+                "white_magic": "false",
+                "geometry": "1145x645-154-160",
+                "normalize": "false",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 113,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 645,
+                        "w": 1145
+                    }
+                },
+                "imgid": "4"
+            },
+            "ingredients": {
+                "rev": "8",
+                "white_magic": "false",
+                "normalize": "false",
+                "sizes": {
+                    "400": {
+                        "h": 116,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 29,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 520,
+                        "w": 1790
+                    },
+                    "200": {
+                        "h": 58,
+                        "w": 200
+                    }
+                },
+                "geometry": "1790x520-59-292",
+                "imgid": "3"
+            },
+            "front_fr": {
+                "rev": "7",
+                "white_magic": "false",
+                "geometry": "1778x2444-12-185",
+                "normalize": "false",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 291
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 73
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 145
+                    },
+                    "full": {
+                        "h": 2444,
+                        "w": 1778
+                    }
+                },
+                "imgid": "1"
+            },
+            "3": {
+                "uploaded_t": "1450535806",
+                "uploader": "phoenix",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1125,
+                        "w": 2000
+                    }
+                }
+            },
+            "1": {
+                "uploaded_t": "1450535773",
+                "uploader": "phoenix",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 225
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 56
+                    },
+                    "full": {
+                        "h": 3555,
+                        "w": 2000
+                    }
+                }
+            },
+            "4": {
+                "uploaded_t": "1450535827",
+                "uploader": "phoenix",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1125,
+                        "w": 2000
+                    }
+                }
+            },
+            "front": {
+                "rev": "7",
+                "white_magic": "false",
+                "geometry": "1778x2444-12-185",
+                "normalize": "false",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 291
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 73
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 145
+                    },
+                    "full": {
+                        "h": 2444,
+                        "w": 1778
+                    }
+                },
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": "1450535788",
+                "uploader": "phoenix",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1125,
+                        "w": 2000
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "rev": "8",
+                "white_magic": "false",
+                "normalize": "false",
+                "sizes": {
+                    "400": {
+                        "h": 116,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 29,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 520,
+                        "w": 1790
+                    },
+                    "200": {
+                        "h": 58,
+                        "w": 200
+                    }
+                },
+                "geometry": "1790x520-59-292",
+                "imgid": "3"
+            }
+        },
+        "ingredients_text_with_allergens_fr": "Pâtes alimentaires de qualité supérieure cuites 32% (semoule de <span class=\"allergen\">blé</span> dur de qualité supérieure, eau), tomate concassées 23% (tomate pelée concassée 18%, purée de tomate), <span class=\"allergen\">thon</span> 15% (<span class=\"allergen\">thon</span>, eau, sel), oignon préfrit 3,4% (oignon, huile de tournesol), <span class=\"allergen\">emmental</span> râpé 3,3%, oignon 3,2%, double concentré de tomate, vin blanc, aubergine grillée 2%, courgette grillées 2%, huile d'olive vierge extra 2%, pulpe d'ail 1,6%, sucre, sel, huile de tournesol, extrait de paprika 0,8%, farine de <span class=\"allergen\">blé</span>, basilic 0,4%, gingembre, persil 0,4%, épaississant : gomme xanthane, herbes de Provence 0,04% (romarin, thym, basilic, marjolaine), poivre. Pourcentages exprimés sur l'ensemble du produit.",
+        "ingredients_n": 37,
+        "manufacturing_places_debug_tags": [],
+        "editors_tags": [
+            "moon-rabbit",
+            "segundo",
+            "roboto-app",
+            "phoenix"
+        ],
+        "allergens_tags": [
+            "en:fish",
+            "en:gluten",
+            "en:milk"
+        ],
+        "countries_lc": "fr",
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "completed_t": 1450542271,
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "emb_codes_debug_tags": [],
+        "code": "3245412470929",
+        "manufacturing_places": "France",
+        "codes_tags": [
+            "code-13",
+            "3245412470xxx",
+            "324541247xxxx",
+            "32454124xxxxx",
+            "3245412xxxxxx",
+            "324541xxxxxxx",
+            "32454xxxxxxxx",
+            "3245xxxxxxxxx",
+            "324xxxxxxxxxx",
+            "32xxxxxxxxxxx",
+            "3xxxxxxxxxxxx"
+        ],
+        "labels": "No artificial flavors, Green Dot, No artificial colors, No colorings, No flavour enhancer, en:made-in-france",
+        "last_modified_by": "roboto-app",
+        "last_edit_dates_tags": [
+            "2020-02-27",
+            "2020-02",
+            "2020"
+        ],
+        "entry_dates_tags": [
+            "2015-12-19",
+            "2015-12",
+            "2015"
+        ],
+        "creator": "phoenix",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "macaroni",
+            "rape",
+            "thon",
+            "green",
+            "flavor",
+            "plat",
+            "dot",
+            "micro-onde",
+            "aux",
+            "gratin",
+            "base",
+            "coloring",
+            "au",
+            "legume",
+            "de",
+            "artificial",
+            "enhancer",
+            "carrefour",
+            "color",
+            "poisson",
+            "prepare",
+            "flavour",
+            "rechauffer",
+            "no",
+            "emmental",
+            "made-in-france",
+            "et",
+            "pate"
+        ],
+        "amino_acids_tags": [],
+        "link": "",
+        "ingredients_debug": [
+            "Pâtes alimentaires de qualité supérieure cuites 32% ",
+            "(",
+            "(",
+            null,
+            null,
+            "semoule de _blé_ dur de qualité supérieure",
+            ",",
+            null,
+            null,
+            null,
+            " eau)",
+            ",",
+            null,
+            null,
+            null,
+            " tomate concassées 23% ",
+            "(",
+            "(",
+            null,
+            null,
+            "tomate pelée concassée 18%",
+            ",",
+            null,
+            null,
+            null,
+            " purée de tomate)",
+            ",",
+            null,
+            null,
+            null,
+            " _thon_ 15% ",
+            "(",
+            "(",
+            null,
+            null,
+            "thon",
+            ",",
+            null,
+            null,
+            null,
+            " eau",
+            ",",
+            null,
+            null,
+            null,
+            " sel)",
+            ",",
+            null,
+            null,
+            null,
+            " oignon préfrit 3",
+            ",",
+            null,
+            null,
+            null,
+            "4% ",
+            "(",
+            "(",
+            null,
+            null,
+            "oignon",
+            ",",
+            null,
+            null,
+            null,
+            " huile de tournesol)",
+            ",",
+            null,
+            null,
+            null,
+            " _emmental_ râpé 3",
+            ",",
+            null,
+            null,
+            null,
+            "3%",
+            ",",
+            null,
+            null,
+            null,
+            " oignon 3",
+            ",",
+            null,
+            null,
+            null,
+            "2%",
+            ",",
+            null,
+            null,
+            null,
+            " double concentré de tomate",
+            ",",
+            null,
+            null,
+            null,
+            " vin blanc",
+            ",",
+            null,
+            null,
+            null,
+            " aubergine grillée 2%",
+            ",",
+            null,
+            null,
+            null,
+            " courgette grillées 2%",
+            ",",
+            null,
+            null,
+            null,
+            " huile d'olive vierge extra 2%",
+            ",",
+            null,
+            null,
+            null,
+            " pulpe d'ail 1",
+            ",",
+            null,
+            null,
+            null,
+            "6%",
+            ",",
+            null,
+            null,
+            null,
+            " sucre",
+            ",",
+            null,
+            null,
+            null,
+            " sel",
+            ",",
+            null,
+            null,
+            null,
+            " huile de tournesol",
+            ",",
+            null,
+            null,
+            null,
+            " extrait de paprika 0",
+            ",",
+            null,
+            null,
+            null,
+            "8%",
+            ",",
+            null,
+            null,
+            null,
+            " farine de _blé_",
+            ",",
+            null,
+            null,
+            null,
+            " basilic 0",
+            ",",
+            null,
+            null,
+            null,
+            "4%",
+            ",",
+            null,
+            null,
+            null,
+            " gingembre",
+            ",",
+            null,
+            null,
+            null,
+            " persil 0",
+            ",",
+            null,
+            null,
+            null,
+            "4%",
+            ",",
+            null,
+            null,
+            null,
+            " épaississant ",
+            ":",
+            ":",
+            null,
+            null,
+            "  gomme xanthane",
+            ",",
+            null,
+            null,
+            null,
+            " herbes de Provence 0",
+            ",",
+            null,
+            null,
+            null,
+            "04% ",
+            "(",
+            "(",
+            null,
+            null,
+            "romarin",
+            ",",
+            null,
+            null,
+            null,
+            " thym",
+            ",",
+            null,
+            null,
+            null,
+            " basilic",
+            ",",
+            null,
+            null,
+            null,
+            " marjolaine)",
+            ",",
+            null,
+            null,
+            null,
+            " poivre",
+            ". ",
+            null,
+            null,
+            null,
+            "Pourcentages exprimés sur l'ensemble du produit."
+        ],
+        "languages_codes": {
+            "fr": 5
+        },
+        "labels_lc": "en",
+        "packaging": "Barquette,Film,Plastique,Etui,Carton",
+        "packaging_debug_tags": [],
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/324/541/247/0929/front_fr.7.400.jpg",
+        "last_image_dates_tags": [
+            "2015-12-19",
+            "2015-12",
+            "2015"
+        ],
+        "popularity_key": 0,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/324/541/247/0929/front_fr.7.200.jpg",
+        "expiration_date": "01/01/2016",
+        "data_quality_warnings_tags": [],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "generic_name_fr_debug_tags": [],
+        "debug_param_sorted_langs": [
+            "fr"
+        ],
+        "ecoscore_score": 59,
+        "photographers_tags": [
+            "phoenix"
+        ],
+        "product_name_fr_debug_tags": [],
+        "last_modified_t": 1582759842,
+        "ingredients": [
+            {
+                "percent_max": "32",
+                "id": "fr:Pâtes alimentaires de qualité supérieure cuites",
+                "text": "Pâtes alimentaires de qualité supérieure cuites",
+                "percent_estimate": "32",
+                "percent_min": "32",
+                "percent": "32"
+            },
+            {
+                "percent_min": "23",
+                "percent_estimate": "23",
+                "percent": "23",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "23",
+                "id": "en:chopped-tomatoes",
+                "text": "tomate concassées"
+            },
+            {
+                "percent_min": "15",
+                "percent_estimate": "15",
+                "percent": "15",
+                "vegan": "no",
+                "vegetarian": "no",
+                "percent_max": "15",
+                "id": "en:tuna",
+                "text": "_thon_"
+            },
+            {
+                "percent": "3.4",
+                "percent_min": "3.4",
+                "percent_estimate": "3.4",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "3.4",
+                "id": "en:pre-fried-onions",
+                "text": "oignon préfrit"
+            },
+            {
+                "percent_estimate": "3.3",
+                "percent_min": "3.3",
+                "percent": "3.3",
+                "vegan": "no",
+                "vegetarian": "maybe",
+                "percent_max": "3.3",
+                "id": "en:grated-emmental-cheese",
+                "text": "_emmental_ râpé"
+            },
+            {
+                "percent_estimate": "3.2",
+                "percent_min": "3.2",
+                "percent": "3.2",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "3.2",
+                "id": "en:onion",
+                "text": "oignon"
+            },
+            {
+                "percent_max": "3.2",
+                "id": "en:double-concentrated-tomato",
+                "text": "double concentré de tomate",
+                "percent_min": "2",
+                "percent_estimate": 2.6,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": "3.2",
+                "id": "en:white-wine",
+                "percent_estimate": 2.6,
+                "percent_min": "2",
+                "text": "vin blanc",
+                "vegan": "maybe",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_estimate": "2",
+                "percent_min": "2",
+                "percent": "2",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "2",
+                "id": "en:grilled-aubergines",
+                "text": "aubergine grillée"
+            },
+            {
+                "percent_estimate": "2",
+                "percent_min": "2",
+                "percent": "2",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "2",
+                "id": "en:grilled-courgette",
+                "text": "courgette grillées"
+            },
+            {
+                "percent": "2",
+                "percent_estimate": "2",
+                "percent_min": "2",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "from_palm_oil": "no",
+                "percent_max": "2",
+                "id": "en:extra-virgin-olive-oil",
+                "text": "huile d'olive vierge extra"
+            },
+            {
+                "percent": "1.6",
+                "percent_min": "1.6",
+                "percent_estimate": "1.6",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "1.6",
+                "id": "en:garlic-paste",
+                "text": "pulpe d'ail"
+            },
+            {
+                "percent_max": "1.6",
+                "id": "en:sugar",
+                "text": "sucre",
+                "percent_min": "0.8",
+                "percent_estimate": 1.2,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": "1.6",
+                "id": "en:salt",
+                "text": "sel",
+                "percent_estimate": 1.2,
+                "percent_min": "0.8",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": "0.8",
+                "percent_estimate": 1.2,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "from_palm_oil": "no",
+                "percent_max": "1.6",
+                "id": "en:sunflower-oil",
+                "text": "huile de tournesol"
+            },
+            {
+                "percent": "0.8",
+                "percent_min": "0.8",
+                "percent_estimate": "0.8",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "0.8",
+                "id": "en:e160c",
+                "text": "extrait de paprika"
+            },
+            {
+                "percent_max": "0.8",
+                "id": "en:wheat-flour",
+                "text": "farine de _blé_",
+                "percent_min": "0.4",
+                "percent_estimate": 0.6,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent": "0.4",
+                "percent_min": "0.4",
+                "percent_estimate": "0.4",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "0.4",
+                "id": "en:basil",
+                "text": "basilic"
+            },
+            {
+                "percent_max": "0.4",
+                "id": "en:ginger",
+                "text": "gingembre",
+                "percent_estimate": 0.4,
+                "percent_min": "0.4",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent": "0.4",
+                "percent_estimate": "0.4",
+                "percent_min": "0.4",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "0.4",
+                "id": "en:parsley",
+                "text": "persil"
+            },
+            {
+                "percent_max": "0.4",
+                "id": "en:thickener",
+                "text": "épaississant",
+                "percent_min": "0.04",
+                "percent_estimate": 0.22
+            },
+            {
+                "percent_estimate": "0.04",
+                "percent_min": "0.04",
+                "percent": "0.04",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "0.04",
+                "id": "en:herbes-de-provence",
+                "text": "herbes de Provence"
+            },
+            {
+                "percent_max": "0.04",
+                "id": "en:pepper",
+                "percent_min": 0,
+                "percent_estimate": 0.839999999999989,
+                "text": "poivre",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            }
+        ],
+        "nutriscore_grade": "b",
+        "stores": "Carrefour",
+        "countries": "France",
+        "cities_tags": [
+            "avignon-vaucluse-france",
+            "avignon-vaucluse-france"
+        ],
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "pasta-au-gratin-oven-grilled"
+        ],
+        "brands": "Carrefour",
+        "categories": "Plats préparés, Plats à base de pâtes, Gratins, Plats préparés au poisson, Plats préparés à réchauffer au micro-ondes, Plats au thon, Gratins de pâtes, Macaroni préparés",
+        "ingredients_text_with_allergens": "Pâtes alimentaires de qualité supérieure cuites 32% (semoule de <span class=\"allergen\">blé</span> dur de qualité supérieure, eau), tomate concassées 23% (tomate pelée concassée 18%, purée de tomate), <span class=\"allergen\">thon</span> 15% (<span class=\"allergen\">thon</span>, eau, sel), oignon préfrit 3,4% (oignon, huile de tournesol), <span class=\"allergen\">emmental</span> râpé 3,3%, oignon 3,2%, double concentré de tomate, vin blanc, aubergine grillée 2%, courgette grillées 2%, huile d'olive vierge extra 2%, pulpe d'ail 1,6%, sucre, sel, huile de tournesol, extrait de paprika 0,8%, farine de <span class=\"allergen\">blé</span>, basilic 0,4%, gingembre, persil 0,4%, épaississant : gomme xanthane, herbes de Provence 0,04% (romarin, thym, basilic, marjolaine), poivre. Pourcentages exprimés sur l'ensemble du produit.",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "nutrition_grades": "b",
+        "nutrient_levels_tags": [
+            "en:fat-in-moderate-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-low-quantity",
+            "en:salt-in-moderate-quantity"
+        ],
+        "known_ingredients_n": 57,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Pâtes alimentaires de qualité supérieure cuites 32% (semoule de _blé_ dur de qualité supérieure, eau), tomate concassées 23% (tomate pelée concassée 18%, purée de tomate), _thon_ 15% (thon, eau, sel), oignon préfrit 3,4% (oignon, huile de tournesol), _emmental_ râpé 3,3%, oignon 3,2%, double concentré de tomate, vin blanc, aubergine grillée 2%, courgette grillées 2%, huile d'olive vierge extra 2%, pulpe d'ail 1,6%, sucre, sel, huile de tournesol, extrait de paprika 0,8%, farine de _blé_, basilic 0,4%, gingembre, persil 0,4%, épaississant : gomme xanthane, herbes de Provence 0,04% (romarin, thym, basilic, marjolaine), poivre. Pourcentages exprimés sur l'ensemble du produit.",
+        "serving_size_debug_tags": [],
+        "product_name": "Gratin de macaroni aux légumes et au thon A l'emmental râpé",
+        "origins": "",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Pâtes alimentaires de qualité supérieure cuites 32% (semoule de _blé_ dur de qualité supérieure, eau), tomate concassées 23% (tomate pelée concassée 18%, purée de tomate), _thon_ 15% (thon, eau, sel), oignon préfrit 3,4% (oignon, huile de tournesol), _emmental_ râpé 3,3%, oignon 3,2%, double concentré de tomate, vin blanc, aubergine grillée 2%, courgette grillées 2%, huile d'olive vierge extra 2%, pulpe d'ail 1,6%, sucre, sel, huile de tournesol, extrait de paprika 0,8%, farine de _blé_, basilic 0,4%, gingembre, persil 0,4%, épaississant : gomme xanthane, herbes de Provence 0,04% (romarin, thym, basilic, marjolaine), poivre. Pourcentages exprimés sur l'ensemble du produit.",
+        "lang_debug_tags": [],
+        "categories_lc": "fr",
+        "serving_quantity": 300,
+        "allergens": "en:fish,en:gluten,en:milk",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/324/541/247/0929/ingredients_fr.8.100.jpg",
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "c",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_value": -5,
+                    "transportation_score_ch": 0,
+                    "value_ie": -5,
+                    "transportation_value_de": 0,
+                    "value_fr": -5,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "value_lu": -5,
+                    "transportation_score_nl": 0
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:tray",
+                            "material": "en:plastic",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": "0"
+                        },
+                        {
+                            "shape": "en:film",
+                            "material": "en:cardboard",
+                            "ecoscore_shape_ratio": "0.1",
+                            "ecoscore_material_score": "92"
+                        },
+                        {
+                            "shape": "en:sleeve",
+                            "material": "en:unknown",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "score": -100.8,
+                    "warning": "unspecified_material"
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "c",
+            "score": 59,
+            "grade_de": "c",
+            "missing_data_warning": 1,
+            "grade_nl": "c",
+            "score_be": 54,
+            "agribalyse": {
+                "co2_transportation": "0.21867549",
+                "ef_distribution": "0.0089786658",
+                "name_fr": "Gratin de pâtes",
+                "agribalyse_food_code": "25122",
+                "score": 69,
+                "ef_consumption": "0.0064417627",
+                "ef_agriculture": "0.23022299999999998",
+                "name_en": "Pasta au gratin (oven grilled)",
+                "ef_packaging": "0.016118590000000002",
+                "co2_total": "2.7189743",
+                "ef_processing": "0.077355142",
+                "is_beverage": 0,
+                "code": "25122",
+                "co2_processing": "0.57302961",
+                "dqr": "2.29",
+                "co2_consumption": "0.012726077",
+                "ef_total": "0.35609135000000003",
+                "co2_distribution": "0.030685111",
+                "co2_agriculture": "1.6712366",
+                "ef_transportation": "0.01695515",
+                "co2_packaging": "0.21221738"
+            },
+            "grade_it": "c",
+            "score_nl": 54,
+            "grade_ie": "c",
+            "missing": {
+                "packagings": 1,
+                "labels": 1,
+                "origins": 1
+            },
+            "score_ch": 54,
+            "score_de": 54,
+            "score_fr": 54,
+            "score_ie": 54,
+            "score_lu": 54,
+            "score_it": 54,
+            "score_es": 54,
+            "grade_ch": "c",
+            "grade_es": "c",
+            "grade": "c",
+            "grade_lu": "c"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/541/247/0929/nutrition_fr.9.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/541/247/0929/nutrition_fr.9.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/541/247/0929/nutrition_fr.9.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/541/247/0929/ingredients_fr.8.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/541/247/0929/ingredients_fr.8.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/541/247/0929/ingredients_fr.8.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/541/247/0929/front_fr.7.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/541/247/0929/front_fr.7.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/324/541/247/0929/front_fr.7.200.jpg"
+                }
+            }
+        },
+        "rev": 15,
+        "origins_old": "",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "roboto-app",
+        "additives_prev_original_tags": [
+            "en:e160c",
+            "en:e415"
+        ],
+        "ingredients_tags": [
+            "fr:pates-alimentaires-de-qualite-superieure-cuites",
+            "en:chopped-tomatoes",
+            "en:vegetable",
+            "en:tomato",
+            "en:tuna",
+            "en:fish",
+            "en:pre-fried-onions",
+            "en:root-vegetable",
+            "en:onion",
+            "en:grated-emmental-cheese",
+            "en:dairy",
+            "en:cheese",
+            "en:double-concentrated-tomato",
+            "en:tomato-concentrate",
+            "en:white-wine",
+            "en:alcohol",
+            "en:wine",
+            "en:grilled-aubergines",
+            "en:aubergine",
+            "en:grilled-courgette",
+            "en:courgette",
+            "en:extra-virgin-olive-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:vegetable-oil",
+            "en:olive-oil",
+            "en:virgin-olive-oil",
+            "en:garlic-paste",
+            "en:garlic",
+            "en:sugar",
+            "en:salt",
+            "en:sunflower-oil",
+            "en:e160c",
+            "en:wheat-flour",
+            "en:cereal",
+            "en:flour",
+            "en:wheat",
+            "en:cereal-flour",
+            "en:basil",
+            "en:herb",
+            "en:ginger",
+            "en:spice",
+            "en:parsley",
+            "en:thickener",
+            "en:herbes-de-provence",
+            "en:pepper",
+            "en:seed",
+            "en:superior-quality-durum-wheat-semolina",
+            "en:durum-wheat",
+            "en:semolina",
+            "en:durum-wheat-semolina",
+            "en:water",
+            "en:crushed-peeled-tomato",
+            "en:crushed-tomato",
+            "en:e415",
+            "en:rosemary",
+            "en:thyme",
+            "en:marjoram"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/324/541/247/0929/nutrition_fr.9.100.jpg",
+        "ingredients_from_palm_oil_tags": [],
+        "carbon_footprint_percent_of_known_ingredients": 70.2,
+        "nutrition_data_prepared_per_debug_tags": [],
+        "categories_hierarchy": [
+            "en:meals",
+            "en:pasta-dishes",
+            "en:gratins",
+            "en:meals-with-fish",
+            "en:microwave-meals",
+            "en:meals-with-tuna",
+            "en:pasta-gratin",
+            "fr:Macaroni préparés"
+        ],
+        "ecoscore_grade": "c",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ingredients_percent_analysis": 1,
+        "nutrition_data": "on",
+        "languages": {
+            "en:french": 5
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-25122",
+            "agribalyse-food-code-known",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-25122",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-25122"
+        ],
+        "purchase_places": "Rennes,France",
+        "id": "3245412470929",
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Composite foods",
+        "allergens_from_user": "(fr) en:fish,en:gluten,en:milk",
+        "nutrition_data_prepared": "",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/324/541/247/0929/ingredients_fr.8.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish"
+        ],
+        "additives_old_tags": [
+            "en:e160c",
+            "en:e1403",
+            "en:e415"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "ecoscore_tags": [
+            "c"
+        ],
+        "labels_hierarchy": [
+            "en:no-artificial-flavors",
+            "en:green-dot",
+            "en:made-in-france",
+            "en:no-artificial-colors",
+            "en:no-colorings",
+            "en:no-flavour-enhancer"
+        ],
+        "origins_hierarchy": [],
+        "complete": 1,
+        "ingredients_text_fr_debug_tags": [],
+        "pnns_groups_2": "One-dish meals",
+        "nutrition_score_beverage": 0,
+        "product_quantity": 300,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/324/541/247/0929/front_fr.7.100.jpg",
+        "ingredients_text_debug": "Pâtes alimentaires de qualité supérieure cuites 32% (semoule de _blé_ dur de qualité supérieure, eau), tomate concassées 23% (tomate pelée concassée 18%, purée de tomate), _thon_ 15% (thon, eau, sel), oignon préfrit 3,4% (oignon, huile de tournesol), _emmental_ râpé 3,3%, oignon 3,2%, double concentré de tomate, vin blanc, aubergine grillée 2%, courgette grillées 2%, huile d'olive vierge extra 2%, pulpe d'ail 1,6%, sucre, sel, huile de tournesol, extrait de paprika 0,8%, farine de _blé_, basilic 0,4%, gingembre, persil 0,4%, épaississant :  gomme xanthane, herbes de Provence 0,04% (romarin, thym, basilic, marjolaine), poivre. Pourcentages exprimés sur l'ensemble du produit.",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/324/541/247/0929/front_fr.7.400.jpg",
+        "_id": "3245412470929",
+        "countries_tags": [
+            "en:france"
+        ],
+        "ingredients_hierarchy": [
+            "fr:Pâtes alimentaires de qualité supérieure cuites",
+            "en:chopped-tomatoes",
+            "en:vegetable",
+            "en:tomato",
+            "en:tuna",
+            "en:fish",
+            "en:pre-fried-onions",
+            "en:root-vegetable",
+            "en:onion",
+            "en:grated-emmental-cheese",
+            "en:dairy",
+            "en:cheese",
+            "en:double-concentrated-tomato",
+            "en:tomato-concentrate",
+            "en:white-wine",
+            "en:alcohol",
+            "en:wine",
+            "en:grilled-aubergines",
+            "en:aubergine",
+            "en:grilled-courgette",
+            "en:courgette",
+            "en:extra-virgin-olive-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:vegetable-oil",
+            "en:olive-oil",
+            "en:virgin-olive-oil",
+            "en:garlic-paste",
+            "en:garlic",
+            "en:sugar",
+            "en:salt",
+            "en:sunflower-oil",
+            "en:e160c",
+            "en:wheat-flour",
+            "en:cereal",
+            "en:flour",
+            "en:wheat",
+            "en:cereal-flour",
+            "en:basil",
+            "en:herb",
+            "en:ginger",
+            "en:spice",
+            "en:parsley",
+            "en:thickener",
+            "en:herbes-de-provence",
+            "en:pepper",
+            "en:seed",
+            "en:superior-quality-durum-wheat-semolina",
+            "en:durum-wheat",
+            "en:semolina",
+            "en:durum-wheat-semolina",
+            "en:water",
+            "en:crushed-peeled-tomato",
+            "en:crushed-tomato",
+            "en:e415",
+            "en:rosemary",
+            "en:thyme",
+            "en:marjoram"
+        ],
+        "serving_size": "300 g - 1 Barquette",
+        "stores_tags": [
+            "carrefour"
+        ],
+        "additives_original_tags": [
+            "en:e160c",
+            "en:e415"
+        ],
+        "nutriscore_score": 1,
+        "compared_to_category": "en:pasta-gratin",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "expiration_date_debug_tags": [],
+        "ingredients_n_tags": [
+            "37",
+            "31-40"
+        ],
+        "pnns_groups_1_tags": [
+            "composite-foods",
+            "known"
+        ],
+        "additives_old_n": 3,
+        "packagings": [
+            {
+                "shape": "en:tray",
+                "material": "en:plastic"
+            },
+            {
+                "shape": "en:film",
+                "material": "en:cardboard"
+            },
+            {
+                "shape": "en:sleeve"
+            }
+        ],
+        "brands_tags": [
+            "carrefour"
+        ],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish"
+        ],
+        "data_quality_errors_tags": [],
+        "quantity": "300 g",
+        "link_debug_tags": [],
+        "ingredients_ids_debug": [
+            "pates-alimentaires-de-qualite-superieure-cuites-32",
+            "semoule-de-ble-dur-de-qualite-superieure",
+            "eau",
+            "tomate-concassees-23",
+            "tomate-pelee-concassee-18",
+            "puree-de-tomate",
+            "thon-15",
+            "thon",
+            "eau",
+            "sel",
+            "oignon-prefrit-3",
+            "4",
+            "oignon",
+            "huile-de-tournesol",
+            "emmental-rape-3",
+            "3",
+            "oignon-3",
+            "2",
+            "double-concentre-de-tomate",
+            "vin-blanc",
+            "aubergine-grillee-2",
+            "courgette-grillees-2",
+            "huile-d-olive-vierge-extra-2",
+            "pulpe-d-ail-1",
+            "6",
+            "sucre",
+            "sel",
+            "huile-de-tournesol",
+            "extrait-de-paprika-0",
+            "8",
+            "farine-de-ble",
+            "basilic-0",
+            "4",
+            "gingembre",
+            "persil-0",
+            "4",
+            "epaississant",
+            "gomme-xanthane",
+            "herbes-de-provence-0",
+            "04",
+            "romarin",
+            "thym",
+            "basilic",
+            "marjolaine",
+            "poivre",
+            "pourcentages-exprimes-sur-l-ensemble-du-produit"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 39.2,
+        "ingredients_original_tags": [
+            "fr:Pâtes alimentaires de qualité supérieure cuites",
+            "en:chopped-tomatoes",
+            "en:tuna",
+            "en:pre-fried-onions",
+            "en:grated-emmental-cheese",
+            "en:onion",
+            "en:double-concentrated-tomato",
+            "en:white-wine",
+            "en:grilled-aubergines",
+            "en:grilled-courgette",
+            "en:extra-virgin-olive-oil",
+            "en:garlic-paste",
+            "en:sugar",
+            "en:salt",
+            "en:sunflower-oil",
+            "en:e160c",
+            "en:wheat-flour",
+            "en:basil",
+            "en:ginger",
+            "en:parsley",
+            "en:thickener",
+            "en:herbes-de-provence",
+            "en:pepper",
+            "en:superior-quality-durum-wheat-semolina",
+            "en:water",
+            "en:crushed-peeled-tomato",
+            "en:crushed-tomato",
+            "en:tuna",
+            "en:water",
+            "en:salt",
+            "en:onion",
+            "en:sunflower-oil",
+            "en:e415",
+            "en:rosemary",
+            "en:thyme",
+            "en:basil",
+            "en:marjoram"
+        ],
+        "unknown_ingredients_n": 1,
+        "manufacturing_places_tags": [
+            "france"
+        ],
+        "quantity_debug_tags": [],
+        "emb_codes_orig": "EMB 84007W,FR 84.007.020 CE",
+        "checkers_tags": [],
+        "emb_codes": "EMB 84007W,FR 84.007.020 EC",
+        "max_imgid": "4",
+        "nutrition_data_per_debug_tags": [],
+        "allergens_debug_tags": [],
+        "nutriscore_score_opposite": -1,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/324/541/247/0929/front_fr.7.200.jpg",
+        "brands_debug_tags": [],
+        "generic_name_fr": "",
+        "nutriments": {
+            "proteins": 7.2,
+            "salt_serving": 2.97,
+            "energy_100g": 557,
+            "carbohydrates_unit": "g",
+            "saturated-fat_serving": 3.6,
+            "energy-kj_100g": 557,
+            "sodium_100g": 0.396,
+            "sugars_100g": 2.7,
+            "sodium_value": 0.396,
+            "proteins_serving": 21.6,
+            "salt_100g": 0.99,
+            "nova-group_serving": 4,
+            "nutrition-score-fr_100g": 1,
+            "energy_unit": "kJ",
+            "energy-kj_serving": 1670,
+            "salt_unit": "g",
+            "proteins_unit": "g",
+            "carbohydrates_value": 14,
+            "sugars_unit": "g",
+            "sugars_serving": 8.1,
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt_value": 0.99,
+            "salt": 0.99,
+            "fiber_serving": 3.9,
+            "proteins_value": 7.2,
+            "saturated-fat_100g": 1.2,
+            "fat_serving": 14.7,
+            "fiber_100g": 1.3,
+            "saturated-fat": 1.2,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 39.2,
+            "fat_value": 4.9,
+            "carbon-footprint-from-known-ingredients_100g": 120.14,
+            "energy": 557,
+            "nova-group": 4,
+            "fiber": 1.3,
+            "saturated-fat_value": 1.2,
+            "nova-group_100g": 4,
+            "fat_100g": 4.9,
+            "energy_serving": 1670,
+            "saturated-fat_unit": "g",
+            "energy_value": 557,
+            "sodium_serving": 1.19,
+            "carbon-footprint-from-known-ingredients_serving": 360,
+            "energy-kj_value": 557,
+            "fiber_value": 1.3,
+            "fiber_unit": "g",
+            "energy-kj": 557,
+            "carbon-footprint-from-known-ingredients_product": 360,
+            "proteins_100g": 7.2,
+            "sugars_value": 2.7,
+            "carbohydrates_serving": 42,
+            "sodium_unit": "g",
+            "nutrition-score-fr": 1,
+            "sodium": 0.396,
+            "carbohydrates_100g": 14,
+            "sugars": 2.7,
+            "carbohydrates": 14,
+            "fat": 4.9
+        },
+        "purchase_places_tags": [
+            "rennes",
+            "france"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/324/541/247/0929/ingredients_fr.8.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/324/541/247/0929/nutrition_fr.9.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/3502110000880.json
+++ b/testdata/product/3502110000880.json
@@ -1,0 +1,986 @@
+{
+    "status": 1,
+    "code": "3502110000880",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "popularity_tags": [
+            "bottom-25-percent-scans-2019",
+            "top-80-percent-scans-2019",
+            "top-85-percent-scans-2019",
+            "top-90-percent-scans-2019",
+            "top-100000-fr-scans-2019",
+            "top-country-fr-scans-2019",
+            "at-least-5-scans-2020",
+            "top-75-percent-scans-2020",
+            "top-80-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-100000-fr-scans-2020",
+            "top-country-fr-scans-2020",
+            "at-least-5-fr-scans-2020"
+        ],
+        "preparation_fr": "Servir très frais",
+        "conservation_conditions_fr": "À consommer de préférence avant: voir sur le bouchon ou le col de la bouteille.",
+        "customer_service": "PepsiCo France SNC, 420, rue d'Estienne d'Orves 92705 Colombes CEDEX",
+        "categories_tags": [
+            "en:beverages",
+            "en:carbonated-drinks",
+            "en:sodas",
+            "en:colas",
+            "en:sweetened-beverages"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "origins_tags": [],
+        "product_name_fr": "Pepsi 2 L",
+        "generic_name": "Boisson gazeuse rafraîchissante aux extraits végétaux.",
+        "teams_tags": [
+            "chocolatine",
+            "la-robe-est-bleue"
+        ],
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "preparation": "Servir très frais",
+        "last_image_t": 1376566383,
+        "emb_codes_20141016": "",
+        "additives_n": 2,
+        "pnns_groups_2_tags": [
+            "sweetened-beverages",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "tacite-mass-editor",
+            "teolemon",
+            "org-pepsico-france"
+        ],
+        "sortkey": 1609590656,
+        "categories_old": "Beverages, Carbonated drinks, Sodas, Sweetened beverages, en:colas",
+        "completeness": 0.7875,
+        "categories_properties": {
+            "ciqual_food_code:en": "18063",
+            "agribalyse_proxy_food_code:en": "18018"
+        },
+        "labels_tags": [
+            "en:green-dot"
+        ],
+        "traces_from_user": "(fr) ",
+        "informers_tags": [
+            "shaolan",
+            "tacite-mass-editor",
+            "org-pepsico-france"
+        ],
+        "nutrition_grades_tags": [
+            "e"
+        ],
+        "brands_imported": "Pepsi",
+        "vitamins_tags": [],
+        "lang": "fr",
+        "origins_lc": "fr",
+        "interface_version_modified": "20150316.jqm2",
+        "customer_service_fr_imported": "PepsiCo France SNC, 420, rue d'Estienne d'Orves 92705 Colombes CEDEX",
+        "unique_scans_n": 5,
+        "additives_tags": [
+            "en:e150d",
+            "en:e338"
+        ],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/350/211/000/0880/nutrition_fr.7.400.jpg",
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "nova_group_debug": " -- categories/en:sodas : 3 -- additives/en:e150d : 4",
+        "traces_tags": [],
+        "packaging_tags": [
+            "bouteille-plastique",
+            "pet",
+            "♳"
+        ],
+        "nova_groups": "4",
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/350/211/000/0880/front_fr.4.100.jpg",
+        "nutrient_levels": {
+            "salt": "low",
+            "sugars": "high",
+            "fat": "low",
+            "saturated-fat": "low"
+        },
+        "ingredients_analysis_tags": [
+            "en:palm-oil-free",
+            "en:vegan-status-unknown",
+            "en:vegetarian-status-unknown"
+        ],
+        "created_t": 1376566050,
+        "nutriscore_data": {
+            "proteins": 0,
+            "negative_points": 15,
+            "sugars_points": 8,
+            "score": 15,
+            "sodium_value": 4,
+            "positive_points": 0,
+            "is_water": 0,
+            "saturated_fat_value": 0,
+            "proteins_points": 0,
+            "saturated_fat_points": 0,
+            "saturated_fat_ratio": 0,
+            "proteins_value": 0,
+            "saturated_fat_ratio_points": 0,
+            "fiber_points": 0,
+            "grade": "e",
+            "is_cheese": 0,
+            "energy": 185,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 0,
+            "energy_points": 7,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 0,
+            "is_fat": 0,
+            "energy_value": 185,
+            "is_beverage": 1,
+            "fiber_value": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 0,
+            "sugars_value": 10.9,
+            "saturated_fat": 0,
+            "sodium": 4,
+            "sugars": 10.9
+        },
+        "nova_group": 4,
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "e",
+        "data_sources_imported": "Database - CodeOnline, Database - GDSN, Databases",
+        "scans_n": 7,
+        "nucleotides_tags": [],
+        "ingredients_text_with_allergens_fr": "Eau gazéifiée,sucre,colorant (caramel E150d),acidifiant (acide phosphorique),arômes (dont extraits végétaux et caféine)",
+        "images": {
+            "nutrition_fr": {
+                "rev": "7",
+                "white_magic": null,
+                "normalize": null,
+                "geometry": "1345x525-100-440",
+                "sizes": {
+                    "400": {
+                        "h": 156,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 39,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 78,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 525,
+                        "w": 1345
+                    }
+                },
+                "imgid": "3"
+            },
+            "nutrition": {
+                "rev": "7",
+                "white_magic": null,
+                "normalize": null,
+                "geometry": "1345x525-100-440",
+                "sizes": {
+                    "400": {
+                        "h": 156,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 39,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 78,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 525,
+                        "w": 1345
+                    }
+                },
+                "imgid": "3"
+            },
+            "ingredients": {
+                "rev": "6",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 104,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 26,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 355,
+                        "w": 1360
+                    },
+                    "200": {
+                        "h": 52,
+                        "w": 200
+                    }
+                },
+                "geometry": "1360x355-60-170",
+                "normalize": null,
+                "imgid": "3"
+            },
+            "front_fr": {
+                "rev": "4",
+                "white_magic": null,
+                "normalize": null,
+                "geometry": "0x0--4--5",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 129
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 32
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 64
+                    },
+                    "full": {
+                        "h": 2000,
+                        "w": 644
+                    }
+                },
+                "imgid": "2"
+            },
+            "3": {
+                "uploaded_t": 1376566383,
+                "uploader": "shaolan",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "1": {
+                "uploaded_t": 1376566050,
+                "uploader": "shaolan",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "front": {
+                "rev": "4",
+                "white_magic": null,
+                "normalize": null,
+                "geometry": "0x0--4--5",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 129
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 32
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 64
+                    },
+                    "full": {
+                        "h": 2000,
+                        "w": 644
+                    }
+                },
+                "imgid": "2"
+            },
+            "2": {
+                "uploaded_t": 1376566374,
+                "uploader": "shaolan",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 129
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 32
+                    },
+                    "full": {
+                        "h": 2000,
+                        "w": 644
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "rev": "6",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 104,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 26,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 355,
+                        "w": 1360
+                    },
+                    "200": {
+                        "h": 52,
+                        "w": 200
+                    }
+                },
+                "geometry": "1360x355-60-170",
+                "normalize": null,
+                "imgid": "3"
+            }
+        },
+        "owner_fields": {
+            "lc": 1619519181,
+            "proteins": 1619519181,
+            "serving_size": 1619519181,
+            "preparation_fr": 1619519181,
+            "energy-kcal": 1619519181,
+            "conservation_conditions_fr": 1619519181,
+            "lang": 1619519181,
+            "ingredients_text_fr": 1619519181,
+            "product_name_fr": 1619519181,
+            "nutrition_data_per": 1619519181,
+            "generic_name_fr": 1619519181,
+            "energy-kj": 1619519181,
+            "customer_service_fr": 1619519181,
+            "salt": 1619519181,
+            "labels": 1619519181,
+            "quantity": 1619519181,
+            "countries": 1619519181,
+            "nutrition_data_prepared_per": 1619519181,
+            "abbreviated_product_name": 1619519181,
+            "brands": 1619519181,
+            "obsolete": 1619519181,
+            "data_sources": 1619519181,
+            "sugars": 1619519181,
+            "carbohydrates": 1619519181,
+            "saturated-fat": 1619519181,
+            "fat": 1619519181
+        },
+        "ingredients_n": 9,
+        "editors_tags": [
+            "org-pepsico-france",
+            "shaolan",
+            "teolemon",
+            "tacite-mass-editor"
+        ],
+        "countries_lc": "fr",
+        "allergens_tags": [],
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "code": "3502110000880",
+        "customer_service_fr": "PepsiCo France SNC, 420, rue d'Estienne d'Orves 92705 Colombes CEDEX",
+        "codes_tags": [
+            "code-13",
+            "3502110000xxx",
+            "350211000xxxx",
+            "35021100xxxxx",
+            "3502110xxxxxx",
+            "350211xxxxxxx",
+            "35021xxxxxxxx",
+            "3502xxxxxxxxx",
+            "350xxxxxxxxxx",
+            "35xxxxxxxxxxx",
+            "3xxxxxxxxxxxx"
+        ],
+        "labels": "Point Vert",
+        "last_modified_by": "org-pepsico-france",
+        "last_edit_dates_tags": [
+            "2021-04-27",
+            "2021-04",
+            "2021"
+        ],
+        "entry_dates_tags": [
+            "2013-08-15",
+            "2013-08",
+            "2013"
+        ],
+        "creator": "shaolan",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "cola",
+            "point",
+            "rafraichissante",
+            "extrait",
+            "avec",
+            "pepsi",
+            "ajoute",
+            "sucre",
+            "aux",
+            "au",
+            "vert",
+            "vegetaux",
+            "soda",
+            "gazeuse",
+            "boisson"
+        ],
+        "amino_acids_tags": [],
+        "countries_imported": "France",
+        "ingredients_debug": [
+            "eau gazéifié",
+            ",",
+            null,
+            null,
+            null,
+            " sucre",
+            ",",
+            null,
+            null,
+            null,
+            " colorant ",
+            ":",
+            ":",
+            null,
+            null,
+            " ",
+            "(",
+            "(",
+            null,
+            null,
+            "e150d",
+            " - ",
+            " - ",
+            " - ",
+            null,
+            ")",
+            ",",
+            null,
+            null,
+            null,
+            " acidifiant ",
+            ":",
+            ":",
+            null,
+            null,
+            " ",
+            "(",
+            "(",
+            null,
+            null,
+            "acide phosphorique)",
+            ",",
+            null,
+            null,
+            null,
+            " arômes ",
+            "(",
+            "(",
+            null,
+            null,
+            "dont extraits naturels de végétaux et caféiné)."
+        ],
+        "labels_lc": "fr",
+        "languages_codes": {
+            "fr": 9
+        },
+        "packaging": "Bouteille Plastique,PET,♳",
+        "packaging_debug_tags": [],
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/350/211/000/0880/front_fr.4.400.jpg",
+        "last_image_dates_tags": [
+            "2013-08-15",
+            "2013-08",
+            "2013"
+        ],
+        "popularity_key": 5,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/350/211/000/0880/front_fr.4.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [
+            "en:nutrition-value-under-0-1-g-salt"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-not-applicable",
+            "en:ecoscore-not-computed"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "shaolan"
+        ],
+        "last_modified_t": 1619519383,
+        "ingredients": [
+            {
+                "percent_max": 100,
+                "id": "en:carbonated-water",
+                "percent_estimate": 60,
+                "percent_min": 20,
+                "text": "Eau gazéifiée",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 50,
+                "id": "en:sugar",
+                "percent_estimate": 20,
+                "text": "sucre",
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 33.3333333333333,
+                "id": "en:colour",
+                "text": "colorant",
+                "percent_min": 0,
+                "percent_estimate": 10
+            },
+            {
+                "percent_max": 25,
+                "id": "en:acid",
+                "percent_min": 0,
+                "text": "acidifiant",
+                "percent_estimate": 5
+            },
+            {
+                "percent_min": 0,
+                "percent_estimate": 5,
+                "vegan": "maybe",
+                "vegetarian": "maybe",
+                "percent_max": 20,
+                "id": "en:flavouring",
+                "text": "arômes"
+            }
+        ],
+        "nutriscore_grade": "e",
+        "stores": "",
+        "countries": "France",
+        "other_nutritional_substances_tags": [],
+        "cities_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "brands": "Pepsi",
+        "categories": "Boissons, Boissons gazeuses, Sodas, Sodas au cola, Boissons avec sucre ajouté",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-to-be-completed, en:origins-to-be-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:packaging-photo-to-be-selected, en:nutrition-photo-selected, en:ingredients-photo-selected, en:front-photo-selected, en:photos-uploaded",
+        "ingredients_text_with_allergens": "Eau gazéifiée,sucre,colorant (caramel E150d),acidifiant (acide phosphorique),arômes (dont extraits végétaux et caféine)",
+        "nutrition_grades": "e",
+        "nutrient_levels_tags": [
+            "en:fat-in-low-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-high-quantity",
+            "en:salt-in-low-quantity"
+        ],
+        "nutrition_data_prepared_per_imported": "100g",
+        "nutrition_data_per_imported": "100g",
+        "known_ingredients_n": 11,
+        "minerals_prev_tags": [],
+        "product_name_fr_imported": "Pepsi 2 L",
+        "product_name": "Pepsi 2 L",
+        "ingredients_text": "Eau gazéifiée,sucre,colorant (caramel E150d),acidifiant (acide phosphorique),arômes (dont extraits végétaux et caféine)",
+        "origins": "",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Eau gazéifiée,sucre,colorant (caramel E150d),acidifiant (acide phosphorique),arômes (dont extraits végétaux et caféine)",
+        "sources_fields": {
+            "org-gs1": {
+                "gln": "3502110007360",
+                "lastChangeDateTime": "2019-11-05T18:37:21+01:00",
+                "partyName": "PEPSICO FRANCE",
+                "isAllergenRelevantDataProvided": "true",
+                "gpcCategoryCode": "10000201"
+            }
+        },
+        "allergens": "",
+        "categories_lc": "fr",
+        "serving_size_imported": "250 ml (pour 250 ml**)",
+        "serving_quantity": "250",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/350/211/000/0880/ingredients_fr.6.100.jpg",
+        "obsolete_imported": "0",
+        "ecoscore_data": {
+            "status": "unknown",
+            "adjustments": {},
+            "ecoscore_not_applicable_for_category": "en:sodas"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/350/211/000/0880/nutrition_fr.7.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/350/211/000/0880/nutrition_fr.7.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/350/211/000/0880/nutrition_fr.7.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/350/211/000/0880/ingredients_fr.6.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/350/211/000/0880/ingredients_fr.6.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/350/211/000/0880/ingredients_fr.6.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/350/211/000/0880/front_fr.4.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/350/211/000/0880/front_fr.4.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/350/211/000/0880/front_fr.4.200.jpg"
+                }
+            }
+        },
+        "rev": 12,
+        "origins_old": "",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "org-pepsico-france",
+        "additives_prev_original_tags": [
+            "en:e150d",
+            "en:e338"
+        ],
+        "ingredients_tags": [
+            "en:carbonated-water",
+            "en:water",
+            "en:sugar",
+            "en:colour",
+            "en:acid",
+            "en:flavouring",
+            "en:e150d",
+            "en:e338",
+            "en:vegetable-extract",
+            "en:extract",
+            "en:caffeine"
+        ],
+        "data_sources_tags": [
+            "database-codeonline",
+            "database-gdsn",
+            "databases"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/350/211/000/0880/nutrition_fr.7.100.jpg",
+        "abbreviated_product_name_imported": "Pepsi reg pet 2l maxi format",
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:beverages",
+            "en:carbonated-drinks",
+            "en:sodas",
+            "en:colas",
+            "en:sweetened-beverages"
+        ],
+        "quantity_imported": "2000 ml",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "not-applicable",
+        "nutrition_data": "on",
+        "languages": {
+            "en:french": 9
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-18018",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-18063",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-18018"
+        ],
+        "purchase_places": "",
+        "id": "3502110000880",
+        "sources": [
+            {
+                "import_t": 1619519383,
+                "id": "org-pepsico-france",
+                "fields": [
+                    "product_name_fr",
+                    "abbreviated_product_name",
+                    "generic_name_fr",
+                    "quantity",
+                    "labels",
+                    "conservation_conditions_fr",
+                    "customer_service_fr",
+                    "preparation_fr",
+                    "data_sources",
+                    "serving_size",
+                    "ingredients_text_fr",
+                    "nutrients.energy-kcal_unit",
+                    "nutrients.energy-kcal_value",
+                    "nutrients.salt_value"
+                ],
+                "manufacturer": 1,
+                "url": null,
+                "name": "pepsico-france",
+                "images": []
+            }
+        ],
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Beverages",
+        "allergens_from_user": "(fr) ",
+        "labels_imported": "Point Vert",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/350/211/000/0880/ingredients_fr.6.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:nutrition-value-under-0-1-g-salt"
+        ],
+        "additives_old_tags": [
+            "en:e150d",
+            "en:e338"
+        ],
+        "origins_hierarchy": [],
+        "labels_hierarchy": [
+            "en:green-dot"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "ecoscore_tags": [
+            "not-applicable"
+        ],
+        "lc_imported": "fr",
+        "complete": 0,
+        "pnns_groups_2": "Sweetened beverages",
+        "nutrition_score_beverage": 1,
+        "new_additives_n": 2,
+        "product_quantity": "2000",
+        "teams": "chocolatine,la-robe-est-bleue",
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/350/211/000/0880/front_fr.4.100.jpg",
+        "ingredients_text_debug": "eau gazéifié, sucre, colorant : (e150d - ), acidifiant : (acide phosphorique), arômes (dont extraits naturels de végétaux et caféiné).",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/350/211/000/0880/front_fr.4.400.jpg",
+        "_id": "3502110000880",
+        "countries_tags": [
+            "en:france"
+        ],
+        "serving_size": "250 ml (pour 250 ml**)",
+        "ingredients_hierarchy": [
+            "en:carbonated-water",
+            "en:water",
+            "en:sugar",
+            "en:colour",
+            "en:acid",
+            "en:flavouring",
+            "en:e150d",
+            "en:e338",
+            "en:vegetable-extract",
+            "en:extract",
+            "en:caffeine"
+        ],
+        "additives_original_tags": [
+            "en:e150d",
+            "en:e338"
+        ],
+        "stores_tags": [],
+        "nutriscore_score": 15,
+        "compared_to_category": "en:sweetened-beverages",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "9",
+            "1-10"
+        ],
+        "pnns_groups_1_tags": [
+            "beverages",
+            "known"
+        ],
+        "additives_old_n": 2,
+        "packagings": [
+            {
+                "shape": "en:bottle",
+                "material": "en:pet-polyethylene-terephthalate"
+            }
+        ],
+        "preparation_fr_imported": "Servir très frais",
+        "quantity": "2000 ml",
+        "data_quality_errors_tags": [],
+        "data_quality_info_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "brands_tags": [
+            "pepsi"
+        ],
+        "owners_tags": "org-pepsico-france",
+        "ingredients_ids_debug": [
+            "eau-gazeifie",
+            "sucre",
+            "colorant",
+            "e150d",
+            "acidifiant",
+            "acide-phosphorique",
+            "aromes",
+            "dont-extraits-naturels-de-vegetaux-et-cafeine"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "ingredients_original_tags": [
+            "en:carbonated-water",
+            "en:sugar",
+            "en:colour",
+            "en:acid",
+            "en:flavouring",
+            "en:e150d",
+            "en:e338",
+            "en:vegetable-extract",
+            "en:caffeine"
+        ],
+        "data_sources": "Database - CodeOnline, Database - GDSN, Databases",
+        "unknown_ingredients_n": 0,
+        "ingredients_text_fr_imported": "Eau gazéifiée,sucre,colorant (caramel E150d),acidifiant (acide phosphorique),arômes (dont extraits végétaux et caféine)",
+        "conservation_conditions_fr_imported": "À consommer de préférence avant: voir sur le bouchon ou le col de la bouteille.",
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "lang_imported": "fr",
+        "max_imgid": "3",
+        "emb_codes": "",
+        "editors": [
+            "shaolan"
+        ],
+        "nutriscore_score_opposite": -15,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/350/211/000/0880/front_fr.4.200.jpg",
+        "generic_name_fr": "Boisson gazeuse rafraîchissante aux extraits végétaux.",
+        "nutriments": {
+            "proteins": 0,
+            "salt_serving": 0.025,
+            "energy_100g": 185,
+            "carbohydrates_unit": "g",
+            "saturated-fat_serving": 0,
+            "energy-kj_100g": 185,
+            "sodium_100g": 0.004,
+            "sugars_100g": 10.9,
+            "energy-kcal": 44,
+            "proteins_serving": 0,
+            "sodium_value": 0.004,
+            "nova-group_serving": 4,
+            "salt_100g": 0.01,
+            "nutrition-score-fr_100g": 15,
+            "energy_unit": "kJ",
+            "salt_unit": "g",
+            "energy-kj_serving": 462,
+            "proteins_unit": "g",
+            "carbohydrates_value": 10.9,
+            "sugars_unit": "g",
+            "sugars_serving": 27.2,
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt": 0.01,
+            "salt_value": 0.01,
+            "proteins_value": 0,
+            "saturated-fat_100g": 0,
+            "fat_serving": 0,
+            "energy-kcal_100g": 44,
+            "saturated-fat": 0,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "fat_value": 0,
+            "energy": 185,
+            "nova-group": 4,
+            "saturated-fat_value": 0,
+            "energy-kcal_value": 44,
+            "nova-group_100g": 4,
+            "energy_serving": 462,
+            "fat_100g": 0,
+            "saturated-fat_unit": "g",
+            "energy_value": 185,
+            "sodium_serving": 0.01,
+            "energy-kj_value": 185,
+            "energy-kj": 185,
+            "sugars_value": 10.9,
+            "proteins_100g": 0,
+            "sodium_unit": "g",
+            "nutrition-score-fr": 15,
+            "carbohydrates_serving": 27.2,
+            "carbohydrates_100g": 10.9,
+            "sodium": 0.004,
+            "sugars": 10.9,
+            "carbohydrates": 10.9,
+            "energy-kcal_serving": 110,
+            "fat": 0,
+            "energy-kcal_unit": "kcal"
+        },
+        "generic_name_fr_imported": "Boisson gazeuse rafraîchissante aux extraits végétaux.",
+        "purchase_places_tags": [],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/350/211/000/0880/ingredients_fr.6.200.jpg",
+        "abbreviated_product_name": "Pepsi reg pet 2l maxi format",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/350/211/000/0880/nutrition_fr.7.200.jpg",
+        "conservation_conditions": "À consommer de préférence avant: voir sur le bouchon ou le col de la bouteille.",
+        "owner": "org-pepsico-france"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/3551100749018.json
+++ b/testdata/product/3551100749018.json
@@ -1,0 +1,1263 @@
+{
+    "status": 1,
+    "code": "3551100749018",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "categories_tags": [
+            "en:snacks",
+            "en:sweet-snacks",
+            "en:biscuits-and-cakes",
+            "en:biscuits",
+            "en:filled-biscuits",
+            "en:gluten-free-biscuits"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [
+            "en:eggs",
+            "en:milk"
+        ],
+        "product_name_fr": "Biscuits fourrés abricot",
+        "generic_name": "Biscuits aux fruits fourrés abricot",
+        "origins_tags": [],
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1368223585,
+        "emb_codes_20141016": "",
+        "additives_n": 5,
+        "allergens_lc": "en",
+        "pnns_groups_2_tags": [
+            "biscuits-and-cakes",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "big-brother",
+            "manu1400",
+            "desan",
+            "musarana"
+        ],
+        "sortkey": 1587240099,
+        "categories_old": "Snacks, Snacks sucrés, Biscuits et gâteaux, Biscuits, Biscuits fourrés, Biscuits sans gluten",
+        "completeness": 0.9,
+        "categories_properties": {
+            "agribalyse_proxy_food_code:en": "24000"
+        },
+        "labels_tags": [
+            "en:gluten-free"
+        ],
+        "traces_from_user": "(en) ",
+        "informers_tags": [
+            "big-brother",
+            "manu1400",
+            "desan"
+        ],
+        "nutrition_grades_tags": [
+            "e"
+        ],
+        "vitamins_tags": [],
+        "lang": "fr",
+        "origins_lc": "fr",
+        "interface_version_modified": "20190830",
+        "unique_scans_n": 3,
+        "additives_tags": [
+            "en:e333",
+            "en:e412",
+            "en:e440",
+            "en:e500",
+            "en:e500ii",
+            "en:e503",
+            "en:e503ii"
+        ],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/355/110/074/9018/nutrition_fr.8.400.jpg",
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "nova_group_debug": " -- ingredients/en:starch : 3 -- additives/en:e412 : 4",
+        "traces_tags": [],
+        "nova_groups": "4",
+        "packaging_tags": [
+            "boite-carton"
+        ],
+        "allergens_from_ingredients": "œufs, lait",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/355/110/074/9018/front_fr.6.100.jpg",
+        "nutrient_levels": {
+            "salt": "low",
+            "sugars": "high",
+            "saturated-fat": "high",
+            "fat": "high"
+        },
+        "ingredients_analysis_tags": [
+            "en:palm-oil",
+            "en:non-vegan",
+            "en:vegetarian-status-unknown"
+        ],
+        "created_t": 1368223532,
+        "nutriscore_data": {
+            "proteins": 3.4,
+            "negative_points": 22,
+            "sugars_points": 6,
+            "sodium_value": 111.8,
+            "score": 19,
+            "positive_points": 3,
+            "is_water": 0,
+            "saturated_fat_value": 12.5,
+            "proteins_points": 2,
+            "saturated_fat_points": 10,
+            "saturated_fat_ratio": 45.6204379562044,
+            "proteins_value": 3.4,
+            "saturated_fat_ratio_points": 6,
+            "fiber_points": 3,
+            "grade": "e",
+            "is_cheese": 0,
+            "energy": 1972,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 3.5,
+            "energy_points": 5,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 1,
+            "is_fat": 0,
+            "energy_value": 1972,
+            "is_beverage": 0,
+            "fiber_value": 3.5,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 45.6,
+            "sugars_value": 27.3,
+            "saturated_fat": 12.5,
+            "sodium": 111.76,
+            "sugars": 27.3
+        },
+        "amino_acids_prev_tags": [],
+        "nova_group": 4,
+        "nutrition_grade_fr": "e",
+        "scans_n": 4,
+        "nucleotides_tags": [],
+        "ingredients_text_with_allergens_fr": "Farine de maïs, fourrage abricot 26% (fructose. abricot, agent gélifiant : pectine, épaississant : amidon de maïs transformé, correcteur d’acidité : citrate de calcium, huile de palme non hydrogénée, arôme), matière grasse butyrique, sucre, <span class=\"allergen\">œufs</span>, fécule de pomme de terre, sirop de glucose (maïs), sérum (<span class=\"allergen\">lait</span>), épaississant (gomme de guar), sel, poudre à lever (bicarbonate d'ammonium, bicarbonate de sodium); arôme.",
+        "images": {
+            "nutrition": {
+                "rev": "8",
+                "white_magic": null,
+                "geometry": "1830x1310-95-70",
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 286,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 72,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 143,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 1310,
+                        "w": 1830
+                    }
+                },
+                "imgid": "3"
+            },
+            "nutrition_fr": {
+                "rev": "8",
+                "white_magic": null,
+                "geometry": "1830x1310-95-70",
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 286,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 72,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 143,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 1310,
+                        "w": 1830
+                    }
+                },
+                "imgid": "3"
+            },
+            "ingredients": {
+                "rev": "7",
+                "white_magic": null,
+                "geometry": "1355x455-380-685",
+                "sizes": {
+                    "400": {
+                        "h": 134,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 34,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 67,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 455,
+                        "w": 1355
+                    }
+                },
+                "normalize": "checked",
+                "imgid": "2"
+            },
+            "front_fr": {
+                "rev": "6",
+                "white_magic": null,
+                "geometry": "0x0--5--4",
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 153,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 38,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 76,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 763,
+                        "w": 2000
+                    }
+                },
+                "imgid": "1"
+            },
+            "3": {
+                "uploaded_t": 1368223585,
+                "uploader": "big-brother",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "1": {
+                "uploaded_t": 1368223555,
+                "uploader": "big-brother",
+                "sizes": {
+                    "400": {
+                        "h": 153,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 38,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 763,
+                        "w": 2000
+                    }
+                }
+            },
+            "front": {
+                "rev": "6",
+                "white_magic": null,
+                "geometry": "0x0--5--4",
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 153,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 38,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 76,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 763,
+                        "w": 2000
+                    }
+                },
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": 1368223570,
+                "uploader": "big-brother",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "rev": "7",
+                "white_magic": null,
+                "geometry": "1355x455-380-685",
+                "sizes": {
+                    "400": {
+                        "h": 134,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 34,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 67,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 455,
+                        "w": 1355
+                    }
+                },
+                "normalize": "checked",
+                "imgid": "2"
+            }
+        },
+        "ingredients_n": 27,
+        "editors_tags": [
+            "musarana",
+            "manu1400",
+            "big-brother",
+            "desan"
+        ],
+        "allergens_tags": [
+            "en:eggs",
+            "en:milk"
+        ],
+        "traces_lc": "en",
+        "countries_lc": "en",
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "completed_t": 1368223988,
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "manufacturing_places": "",
+        "code": "3551100749018",
+        "codes_tags": [
+            "code-13",
+            "3551100749xxx",
+            "355110074xxxx",
+            "35511007xxxxx",
+            "3551100xxxxxx",
+            "355110xxxxxxx",
+            "35511xxxxxxxx",
+            "3551xxxxxxxxx",
+            "355xxxxxxxxxx",
+            "35xxxxxxxxxxx",
+            "3xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "musarana",
+        "labels": "Gluten-free",
+        "entry_dates_tags": [
+            "2013-05-11",
+            "2013-05",
+            "2013"
+        ],
+        "last_edit_dates_tags": [
+            "2020-04-18",
+            "2020-04",
+            "2020"
+        ],
+        "creator": "big-brother",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "gluten-free",
+            "and",
+            "filled",
+            "cake",
+            "fourre",
+            "sweet",
+            "aux",
+            "biscuit",
+            "snack",
+            "abricot",
+            "fruit",
+            "allergo"
+        ],
+        "link": "",
+        "ingredients_debug": [
+            "Farine de maïs",
+            ",",
+            null,
+            null,
+            null,
+            " fourrage abricot 26% ",
+            "(",
+            "(",
+            null,
+            null,
+            "fructose",
+            ". ",
+            null,
+            null,
+            null,
+            "abricot",
+            ",",
+            null,
+            null,
+            null,
+            " agent gélifiant ",
+            ":",
+            ":",
+            null,
+            null,
+            "  pectine",
+            ",",
+            null,
+            null,
+            null,
+            " épaississant ",
+            ":",
+            ":",
+            null,
+            null,
+            "  amidon de maïs transformé",
+            ",",
+            null,
+            null,
+            null,
+            " correcteur d’acidité ",
+            ":",
+            ":",
+            null,
+            null,
+            " citrate de calcium",
+            ",",
+            null,
+            null,
+            null,
+            " huile de palme non hydrogénée",
+            ",",
+            null,
+            null,
+            null,
+            " arôme)",
+            ",",
+            null,
+            null,
+            null,
+            " matière grasse butyrique",
+            ",",
+            null,
+            null,
+            null,
+            " sucre",
+            ",",
+            null,
+            null,
+            null,
+            " œufs",
+            ",",
+            null,
+            null,
+            null,
+            " fécule de pomme de terre",
+            ",",
+            null,
+            null,
+            null,
+            " sirop de glucose ",
+            "(",
+            "(",
+            null,
+            null,
+            "maïs)",
+            ",",
+            null,
+            null,
+            null,
+            " sérum ",
+            "(",
+            "(",
+            null,
+            null,
+            "lait)",
+            ",",
+            null,
+            null,
+            null,
+            " épaississant ",
+            ":",
+            ":",
+            null,
+            null,
+            " ",
+            "(",
+            "(",
+            null,
+            null,
+            "gomme de guar)",
+            ",",
+            null,
+            null,
+            null,
+            " sel",
+            ",",
+            null,
+            null,
+            null,
+            " poudre à lever ",
+            ":",
+            ":",
+            null,
+            null,
+            " ",
+            "(",
+            "(",
+            null,
+            null,
+            "bicarbonate d'ammonium",
+            ",",
+            null,
+            null,
+            null,
+            " bicarbonate de sodium)",
+            ";",
+            ";",
+            null,
+            null,
+            " arôme."
+        ],
+        "labels_lc": "en",
+        "languages_codes": {
+            "fr": 6
+        },
+        "packaging": "Boite carton",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/355/110/074/9018/front_fr.6.400.jpg",
+        "last_image_dates_tags": [
+            "2013-05-11",
+            "2013-05",
+            "2013"
+        ],
+        "popularity_key": 3,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/355/110/074/9018/front_fr.6.200.jpg",
+        "expiration_date": "30/07/2013",
+        "data_quality_warnings_tags": [],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "big-brother"
+        ],
+        "debug_param_sorted_langs": [
+            "fr"
+        ],
+        "ecoscore_score": 47,
+        "last_modified_t": 1587240099,
+        "ingredients": [
+            {
+                "percent_max": 74,
+                "id": "en:corn-flour",
+                "percent_estimate": 50,
+                "percent_min": "26",
+                "text": "Farine de maïs",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": "26",
+                "id": "fr:fourrage abricot",
+                "text": "fourrage abricot",
+                "percent_estimate": "26",
+                "percent_min": "26",
+                "percent": "26"
+            },
+            {
+                "percent_estimate": 12,
+                "percent_min": 0,
+                "vegan": "no",
+                "from_palm_oil": "no",
+                "vegetarian": "yes",
+                "percent_max": "26",
+                "id": "en:butterfat",
+                "text": "matière grasse butyrique"
+            },
+            {
+                "percent_max": 24,
+                "id": "en:sugar",
+                "percent_min": 0,
+                "percent_estimate": 6,
+                "text": "sucre",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 16,
+                "id": "en:egg",
+                "text": "œufs",
+                "percent_estimate": 3,
+                "percent_min": 0,
+                "vegan": "no",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 12,
+                "id": "en:potato-starch",
+                "text": "fécule de pomme de terre",
+                "percent_estimate": 1.5,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": 0,
+                "percent_estimate": 0.75,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": 9.6,
+                "id": "en:glucose-syrup",
+                "text": "sirop de glucose"
+            },
+            {
+                "percent_max": 8,
+                "id": "fr:sérum",
+                "percent_min": 0,
+                "percent_estimate": 0.375,
+                "text": "sérum"
+            },
+            {
+                "percent_max": 6.85714285714286,
+                "id": "en:thickener",
+                "percent_estimate": 0.1875,
+                "percent_min": 0,
+                "text": "épaississant"
+            },
+            {
+                "percent_max": 6,
+                "id": "en:salt",
+                "percent_estimate": 0.09375,
+                "percent_min": 0,
+                "text": "sel",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 5.33333333333333,
+                "id": "en:raising-agent",
+                "text": "poudre à lever",
+                "percent_min": 0,
+                "percent_estimate": 0.046875
+            },
+            {
+                "percent_max": 4.8,
+                "id": "en:flavouring",
+                "text": "arôme",
+                "percent_estimate": 0.046875,
+                "percent_min": 0,
+                "vegan": "maybe",
+                "vegetarian": "maybe"
+            }
+        ],
+        "nutriscore_grade": "e",
+        "stores": "Auchan",
+        "countries": "France",
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "cities_tags": [],
+        "brands": "Allergo",
+        "categories": "Snacks, Snacks sucrés, Biscuits et gâteaux, Biscuits, Biscuits fourrés, Biscuits sans gluten",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "ingredients_text_with_allergens": "Farine de maïs, fourrage abricot 26% (fructose. abricot, agent gélifiant : pectine, épaississant : amidon de maïs transformé, correcteur d’acidité : citrate de calcium, huile de palme non hydrogénée, arôme), matière grasse butyrique, sucre, <span class=\"allergen\">œufs</span>, fécule de pomme de terre, sirop de glucose (maïs), sérum (<span class=\"allergen\">lait</span>), épaississant (gomme de guar), sel, poudre à lever (bicarbonate d'ammonium, bicarbonate de sodium); arôme.",
+        "nutrition_grades": "e",
+        "nutrient_levels_tags": [
+            "en:fat-in-high-quantity",
+            "en:saturated-fat-in-high-quantity",
+            "en:sugars-in-high-quantity",
+            "en:salt-in-low-quantity"
+        ],
+        "known_ingredients_n": 39,
+        "minerals_prev_tags": [],
+        "other_nutritional_substances_prev_tags": [],
+        "product_name": "Biscuits fourrés abricot",
+        "ingredients_text": "Farine de maïs, fourrage abricot 26% (fructose. abricot, agent gélifiant : pectine, épaississant : amidon de maïs transformé, correcteur d’acidité : citrate de calcium, huile de palme non hydrogénée, arôme), matière grasse butyrique, sucre, œufs, fécule de pomme de terre, sirop de glucose (maïs), sérum (lait), épaississant (gomme de guar), sel, poudre à lever (bicarbonate d'ammonium, bicarbonate de sodium); arôme.",
+        "origins": "",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Farine de maïs, fourrage abricot 26% (fructose. abricot, agent gélifiant : pectine, épaississant : amidon de maïs transformé, correcteur d’acidité : citrate de calcium, huile de palme non hydrogénée, arôme), matière grasse butyrique, sucre, œufs, fécule de pomme de terre, sirop de glucose (maïs), sérum (lait), épaississant (gomme de guar), sel, poudre à lever (bicarbonate d'ammonium, bicarbonate de sodium); arôme.",
+        "categories_lc": "fr",
+        "allergens": "en:eggs,en:milk",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/355/110/074/9018/ingredients_fr.7.100.jpg",
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "c",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_ch": 0,
+                    "epi_value": -5,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 0,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "packaging": {
+                    "value": -1,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:box",
+                            "material": "en:cardboard",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": "92"
+                        }
+                    ],
+                    "score": 92
+                },
+                "threatened_species": {
+                    "ingredient": "en:palm-oil",
+                    "value": -10
+                }
+            },
+            "grade_fr": "c",
+            "score": 47,
+            "grade_de": "c",
+            "missing_data_warning": 1,
+            "grade_nl": "c",
+            "score_be": 42,
+            "agribalyse": {
+                "co2_transportation": "0.135384",
+                "ef_distribution": "0.0098990521",
+                "name_fr": "Biscuit sec, sans précision",
+                "agribalyse_food_code": "24000",
+                "score": 58,
+                "ef_consumption": "0",
+                "ef_agriculture": "0.36061353999999995",
+                "name_en": "Biscuit (cookie)",
+                "ef_packaging": "0.016471127999999998",
+                "co2_total": "4.4447267",
+                "ef_processing": "0.051325736000000004",
+                "is_beverage": 0,
+                "code": "24000",
+                "co2_processing": "0.32913764",
+                "dqr": "2.14",
+                "agribalyse_proxy_food_code": "24000",
+                "co2_consumption": "0",
+                "ef_total": "0.44895118",
+                "co2_distribution": "0.029120657",
+                "co2_agriculture": "3.8424243",
+                "ef_transportation": "0.010645482000000001",
+                "co2_packaging": "0.10869536"
+            },
+            "grade_it": "c",
+            "score_nl": 42,
+            "grade_ie": "c",
+            "missing": {
+                "labels": 1,
+                "origins": 1
+            },
+            "score_ch": 42,
+            "score_de": 42,
+            "score_fr": 42,
+            "score_ie": 42,
+            "score_lu": 42,
+            "score_it": 42,
+            "score_es": 42,
+            "grade_ch": "c",
+            "grade_es": "c",
+            "grade_lu": "c",
+            "grade": "c"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/355/110/074/9018/nutrition_fr.8.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/355/110/074/9018/nutrition_fr.8.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/355/110/074/9018/nutrition_fr.8.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/355/110/074/9018/ingredients_fr.7.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/355/110/074/9018/ingredients_fr.7.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/355/110/074/9018/ingredients_fr.7.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/355/110/074/9018/front_fr.6.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/355/110/074/9018/front_fr.6.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/355/110/074/9018/front_fr.6.200.jpg"
+                }
+            }
+        },
+        "rev": 13,
+        "origins_old": "",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 1,
+        "last_editor": "musarana",
+        "additives_prev_original_tags": [
+            "en:e440",
+            "en:e333",
+            "en:e412",
+            "en:e503",
+            "en:e500"
+        ],
+        "ingredients_tags": [
+            "en:corn-flour",
+            "en:cereal",
+            "en:flour",
+            "en:corn",
+            "fr:fourrage-abricot",
+            "en:butterfat",
+            "en:dairy",
+            "en:oil-and-fat",
+            "en:fat",
+            "en:milkfat",
+            "en:sugar",
+            "en:egg",
+            "en:potato-starch",
+            "en:starch",
+            "en:glucose-syrup",
+            "en:glucose",
+            "fr:serum",
+            "en:thickener",
+            "en:salt",
+            "en:raising-agent",
+            "en:flavouring",
+            "en:fructose",
+            "en:apricot",
+            "en:fruit",
+            "en:gelling-agent",
+            "en:acidity-regulator",
+            "en:non-hydrogenated-palm-oil",
+            "en:vegetable-oil-and-fat",
+            "en:palm-oil-and-fat",
+            "en:palm-oil",
+            "en:milk",
+            "en:e412",
+            "en:e503ii",
+            "en:e503",
+            "en:e500ii",
+            "en:e500",
+            "en:e440a",
+            "en:modified-corn-starch",
+            "en:corn-starch",
+            "en:modified-starch",
+            "en:e333"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/355/110/074/9018/nutrition_fr.8.100.jpg",
+        "ingredients_from_palm_oil_tags": [
+            "huile-de-palme"
+        ],
+        "categories_hierarchy": [
+            "en:snacks",
+            "en:sweet-snacks",
+            "en:biscuits-and-cakes",
+            "en:biscuits",
+            "en:filled-biscuits",
+            "en:gluten-free-biscuits"
+        ],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "c",
+        "nutrition_data": "on",
+        "ingredients_percent_analysis": 1,
+        "languages": {
+            "en:french": 6
+        },
+        "purchase_places": "Avrillé,France",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-24000",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-unknown",
+            "agribalyse-known",
+            "agribalyse-24000"
+        ],
+        "id": "3551100749018",
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Sugary snacks",
+        "allergens_from_user": "(en) en:eggs,en:milk",
+        "nutrition_data_prepared": "",
+        "additives_debug_tags": [
+            "en-e440i-added",
+            "en-e500ii-added"
+        ],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/355/110/074/9018/ingredients_fr.7.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "additives_old_tags": [
+            "en:e440",
+            "en:e1403",
+            "en:e333",
+            "en:e412",
+            "en:e503",
+            "en:e500"
+        ],
+        "origins_hierarchy": [],
+        "ecoscore_tags": [
+            "c"
+        ],
+        "ingredients_from_palm_oil_n": 1,
+        "labels_hierarchy": [
+            "en:gluten-free"
+        ],
+        "nutrition_score_beverage": 0,
+        "pnns_groups_2": "Biscuits and cakes",
+        "complete": 1,
+        "product_quantity": 175,
+        "new_additives_n": 5,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/355/110/074/9018/front_fr.6.100.jpg",
+        "ingredients_text_debug": "Farine de maïs, fourrage abricot 26% (fructose. abricot, agent gélifiant :  pectine, épaississant :  amidon de maïs transformé, correcteur d’acidité : citrate de calcium, huile de palme non hydrogénée, arôme), matière grasse butyrique, sucre, œufs, fécule de pomme de terre, sirop de glucose (maïs), sérum (lait), épaississant : (gomme de guar), sel, poudre à lever : (bicarbonate d'ammonium, bicarbonate de sodium); arôme.",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/355/110/074/9018/front_fr.6.400.jpg",
+        "_id": "3551100749018",
+        "countries_tags": [
+            "en:france"
+        ],
+        "ingredients_hierarchy": [
+            "en:corn-flour",
+            "en:cereal",
+            "en:flour",
+            "en:corn",
+            "fr:fourrage abricot",
+            "en:butterfat",
+            "en:dairy",
+            "en:oil-and-fat",
+            "en:fat",
+            "en:milkfat",
+            "en:sugar",
+            "en:egg",
+            "en:potato-starch",
+            "en:starch",
+            "en:glucose-syrup",
+            "en:glucose",
+            "fr:sérum",
+            "en:thickener",
+            "en:salt",
+            "en:raising-agent",
+            "en:flavouring",
+            "en:fructose",
+            "en:apricot",
+            "en:fruit",
+            "en:gelling-agent",
+            "en:acidity-regulator",
+            "en:non-hydrogenated-palm-oil",
+            "en:vegetable-oil-and-fat",
+            "en:palm-oil-and-fat",
+            "en:palm-oil",
+            "en:milk",
+            "en:e412",
+            "en:e503ii",
+            "en:e503",
+            "en:e500ii",
+            "en:e500",
+            "en:e440a",
+            "en:modified-corn-starch",
+            "en:corn-starch",
+            "en:modified-starch",
+            "en:e333"
+        ],
+        "additives_original_tags": [
+            "en:e440",
+            "en:e333",
+            "en:e412",
+            "en:e503ii",
+            "en:e500ii"
+        ],
+        "stores_tags": [
+            "auchan"
+        ],
+        "nutriscore_score": 19,
+        "compared_to_category": "en:gluten-free-biscuits",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "27",
+            "21-30"
+        ],
+        "pnns_groups_1_tags": [
+            "sugary-snacks",
+            "known"
+        ],
+        "additives_old_n": 6,
+        "packagings": [
+            {
+                "shape": "en:box",
+                "material": "en:cardboard"
+            }
+        ],
+        "quantity": "175 g",
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "brands_tags": [
+            "allergo"
+        ],
+        "data_quality_errors_tags": [],
+        "ingredients_ids_debug": [
+            "farine-de-mais",
+            "fourrage-abricot-26",
+            "fructose",
+            "abricot",
+            "agent-gelifiant",
+            "pectine",
+            "epaississant",
+            "amidon-de-mais-transforme",
+            "correcteur-d-acidite",
+            "citrate-de-calcium",
+            "huile-de-palme-non-hydrogenee",
+            "arome",
+            "matiere-grasse-butyrique",
+            "sucre",
+            "oeufs",
+            "fecule-de-pomme-de-terre",
+            "sirop-de-glucose",
+            "mais",
+            "serum",
+            "lait",
+            "epaississant",
+            "gomme-de-guar",
+            "sel",
+            "poudre-a-lever",
+            "bicarbonate-d-ammonium",
+            "bicarbonate-de-sodium",
+            "arome"
+        ],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [
+            "en:corn-flour",
+            "fr:fourrage abricot",
+            "en:butterfat",
+            "en:sugar",
+            "en:egg",
+            "en:potato-starch",
+            "en:glucose-syrup",
+            "fr:sérum",
+            "en:thickener",
+            "en:salt",
+            "en:raising-agent",
+            "en:flavouring",
+            "en:fructose",
+            "en:apricot",
+            "en:gelling-agent",
+            "en:thickener",
+            "en:acidity-regulator",
+            "en:non-hydrogenated-palm-oil",
+            "en:flavouring",
+            "en:corn",
+            "en:milk",
+            "en:e412",
+            "en:e503ii",
+            "en:e500ii",
+            "en:e440a",
+            "en:modified-corn-starch",
+            "en:e333"
+        ],
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "traces": "",
+        "unknown_ingredients_n": 2,
+        "manufacturing_places_tags": [],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "forest_footprint_data": {
+            "footprint_per_kg": 0.00238,
+            "ingredients": [
+                {
+                    "type": {
+                        "deforestation_risk": "0.68",
+                        "soy_feed_factor": "0.035",
+                        "name": "Oeufs Importés",
+                        "soy_yield": "0.3"
+                    },
+                    "processing_factor": "1",
+                    "percent_estimate": 3,
+                    "percent": 3,
+                    "tag_type": "ingredients",
+                    "conditions_tags": [],
+                    "matching_tag_id": "en:egg",
+                    "tag_id": "en:egg",
+                    "footprint_per_kg": 0.00238
+                }
+            ],
+            "grade": "a"
+        },
+        "max_imgid": "3",
+        "emb_codes": "",
+        "editors": [
+            "manu1400",
+            "big-brother"
+        ],
+        "nutriscore_score_opposite": -19,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/355/110/074/9018/front_fr.6.200.jpg",
+        "generic_name_fr": "Biscuits aux fruits fourrés abricot",
+        "nutriments": {
+            "proteins": 3.4,
+            "energy_100g": 1972,
+            "carbohydrates_unit": "g",
+            "energy-kj_100g": 1972,
+            "sodium_100g": 0.11176,
+            "sugars_100g": 27.3,
+            "sodium_value": 0.11176,
+            "nova-group_serving": 4,
+            "salt_100g": 0.2794,
+            "nutrition-score-fr_100g": 19,
+            "energy_unit": "kJ",
+            "salt_unit": "g",
+            "carbohydrates_value": 51.3,
+            "proteins_unit": "g",
+            "sugars_unit": "g",
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt_value": 0.2794,
+            "salt": 0.2794,
+            "proteins_value": 3.4,
+            "saturated-fat_100g": 12.5,
+            "fiber_100g": 3.5,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "saturated-fat": 12.5,
+            "fat_value": 27.4,
+            "energy": 1972,
+            "nova-group": 4,
+            "fiber": 3.5,
+            "saturated-fat_value": 12.5,
+            "nova-group_100g": 4,
+            "fat_100g": 27.4,
+            "saturated-fat_unit": "g",
+            "energy_value": 1972,
+            "energy-kj_value": 1972,
+            "fiber_value": 3.5,
+            "fiber_unit": "g",
+            "energy-kj": 1972,
+            "sugars_value": 27.3,
+            "proteins_100g": 3.4,
+            "sodium_unit": "g",
+            "nutrition-score-fr": 19,
+            "sodium": 0.11176,
+            "carbohydrates_100g": 51.3,
+            "sugars": 27.3,
+            "carbohydrates": 51.3,
+            "fat": 27.4
+        },
+        "purchase_places_tags": [
+            "avrille",
+            "france"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/355/110/074/9018/ingredients_fr.7.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/355/110/074/9018/nutrition_fr.8.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/3560070805259.json
+++ b/testdata/product/3560070805259.json
@@ -1,0 +1,1630 @@
+{
+    "status": 1,
+    "code": "3560070805259",
+    "product": {
+        "category_properties": {},
+        "customer_service": "Interdis - TSA 91431 - 91343 MASSY Cedex - France",
+        "traces_hierarchy": [],
+        "product_name_fr": "Pancakes",
+        "generic_name": "6 mini-crêpes épaisses sucrées.",
+        "languages_hierarchy": [
+            "en:dutch",
+            "en:french"
+        ],
+        "preparation": "Idéal pour le petit déjeuner ou le goûter. A déguster froid ou réchauffé 1 minute environ au grille-pain ou 10 secondes au micro-ondes à 750 watts. A consommer nature ou nappé par exemple de sirop d'érable ou de chocolat.",
+        "last_image_t": 1616949618,
+        "emb_codes_20141016": "FR 22.093.041 CE",
+        "carbon_footprint_from_known_ingredients_debug": "en:fresh-whole-milk 35% x 1.2 = 42 g - en:whole-fresh-eggs 12% x 2.6 = 31.2 g - ",
+        "producer_fr": "Fabriqué en France par EMB 22093 K pour Interdis",
+        "allergens_lc": "fr",
+        "customer_service_nl": "Carrefour Product info PB 2000 Evere 3 - 1140 BRUSSELS Tél: 0800/9.10.11",
+        "origin_fr": "Ces pancakes sont fabriqués en Bretagne avec du lait breton, de la farine de blé et des oeufs origine France.",
+        "completeness": 1.0875,
+        "categories_properties": {
+            "agribalyse_proxy_food_code:en": "23799"
+        },
+        "labels_tags": [
+            "en:green-dot",
+            "en:made-in-france",
+            "fr:eco-emballages"
+        ],
+        "traces_from_user": "(fr) ",
+        "downgraded": "non_recyclable_and_non_biodegradable_materials",
+        "vitamins_tags": [],
+        "origins_lc": "fr",
+        "customer_service_fr_imported": "Interdis - TSA 91431 - 91343 MASSY Cedex - France",
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/356/007/080/5259/nutrition_fr.12.400.jpg",
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "nova_groups": "4",
+        "packaging_tags": [
+            "frais",
+            "barquette",
+            "plastique-01"
+        ],
+        "allergens_from_ingredients": "Lait, blé, oeufs, blé",
+        "nutrient_levels": {
+            "sugars": "high",
+            "salt": "moderate",
+            "fat": "moderate",
+            "saturated-fat": "moderate"
+        },
+        "emb_codes_imported": "FR 22.093.041 EC, EMB 22093K",
+        "nutriscore_data": {
+            "proteins": 6.7,
+            "negative_points": 10,
+            "sugars_points": 3,
+            "sodium_value": 344,
+            "score": 4,
+            "positive_points": 6,
+            "saturated_fat_value": 1.8,
+            "is_water": 0,
+            "proteins_points": 4,
+            "saturated_fat_points": 1,
+            "saturated_fat_ratio": 19.5652173913043,
+            "proteins_value": 6.7,
+            "saturated_fat_ratio_points": 2,
+            "fiber_points": 2,
+            "grade": "c",
+            "is_cheese": 0,
+            "energy": 1193,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 2.4,
+            "energy_points": 3,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 3,
+            "is_fat": 0,
+            "energy_value": 1193,
+            "is_beverage": 0,
+            "fiber_value": 2.4,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 19.6,
+            "sugars_value": 18,
+            "saturated_fat": 1.8,
+            "sodium": 344,
+            "sugars": 18
+        },
+        "origin_nl": "Deze pancakes zijn geproduceerd in Bretagne met Bretonse melk, tarwebloem en eieren uit Frankrijk.",
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "c",
+        "data_sources_imported": "Producer - Carrefour, Producers",
+        "nucleotides_tags": [],
+        "images": {
+            "nutrition_fr": {
+                "rev": "12",
+                "white_magic": "false",
+                "ocr": 1,
+                "sizes": {
+                    "400": {
+                        "h": 30,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 7,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 15,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 168,
+                        "w": 2270
+                    }
+                },
+                "orientation": "0",
+                "geometry": "0x0-0-0",
+                "normalize": "false",
+                "imgid": "4"
+            },
+            "nutrition": {
+                "rev": "12",
+                "white_magic": "false",
+                "ocr": 1,
+                "sizes": {
+                    "400": {
+                        "h": 30,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 7,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 15,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 168,
+                        "w": 2270
+                    }
+                },
+                "orientation": "0",
+                "geometry": "0x0-0-0",
+                "normalize": "false",
+                "imgid": "4"
+            },
+            "11": {
+                "uploaded_t": 1607379037,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 90,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 22,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 461,
+                        "w": 2050
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": 1409334414,
+                "uploader": "jacob80",
+                "sizes": {
+                    "400": {
+                        "h": 51,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 13,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 276,
+                        "w": 2162
+                    }
+                }
+            },
+            "15": {
+                "uploaded_t": 1616949618,
+                "uploader": "org-carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 385,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 96,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2276,
+                        "w": 2365
+                    }
+                }
+            },
+            "6": {
+                "uploaded_t": 1548615383,
+                "uploader": "carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 399
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2365,
+                        "w": 2362
+                    }
+                }
+            },
+            "9": {
+                "uploaded_t": 1555324587,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 110,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 28,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 566,
+                        "w": 2050
+                    }
+                }
+            },
+            "front": {
+                "rev": "7",
+                "white_magic": null,
+                "geometry": "0x0--1--1",
+                "normalize": null,
+                "sizes": {
+                    "400": {
+                        "h": 257,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 64,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 292,
+                        "w": 455
+                    },
+                    "200": {
+                        "h": 128,
+                        "w": 200
+                    }
+                },
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": 1409334408,
+                "uploader": "jacob80",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 395
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 99
+                    },
+                    "full": {
+                        "h": 1455,
+                        "w": 1436
+                    }
+                }
+            },
+            "14": {
+                "uploaded_t": 1616949617,
+                "uploader": "org-carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 399
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2365,
+                        "w": 2362
+                    }
+                }
+            },
+            "front_fr": {
+                "y1": "-1",
+                "rev": "28",
+                "y2": "-1",
+                "x2": "-1",
+                "x1": "-1",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 244,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 61,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 122,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 1441,
+                        "w": 2365
+                    }
+                },
+                "coordinates_image_size": "400",
+                "angle": 0,
+                "normalize": "false",
+                "geometry": "0x0--5--5",
+                "imgid": "12"
+            },
+            "12": {
+                "uploaded_t": 1616949616,
+                "uploader": "org-carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 244,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 61,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1441,
+                        "w": 2365
+                    }
+                }
+            },
+            "ingredients": {
+                "rev": "8",
+                "white_magic": null,
+                "geometry": "0x0--5--5",
+                "sizes": {
+                    "400": {
+                        "h": 51,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 13,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 276,
+                        "w": 2162
+                    },
+                    "200": {
+                        "h": 26,
+                        "w": 200
+                    }
+                },
+                "normalize": null,
+                "imgid": "3"
+            },
+            "7": {
+                "uploaded_t": 1548615384,
+                "uploader": "carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 385,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 96,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2276,
+                        "w": 2365
+                    }
+                }
+            },
+            "10": {
+                "uploaded_t": 1607379035,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 257,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 64,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 257,
+                        "w": 400
+                    }
+                }
+            },
+            "13": {
+                "uploaded_t": 1616949617,
+                "uploader": "org-carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 325,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 81,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1919,
+                        "w": 2365
+                    }
+                }
+            },
+            "1": {
+                "uploaded_t": 1409334399,
+                "uploader": "jacob80",
+                "sizes": {
+                    "400": {
+                        "h": 257,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 64,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 292,
+                        "w": 455
+                    }
+                }
+            },
+            "4": {
+                "uploaded_t": 1409334420,
+                "uploader": "jacob80",
+                "sizes": {
+                    "400": {
+                        "h": 30,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 7,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 168,
+                        "w": 2270
+                    }
+                }
+            },
+            "5": {
+                "uploaded_t": 1548615383,
+                "uploader": "carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 325,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 81,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1919,
+                        "w": 2365
+                    }
+                }
+            },
+            "8": {
+                "uploaded_t": 1548615384,
+                "uploader": "carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 244,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 61,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1441,
+                        "w": 2365
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "y1": null,
+                "y2": null,
+                "rev": "22",
+                "x2": null,
+                "white_magic": "0",
+                "x1": null,
+                "ocr": 1,
+                "sizes": {
+                    "400": {
+                        "h": 110,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 28,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 55,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 566,
+                        "w": 2050
+                    }
+                },
+                "angle": null,
+                "orientation": "0",
+                "geometry": "0x0-0-0",
+                "normalize": "0",
+                "imgid": "9"
+            }
+        },
+        "countries_lc": "fr",
+        "update_key": "key_1618065313",
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "manufacturing_places": "Crêperie Jarnoux SA - Rue de la Saudraie la Poterie - ZI de Lanjouan,22400 Lamballe,Côtes-d'Armor,Bretagne,France",
+        "codes_tags": [
+            "code-13",
+            "3560070805xxx",
+            "356007080xxxx",
+            "35600708xxxxx",
+            "3560070xxxxxx",
+            "356007xxxxxxx",
+            "35600xxxxxxxx",
+            "3560xxxxxxxxx",
+            "356xxxxxxxxxx",
+            "35xxxxxxxxxxx",
+            "3xxxxxxxxxxxx"
+        ],
+        "customer_service_fr": "Interdis - TSA 91431 - 91343 MASSY Cedex - France",
+        "last_modified_by": "hungergames",
+        "entry_dates_tags": [
+            "2014-08-29",
+            "2014-08",
+            "2014"
+        ],
+        "conservation_conditions_nl_imported": "Te gebruiken tot: zie datum op de zijkant. Eens geopend, binnen 48 uur consumeren. Te bewaren tussen 0°C en +4°C. \nVerpakt onder beschermende atmosfeer.",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "_keywords": [
+            "breton",
+            "lamballe",
+            "mini-crepe",
+            "bretagne",
+            "galette",
+            "crepe",
+            "sa",
+            "frai",
+            "cotes-d",
+            "oeuf",
+            "eco-emballage",
+            "green",
+            "petit-dejeuner",
+            "aux",
+            "dot",
+            "lait",
+            "jarnoux",
+            "et",
+            "sucree",
+            "france",
+            "armor",
+            "entier",
+            "carrefour",
+            "creperie",
+            "pancake",
+            "22400",
+            "made-in-france",
+            "epaisse"
+        ],
+        "labels_lc": "en",
+        "packaging": "Frais,Barquette,Plastique 01",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/356/007/080/5259/front_fr.28.400.jpg",
+        "popularity_key": 19900000018,
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "jacob80",
+            "carrefour",
+            "kiliweb",
+            "org-carrefour"
+        ],
+        "last_modified_t": 1617205204,
+        "ingredients": [
+            {
+                "percent_estimate": "35",
+                "percent_min": "35",
+                "percent": "35",
+                "vegan": "no",
+                "origins": "en:brittany",
+                "vegetarian": "yes",
+                "percent_max": "35",
+                "id": "en:fresh-whole-milk",
+                "text": "_Lait_ frais entier"
+            },
+            {
+                "percent_max": "35",
+                "id": "en:wheat-flour",
+                "text": "farine de _blé_",
+                "percent_estimate": 23.5,
+                "percent_min": "12",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 29.3333333333333,
+                "id": "en:unrefined-cane-sugar",
+                "text": "sucre roux de canne",
+                "percent_estimate": 20.6666666666667,
+                "percent_min": "12",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent": "12",
+                "percent_estimate": "12",
+                "percent_min": "12",
+                "vegan": "no",
+                "origins": "en:france",
+                "vegetarian": "yes",
+                "percent_max": "12",
+                "id": "en:whole-fresh-eggs",
+                "text": "_oeufs_ entiers frais"
+            },
+            {
+                "percent_estimate": 4.41666666666667,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "from_palm_oil": "no",
+                "percent_max": "12",
+                "id": "en:colza-oil",
+                "text": "huile de colza"
+            },
+            {
+                "percent_max": 10.25,
+                "id": "en:raising-agent",
+                "percent_min": 0,
+                "percent_estimate": 2.20833333333334,
+                "text": "poudre à lever"
+            },
+            {
+                "percent_max": 8.2,
+                "id": "en:e500i",
+                "percent_min": 0,
+                "percent_estimate": 1.10416666666667,
+                "text": "carbonate de sodium",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 6.83333333333333,
+                "id": "en:wheat-starch",
+                "text": "amidon de _blé_",
+                "percent_estimate": 0.552083333333336,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 5.85714285714286,
+                "id": "en:salt",
+                "percent_min": 0,
+                "percent_estimate": 0.276041666666671,
+                "text": "sel",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": 0,
+                "percent_estimate": 0.276041666666671,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "from_palm_oil": "no",
+                "percent_max": 5.125,
+                "id": "en:sunflower-oil",
+                "text": "huile de tournesol"
+            }
+        ],
+        "other_nutritional_substances_tags": [],
+        "cities_tags": [
+            "lamballe-cotes-d-armor-france",
+            "lamballe-cotes-d-armor-france"
+        ],
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-completed, en:characteristics-completed, en:origins-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:packaging-photo-to-be-selected, en:nutrition-photo-selected, en:ingredients-photo-selected, en:front-photo-selected, en:photos-uploaded",
+        "ingredients_text_with_allergens": "<span class=\"allergen\">Lait</span> frais entier (origine Bretagne) 35%, farine de <span class=\"allergen\">blé</span>, sucre roux de canne, <span class=\"allergen\">oeufs</span> entiers frais (origine France) 12%, huile de colza, poudre à lever : diphosphate disodique, carbonate de sodium et amidon de <span class=\"allergen\">blé</span>, sel, huile de tournesol.",
+        "preparation_nl": "Ideaal als ontbijt of vieruurtje. Om koud te eten of verwarmd circa 1 minuut in de broodrooster of 10 seconden in de microgolfoven op 750 watts. Kan puur gegeten worden of eventueel overgoten met ahornsiroop of chocoladesaus.",
+        "nutrient_levels_tags": [
+            "en:fat-in-moderate-quantity",
+            "en:saturated-fat-in-moderate-quantity",
+            "en:sugars-in-high-quantity",
+            "en:salt-in-moderate-quantity"
+        ],
+        "nutrition_data_prepared_per_imported": "100g",
+        "minerals_prev_tags": [],
+        "product_name_fr_imported": "Pancakes",
+        "product_name": "Pancakes",
+        "ingredients_text": "_Lait_ frais entier (origine Bretagne) 35%, farine de _blé_, sucre roux de canne, _oeufs_ entiers frais (origine France) 12%, huile de colza, poudre à lever : diphosphate disodique, carbonate de sodium et amidon de _blé_, sel, huile de tournesol.",
+        "languages_tags": [
+            "en:dutch",
+            "en:french",
+            "en:2",
+            "en:multilingual"
+        ],
+        "allergens": "en:eggs,en:milk",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/356/007/080/5259/ingredients_fr.22.100.jpg",
+        "origin_nl_imported": "Deze pancakes zijn geproduceerd in Bretagne met Bretonse melk, tarwebloem en eieren uit Frankrijk.",
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/080/5259/nutrition_fr.12.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/080/5259/nutrition_fr.12.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/080/5259/nutrition_fr.12.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/080/5259/ingredients_fr.22.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/080/5259/ingredients_fr.22.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/080/5259/ingredients_fr.22.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/080/5259/front_fr.28.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/080/5259/front_fr.28.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/080/5259/front_fr.28.200.jpg"
+                }
+            }
+        },
+        "product_name_nl": "Pancakes",
+        "producer_nl_imported": "Geproduceerd in Frankrijk door EMB 22093 K voor Interdis.",
+        "data_sources_tags": [
+            "producer-carrefour",
+            "producers"
+        ],
+        "producer_nl": "Geproduceerd in Frankrijk door EMB 22093 K voor Interdis.",
+        "ingredients_from_palm_oil_tags": [],
+        "carbon_footprint_percent_of_known_ingredients": 47,
+        "categories_hierarchy": [
+            "en:breakfasts",
+            "en:fresh-foods",
+            "en:crepes-and-galettes",
+            "en:crepes",
+            "en:pancakes",
+            "fr:Pancakes aux oeufs frais"
+        ],
+        "quantity_imported": "132 g",
+        "producer_product_id_imported": "6267",
+        "languages": {
+            "en:french": 12,
+            "en:dutch": 9
+        },
+        "purchase_places": "Villers Bocage 80260,France",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-23799",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-unknown",
+            "agribalyse-known",
+            "agribalyse-23799"
+        ],
+        "no_nutrition_data": null,
+        "allergens_from_user": "(fr) en:eggs,en:milk",
+        "additives_debug_tags": [
+            "en-e450-added",
+            "en-e500i-added"
+        ],
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "ecoscore_tags": [
+            "b"
+        ],
+        "other_information_fr": "Refermable \nAux oeufs frais\nx 6\nPICTO OPERCULE REFERMABLE",
+        "lc_imported": "fr",
+        "nutrition_score_beverage": 0,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/356/007/080/5259/front_fr.28.100.jpg",
+        "ingredients_text_debug": "Lait frais entier (origine Bretagne) 35%, farine de blé, sucre roux de canne, oeufs entiers frais (origine France) 12%, huile de colza, poudre à lever :  diphosphate disodique, carbonate de sodium et amidon de blé, sel, huile de tournesol.",
+        "_id": "3560070805259",
+        "countries_tags": [
+            "en:france"
+        ],
+        "ingredients_hierarchy": [
+            "en:fresh-whole-milk",
+            "en:dairy",
+            "en:milk",
+            "en:whole-milk",
+            "en:fresh-milk",
+            "en:wheat-flour",
+            "en:cereal",
+            "en:flour",
+            "en:wheat",
+            "en:cereal-flour",
+            "en:unrefined-cane-sugar",
+            "en:sugar",
+            "en:cane-sugar",
+            "en:unrefined-sugar",
+            "en:whole-fresh-eggs",
+            "en:egg",
+            "en:whole-egg",
+            "en:colza-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:rapeseed-oil",
+            "en:raising-agent",
+            "en:e500i",
+            "en:e500",
+            "en:wheat-starch",
+            "en:starch",
+            "en:salt",
+            "en:sunflower-oil",
+            "en:vegetable-oil",
+            "en:e450i",
+            "en:e450"
+        ],
+        "additives_original_tags": [
+            "en:e450i",
+            "en:e500i"
+        ],
+        "compared_to_category": "en:pancakes",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-completed",
+            "en:origins-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "11",
+            "11-20"
+        ],
+        "pnns_groups_1_tags": [
+            "unknown",
+            "missing-association"
+        ],
+        "allergens_imported": "Œufs, Gluten, Lait",
+        "brands_tags": [
+            "carrefour"
+        ],
+        "data_quality_errors_tags": [],
+        "owners_tags": "org-carrefour",
+        "ingredients_ids_debug": [
+            "lait-frais-entier",
+            "origine-bretagne-35",
+            "farine-de-ble",
+            "sucre-roux-de-canne",
+            "oeufs-entiers-frais",
+            "origine-france-12",
+            "huile-de-colza",
+            "poudre-a-lever",
+            "diphosphate-disodique",
+            "carbonate-de-sodium-et-amidon-de-ble",
+            "sel",
+            "huile-de-tournesol"
+        ],
+        "ingredients_original_tags": [
+            "en:fresh-whole-milk",
+            "en:wheat-flour",
+            "en:unrefined-cane-sugar",
+            "en:whole-fresh-eggs",
+            "en:colza-oil",
+            "en:raising-agent",
+            "en:e500i",
+            "en:wheat-starch",
+            "en:salt",
+            "en:sunflower-oil",
+            "en:e450i"
+        ],
+        "data_sources": "Producer - Carrefour, Producers",
+        "product_name_nl_imported": "Pancakes",
+        "manufacturing_places_tags": [
+            "creperie-jarnoux-sa-rue-de-la-saudraie-la-poterie-zi-de-lanjouan",
+            "22400-lamballe",
+            "cotes-d-armor",
+            "bretagne",
+            "france"
+        ],
+        "ingredients_text_fr_imported": "_Lait_ frais entier (origine Bretagne) 35%, farine de _blé_, sucre roux de canne, _oeufs_ entiers frais (origine France) 12%, huile de colza, poudre à lever : diphosphate disodique, carbonate de sodium et amidon de _blé_, sel, huile de tournesol.",
+        "conservation_conditions_fr_imported": "A consommer jusqu'au : voir la date figurant sur le côté. A consommer dans les 48h après ouverture. A conserver entre 0°C et +4°C. Conditionné sous atmosphère protectrice.",
+        "emb_codes_orig": "FR 22.093.041 EC, EMB 22093K",
+        "forest_footprint_data": {
+            "footprint_per_kg": 0.0105,
+            "ingredients": [
+                {
+                    "processing_factor": "1",
+                    "type": {
+                        "deforestation_risk": "0.75",
+                        "soy_feed_factor": "0.035",
+                        "name": "Oeufs standards",
+                        "soy_yield": "0.3"
+                    },
+                    "conditions_tags": [
+                        [
+                            "origins",
+                            "en:france"
+                        ]
+                    ],
+                    "tag_type": "ingredients",
+                    "percent": "12",
+                    "matching_tag_id": "en:egg",
+                    "tag_id": "en:whole-fresh-eggs",
+                    "footprint_per_kg": 0.0105
+                }
+            ],
+            "grade": "a"
+        },
+        "max_imgid": "15",
+        "emb_codes": "FR 22.093.041 EC, EMB 22093K",
+        "producer_product_id": "6267",
+        "producer_fr_imported": "Fabriqué en France par EMB 22093 K pour Interdis",
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/356/007/080/5259/ingredients_fr.22.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/356/007/080/5259/nutrition_fr.12.200.jpg",
+        "owner": "org-carrefour",
+        "lc": "fr",
+        "conservation_conditions_nl": "Te gebruiken tot: zie datum op de zijkant. Eens geopend, binnen 48 uur consumeren. Te bewaren tussen 0°C en +4°C. \nVerpakt onder beschermende atmosfeer.",
+        "traces_from_ingredients": "",
+        "preparation_fr": "Idéal pour le petit déjeuner ou le goûter. A déguster froid ou réchauffé 1 minute environ au grille-pain ou 10 secondes au micro-ondes à 750 watts. A consommer nature ou nappé par exemple de sirop d'érable ou de chocolat.",
+        "popularity_tags": [
+            "bottom-25-percent-scans-2019",
+            "top-80-percent-scans-2019",
+            "top-85-percent-scans-2019",
+            "top-90-percent-scans-2019",
+            "top-country-fr-scans-2019",
+            "top-50000-be-scans-2019",
+            "top-100000-be-scans-2019",
+            "top-100000-scans-2020",
+            "at-least-5-scans-2020",
+            "top-75-percent-scans-2020",
+            "top-80-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-100000-fr-scans-2020",
+            "top-country-fr-scans-2020",
+            "at-least-5-fr-scans-2020"
+        ],
+        "conservation_conditions_fr": "A consommer jusqu'au : voir la date figurant sur le côté. A consommer dans les 48h après ouverture. A conserver entre 0°C et +4°C. Conditionné sous atmosphère protectrice.",
+        "categories_tags": [
+            "en:breakfasts",
+            "en:fresh-foods",
+            "en:crepes-and-galettes",
+            "en:crepes",
+            "en:pancakes",
+            "fr:pancakes-aux-oeufs-frais"
+        ],
+        "ingredients_text_with_allergens_nl": "Volle verse <span class=\"allergen\">melk</span> (uit Bretagne) 35%,<span class=\"allergen\"> _tarwe</span>_bloem, ruwe rietsuiker, verse hele <span class=\"allergen\">eieren</span> (uit Frankrijk) 12%, koolzaadolie, rijsmiddelen: dinatriumdifosfaat, natriumcarbonaat en <span class=\"allergen\">_tarwe</span>_zetmeel, zout, zonnebloemolie.",
+        "allergens_hierarchy": [
+            "en:eggs",
+            "en:gluten",
+            "en:milk"
+        ],
+        "categories_imported": "Pancakes",
+        "origins_tags": [
+            "en:france",
+            "en:brittany",
+            "fr:22400-lamballe",
+            "fr:creperie-jarnoux-sa",
+            "fr:cotes-d-armor",
+            "fr:lait-frais-entier-breton"
+        ],
+        "stores_imported": "Carrefour",
+        "additives_n": 2,
+        "pnns_groups_2_tags": [
+            "unknown",
+            "missing-association"
+        ],
+        "emb_codes_tags": [
+            "fr-22-093-041-ec",
+            "emb-22093k"
+        ],
+        "correctors_tags": [
+            "jacob80",
+            "sebleouf",
+            "carrefour",
+            "openfoodfacts-contributors",
+            "org-carrefour",
+            "hungergames"
+        ],
+        "origin_fr_imported": "Ces pancakes sont fabriqués en Bretagne avec du lait breton, de la farine de blé et des oeufs origine France.",
+        "sortkey": 1609504450,
+        "generic_name_nl_imported": "6 dikke, zoete minipannenkoeken.",
+        "categories_old": "Petit-déjeuners, Frais, Crêpes et galettes, Crêpes, Pancakes, Pancakes aux oeufs frais",
+        "nutrition_grades_tags": [
+            "c"
+        ],
+        "informers_tags": [
+            "jacob80",
+            "sebleouf",
+            "carrefour",
+            "openfoodfacts-contributors",
+            "selenee",
+            "org-carrefour"
+        ],
+        "brands_imported": "Carrefour",
+        "lang": "fr",
+        "interface_version_modified": "20150316.jqm2",
+        "additives_tags": [
+            "en:e450",
+            "en:e450i",
+            "en:e500",
+            "en:e500i"
+        ],
+        "unique_scans_n": 6,
+        "stores_debug_tags": [],
+        "unknown_nutrients_tags": [],
+        "nova_group_debug": " -- ingredients/en:salt : 3 -- additives/en:e450 : 4",
+        "traces_tags": [],
+        "generic_name_nl": "6 dikke, zoete minipannenkoeken.",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-free",
+            "en:non-vegan",
+            "en:vegetarian"
+        ],
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/356/007/080/5259/front_fr.28.100.jpg",
+        "created_t": 1409334382,
+        "nova_group": 4,
+        "scans_n": 7,
+        "ingredients_text_with_allergens_fr": "<span class=\"allergen\">Lait</span> frais entier (origine Bretagne) 35%, farine de <span class=\"allergen\">blé</span>, sucre roux de canne, <span class=\"allergen\">oeufs</span> entiers frais (origine France) 12%, huile de colza, poudre à lever : diphosphate disodique, carbonate de sodium et amidon de <span class=\"allergen\">blé</span>, sel, huile de tournesol.",
+        "owner_fields": {
+            "preparation_nl": 1616937029,
+            "lc": 1616937029,
+            "proteins": 1616937029,
+            "conservation_conditions_nl": 1616937029,
+            "energy-kcal": 1616937029,
+            "preparation_fr": 1616937029,
+            "conservation_conditions_fr": 1616937029,
+            "ingredients_text_fr": 1616937029,
+            "allergens": 1616937029,
+            "product_name_fr": 1616937029,
+            "product_name_nl": 1616937029,
+            "customer_service_fr": 1616937029,
+            "salt": 1616937029,
+            "quantity": 1616937029,
+            "producer_fr": 1616937029,
+            "nutrition_data_prepared_per": 1616937029,
+            "customer_service_nl": 1616937029,
+            "data_sources": 1616937029,
+            "origin_fr": 1616937029,
+            "producer_nl": 1616937029,
+            "saturated-fat": 1616937029,
+            "energy": 1616937029,
+            "fiber": 1616937029,
+            "emb_codes": 1616937029,
+            "lang": 1616937029,
+            "nutrition_data_per": 1616937029,
+            "producer_product_id": 1616937029,
+            "generic_name_fr": 1616937029,
+            "generic_name_nl": 1616937029,
+            "energy-kj": 1616937029,
+            "ingredients_text_nl": 1616937029,
+            "stores": 1616937029,
+            "countries": 1616937029,
+            "brands": 1616937029,
+            "obsolete": 1616937029,
+            "categories": 1616937029,
+            "origin_nl": 1616937029,
+            "sugars": 1616937029,
+            "carbohydrates": 1616937029,
+            "fat": 1616937029
+        },
+        "ingredients_n": 11,
+        "origin": "Ces pancakes sont fabriqués en Bretagne avec du lait breton, de la farine de blé et des oeufs origine France.",
+        "editors_tags": [
+            "carrefour",
+            "openfoodfacts-contributors",
+            "kiliweb",
+            "jacob80",
+            "sebleouf",
+            "hungergames",
+            "org-carrefour",
+            "selenee"
+        ],
+        "allergens_tags": [
+            "en:eggs",
+            "en:gluten",
+            "en:milk"
+        ],
+        "nucleotides_prev_tags": [],
+        "emb_codes_debug_tags": [],
+        "code": "3560070805259",
+        "labels": "Green Dot, fr:Eco-Emballages, en:made-in-france",
+        "last_edit_dates_tags": [
+            "2021-03-31",
+            "2021-03",
+            "2021"
+        ],
+        "creator": "jacob80",
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "countries_imported": "France",
+        "link": "http://www.creperie-jarnoux.com/",
+        "ingredients_debug": [
+            "Lait frais entier ",
+            "(",
+            "(",
+            null,
+            null,
+            "origine Bretagne) 35%",
+            ",",
+            null,
+            null,
+            null,
+            " farine de blé",
+            ",",
+            null,
+            null,
+            null,
+            " sucre roux de canne",
+            ",",
+            null,
+            null,
+            null,
+            " oeufs entiers frais ",
+            "(",
+            "(",
+            null,
+            null,
+            "origine France) 12%",
+            ",",
+            null,
+            null,
+            null,
+            " huile de colza",
+            ",",
+            null,
+            null,
+            null,
+            " poudre à lever ",
+            ":",
+            ":",
+            null,
+            null,
+            "  diphosphate disodique",
+            ",",
+            null,
+            null,
+            null,
+            " carbonate de sodium et amidon de blé",
+            ",",
+            null,
+            null,
+            null,
+            " sel",
+            ",",
+            null,
+            null,
+            null,
+            " huile de tournesol."
+        ],
+        "languages_codes": {
+            "fr": 12,
+            "nl": 9
+        },
+        "last_image_dates_tags": [
+            "2021-03-28",
+            "2021-03",
+            "2021"
+        ],
+        "expiration_date": "23/08/2014",
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/356/007/080/5259/front_fr.28.200.jpg",
+        "data_quality_warnings_tags": [
+            "en:ecoscore-production-system-no-label"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed",
+            "en:forest-footprint-computed",
+            "en:forest-footprint-a"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-completed",
+            "en:origins-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "ecoscore_score": 76,
+        "other_information_nl": "Hersluitbaar\nMet verse eieren\nx 6\nPICTO OPERCULE REFERMABLE",
+        "nutriscore_grade": "c",
+        "countries": "France",
+        "stores": "Carrefour Market,Banque alimentaire, Carrefour",
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "brands": "Carrefour",
+        "categories": "Petit-déjeuners, Frais, Crêpes et galettes, Crêpes, Pancakes, Pancakes aux oeufs frais",
+        "nutrition_grades": "c",
+        "known_ingredients_n": 31,
+        "nutrition_data_per_imported": "100g",
+        "origins": "Crêperie Jarnoux SA,22400 Lamballe,Côtes-d'Armor,Bretagne,France,Lait frais entier breton",
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "_Lait_ frais entier (origine Bretagne) 35%, farine de _blé_, sucre roux de canne, _oeufs_ entiers frais (origine France) 12%, huile de colza, poudre à lever : diphosphate disodique, carbonate de sodium et amidon de _blé_, sel, huile de tournesol.",
+        "serving_quantity": "22",
+        "customer_service_nl_imported": "Carrefour Product info PB 2000 Evere 3 - 1140 BRUSSELS Tél: 0800/9.10.11",
+        "categories_lc": "fr",
+        "obsolete_imported": "0",
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "b",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:tray",
+                            "material": "en:plastic",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": "0"
+                        }
+                    ],
+                    "score": 0
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_es": 4,
+                    "transportation_value_fr": 10,
+                    "transportation_value_be": 8,
+                    "transportation_value_ch": 7,
+                    "transportation_score_be": 55.25,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:france",
+                            "percent": 65
+                        },
+                        {
+                            "origin": "en:unknown",
+                            "percent": 35
+                        }
+                    ],
+                    "epi_score": 60.45,
+                    "epi_value": 1,
+                    "transportation_score_ch": 44.85,
+                    "transportation_score_ie": 30.55,
+                    "value_nl": 9,
+                    "value_ie": 6,
+                    "transportation_value_de": 6,
+                    "value_fr": 11,
+                    "value_be": 9,
+                    "value_es": 5,
+                    "transportation_value_ie": 5,
+                    "transportation_score_it": 30.55,
+                    "transportation_score_de": 39.65,
+                    "origins_from_origins_field": [
+                        "en:france"
+                    ],
+                    "transportation_score_fr": 65,
+                    "transportation_value_nl": 8,
+                    "transportation_value_lu": 8,
+                    "value_ch": 8,
+                    "transportation_score_es": 24.05,
+                    "transportation_value_it": 5,
+                    "value_de": 7,
+                    "value_it": 6,
+                    "transportation_score_lu": 53.3,
+                    "transportation_score_nl": 50.05,
+                    "value_lu": 9
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "b",
+            "score": 76,
+            "grade_de": "b",
+            "missing_data_warning": 1,
+            "grade_nl": "b",
+            "score_be": 85,
+            "agribalyse": {
+                "co2_transportation": "0.12289334",
+                "ef_distribution": "0.0098990521",
+                "name_fr": "Crêpe, nature, préemballée, rayon frais",
+                "score": 86,
+                "ef_agriculture": "0.15860705",
+                "ef_consumption": "0",
+                "name_en": "Crepe, plain, prepacked, refrigerated",
+                "co2_total": "1.7398075",
+                "ef_packaging": "0.021564136",
+                "ef_processing": "0.035113544000000003",
+                "is_beverage": 0,
+                "co2_processing": "0.15494358",
+                "dqr": "2.27",
+                "agribalyse_proxy_food_code": "23799",
+                "code": "23799",
+                "co2_consumption": "0",
+                "co2_distribution": "0.029120657",
+                "ef_total": "0.23473903",
+                "co2_agriculture": "1.14697",
+                "ef_transportation": "0.0095553106",
+                "co2_packaging": "0.28587888"
+            },
+            "grade_it": "b",
+            "score_nl": 85,
+            "grade_ie": "b",
+            "missing": {
+                "labels": 1
+            },
+            "score_ch": 84,
+            "score_de": 83,
+            "score_fr": 87,
+            "score_ie": 82,
+            "score_lu": 85,
+            "score_it": 82,
+            "score_es": 81,
+            "grade_ch": "b",
+            "grade_es": "b",
+            "grade": "b",
+            "grade_lu": "b"
+        },
+        "origins_old": "Crêperie Jarnoux SA,22400 Lamballe,Côtes-d'Armor,Bretagne,France,Lait frais entier breton",
+        "rev": 32,
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "hungergames",
+        "additives_prev_original_tags": [
+            "en:e450i",
+            "en:e500"
+        ],
+        "ingredients_tags": [
+            "en:fresh-whole-milk",
+            "en:dairy",
+            "en:milk",
+            "en:whole-milk",
+            "en:fresh-milk",
+            "en:wheat-flour",
+            "en:cereal",
+            "en:flour",
+            "en:wheat",
+            "en:cereal-flour",
+            "en:unrefined-cane-sugar",
+            "en:sugar",
+            "en:cane-sugar",
+            "en:unrefined-sugar",
+            "en:whole-fresh-eggs",
+            "en:egg",
+            "en:whole-egg",
+            "en:colza-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:rapeseed-oil",
+            "en:raising-agent",
+            "en:e500i",
+            "en:e500",
+            "en:wheat-starch",
+            "en:starch",
+            "en:salt",
+            "en:sunflower-oil",
+            "en:vegetable-oil",
+            "en:e450i",
+            "en:e450"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/356/007/080/5259/nutrition_fr.12.100.jpg",
+        "ecoscore_grade": "b",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "nutrition_data": "on",
+        "ingredients_text_nl_imported": "Volle verse _melk_ (uit Bretagne) 35%, _tarwe_bloem, ruwe rietsuiker, verse hele _eieren_ (uit Frankrijk) 12%, koolzaadolie, rijsmiddelen: dinatriumdifosfaat, natriumcarbonaat en _tarwe_zetmeel, zout, zonnebloemolie.",
+        "id": "3560070805259",
+        "sources": [
+            {
+                "import_t": 1548615382,
+                "id": "carrefour",
+                "fields": [
+                    "product_name_fr",
+                    "product_name_nl",
+                    "generic_name_fr",
+                    "generic_name_nl",
+                    "quantity",
+                    "emb_codes",
+                    "stores",
+                    "other_information_fr",
+                    "other_information_nl",
+                    "conservation_conditions_fr",
+                    "conservation_conditions_nl",
+                    "ingredients_text_fr",
+                    "ingredients_text_nl"
+                ],
+                "url": "https://www.carrefour.fr",
+                "manufacturer": "1",
+                "name": "Carrefour",
+                "images": []
+            },
+            {
+                "import_t": 1549477840,
+                "id": "carrefour",
+                "fields": [
+                    "customer_service_fr",
+                    "customer_service_nl",
+                    "producer_fr",
+                    "producer_nl",
+                    "preparation_fr",
+                    "preparation_nl"
+                ],
+                "url": "https://www.carrefour.fr",
+                "manufacturer": "1",
+                "name": "Carrefour",
+                "images": []
+            },
+            {
+                "import_t": 1616949615,
+                "id": "org-carrefour",
+                "fields": [
+                    "producer_product_id",
+                    "origin_fr",
+                    "origin_nl",
+                    "allergens",
+                    "ingredients_text_fr",
+                    "ingredients_text_nl",
+                    "nutrients.energy_value",
+                    "nutrients.energy-kcal_unit",
+                    "nutrients.energy-kcal_value",
+                    "nutrients.energy-kj_value",
+                    "nutrients.fat_value",
+                    "nutrients.fiber_value",
+                    "nutrients.proteins_value",
+                    "nutrients.salt_value",
+                    "nutrients.saturated-fat_value",
+                    "nutrients.sugars_value"
+                ],
+                "url": null,
+                "manufacturer": 1,
+                "name": "carrefour",
+                "images": []
+            }
+        ],
+        "pnns_groups_1": "unknown",
+        "other_information": "Refermable \nAux oeufs frais\nx 6\nPICTO OPERCULE REFERMABLE",
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/356/007/080/5259/ingredients_fr.22.400.jpg",
+        "data_quality_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish",
+            "en:ecoscore-production-system-no-label"
+        ],
+        "additives_old_tags": [
+            "en:e450",
+            "en:e500"
+        ],
+        "labels_hierarchy": [
+            "en:green-dot",
+            "en:made-in-france",
+            "fr:Eco-Emballages"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "origins_hierarchy": [
+            "en:france",
+            "en:brittany",
+            "fr:22400 Lamballe",
+            "fr:Crêperie Jarnoux SA",
+            "fr:Côtes-d'Armor",
+            "fr:Lait frais entier breton"
+        ],
+        "complete": 0,
+        "pnns_groups_2": "unknown",
+        "new_additives_n": 3,
+        "product_quantity": "132",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/356/007/080/5259/front_fr.28.400.jpg",
+        "preparation_nl_imported": "Ideaal als ontbijt of vieruurtje. Om koud te eten of verwarmd circa 1 minuut in de broodrooster of 10 seconden in de microgolfoven op 750 watts. Kan puur gegeten worden of eventueel overgoten met ahornsiroop of chocoladesaus.",
+        "producer": "Fabriqué en France par EMB 22093 K pour Interdis",
+        "serving_size": "22g",
+        "stores_tags": [
+            "carrefour-market",
+            "banque-alimentaire",
+            "carrefour"
+        ],
+        "nutriscore_score": 4,
+        "additives_old_n": 2,
+        "packagings": [
+            {
+                "shape": "en:tray",
+                "material": "en:plastic"
+            }
+        ],
+        "preparation_fr_imported": "Idéal pour le petit déjeuner ou le goûter. A déguster froid ou réchauffé 1 minute environ au grille-pain ou 10 secondes au micro-ondes à 750 watts. A consommer nature ou nappé par exemple de sirop d'érable ou de chocolat.",
+        "data_quality_info_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish"
+        ],
+        "quantity": "132 g",
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "unknown_ingredients_n": 0,
+        "checkers_tags": [],
+        "lang_imported": "fr",
+        "editors": [
+            "jacob80"
+        ],
+        "nutriscore_score_opposite": -4,
+        "generic_name_fr": "6 mini-crêpes épaisses sucrées.",
+        "image_small_url": "https://static.openfoodfacts.net/images/products/356/007/080/5259/front_fr.28.200.jpg",
+        "nutriments": {
+            "carbohydrates_unit": "g",
+            "saturated-fat_serving": 0.396,
+            "energy-kj_100g": 1193,
+            "sugars_100g": 18,
+            "energy-kcal": 284,
+            "proteins_serving": 1.47,
+            "sodium_value": 0.344,
+            "salt_100g": 0.86,
+            "nova-group_serving": 4,
+            "energy_unit": "kJ",
+            "energy-kj_serving": 262,
+            "sugars_unit": "g",
+            "energy-kj_unit": "kJ",
+            "salt": 0.86,
+            "energy-kcal_100g": 284,
+            "fiber_100g": 2.4,
+            "saturated-fat": 1.8,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "fat_value": 9.2,
+            "fiber": 2.4,
+            "nova-group_100g": 4,
+            "energy_value": 1193,
+            "carbon-footprint-from-known-ingredients_serving": 16.1,
+            "fiber_value": 2.4,
+            "fiber_unit": "g",
+            "carbohydrates_serving": 9.24,
+            "sodium_unit": "g",
+            "carbohydrates_100g": 42,
+            "fat": 9.2,
+            "energy-kcal_unit": "kcal",
+            "proteins": 6.7,
+            "salt_serving": 0.189,
+            "energy_100g": 1193,
+            "sodium_100g": 0.344,
+            "nutrition-score-fr_100g": 4,
+            "salt_unit": "g",
+            "proteins_unit": "g",
+            "carbohydrates_value": 42,
+            "sugars_serving": 3.96,
+            "fat_unit": "g",
+            "salt_value": 0.86,
+            "fiber_serving": 0.528,
+            "proteins_value": 6.7,
+            "saturated-fat_100g": 1.8,
+            "fat_serving": 2.02,
+            "carbon-footprint-from-known-ingredients_100g": 73.2,
+            "energy": 1193,
+            "nova-group": 4,
+            "saturated-fat_value": 1.8,
+            "energy-kcal_value": 284,
+            "fat_100g": 9.2,
+            "energy_serving": 262,
+            "saturated-fat_unit": "g",
+            "sodium_serving": 0.0757,
+            "energy-kj_value": 1193,
+            "energy-kj": 1193,
+            "carbon-footprint-from-known-ingredients_product": 96.6,
+            "proteins_100g": 6.7,
+            "sugars_value": 18,
+            "nutrition-score-fr": 4,
+            "sodium": 0.344,
+            "sugars": 18,
+            "carbohydrates": 42,
+            "energy-kcal_serving": 62.5
+        },
+        "generic_name_fr_imported": "6 mini-crêpes épaisses sucrées.",
+        "purchase_places_tags": [
+            "villers-bocage-80260",
+            "france"
+        ],
+        "ingredients_text_nl": "Volle verse _melk_ (uit Bretagne) 35%, _tarwe_bloem, ruwe rietsuiker, verse hele _eieren_ (uit Frankrijk) 12%, koolzaadolie, rijsmiddelen: dinatriumdifosfaat, natriumcarbonaat en _tarwe_zetmeel, zout, zonnebloemolie.",
+        "conservation_conditions": "A consommer jusqu'au : voir la date figurant sur le côté. A consommer dans les 48h après ouverture. A conserver entre 0°C et +4°C. Conditionné sous atmosphère protectrice."
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/3560070976867.json
+++ b/testdata/product/3560070976867.json
@@ -1,0 +1,1915 @@
+{
+    "status": 1,
+    "code": "3560070976867",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "fruits à coque",
+        "conservation_conditions_nl": "Ten minste houdbaar tot / Lotnr.: zie zijkant verpakking.\nDroog bewaren op kamertemperatuur.\n\nSUR LE SACHET individuel: \nTen minste houdbaar tot / Lotnr.: zie zijkant kartonnen verpakking.\nDroog bewaren op kamertemperatuur.",
+        "category_properties": {
+            "ciqual_food_name:fr": "Gâteau -aliment moyen-",
+            "ciqual_food_name:en": "Chocolate cake"
+        },
+        "traces_debug_tags": [],
+        "popularity_tags": [
+            "top-100000-scans-2019",
+            "at-least-5-scans-2019",
+            "top-75-percent-scans-2019",
+            "top-80-percent-scans-2019",
+            "top-85-percent-scans-2019",
+            "top-90-percent-scans-2019",
+            "top-100000-fr-scans-2019",
+            "top-country-fr-scans-2019",
+            "at-least-5-fr-scans-2019",
+            "top-100000-scans-2020",
+            "at-least-5-scans-2020",
+            "top-75-percent-scans-2020",
+            "top-80-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-100000-fr-scans-2020",
+            "top-country-fr-scans-2020",
+            "at-least-5-fr-scans-2020"
+        ],
+        "conservation_conditions_fr": "A consommer de préférence avant le / n° de lot : voir sur le côté de l'emballage.\nA conserver à température ambiante et à l'abri de l'humidité.\n\nSUR LE SACHET individuel: \nA consommer de préférence avant le / n° de lot : voir sur le côté de l'emballage cartonné\nA conserver à température ambiante et à l'abri de l'humidité.",
+        "customer_service": "Interdis - TSA 91431 - 91343 MASSY Cedex - France",
+        "categories_tags": [
+            "en:snacks",
+            "en:sweet-snacks",
+            "en:biscuits-and-cakes",
+            "en:cakes",
+            "en:chocolate-cakes",
+            "en:brownies"
+        ],
+        "traces_hierarchy": [
+            "en:nuts"
+        ],
+        "ingredients_text_with_allergens_nl": "<span class=\"allergen\">Eieren</span>, suiker, koolzaadolie,<span class=\"allergen\"> _melk</span>_chocolade 8,7% (suiker, volle_<span class=\"allergen\">melk</span>_poeder, cacaoboter, cacaomassa, <span class=\"allergen\">lactose</span>, emulgator: zonnebloemlecithinen, natuurlijk vanillearoma), chocoladestukjes 8,7% (cacaomassa, suiker, cacaoboter), rijstbloem 5,5%, aardappelzetmeel 5,5%, bevochtigingsmiddel: glycerol, magerecacaopoeder, glucosestroop, invertsuikerstroop, rijstzetmeel, rijsmiddelen: difosfaten en natriumcarbonaten, voedingszuur: citroenzuur, conserveermiddel: kaliumsorbaat, stabilisator: xanthaangom.\nKan sporen bevatten van<span class=\"allergen\"> noten</span>.",
+        "allergens_hierarchy": [
+            "en:eggs",
+            "en:milk"
+        ],
+        "generic_name": "Petits gâteaux au chocolat et aux pépites de chocolat sans gluten à base de farine de riz et amidon de pomme de terre.",
+        "product_name_fr": "Brownies No Gluten !*",
+        "origins_tags": [],
+        "languages_hierarchy": [
+            "en:french",
+            "en:dutch"
+        ],
+        "stores_imported": "Carrefour",
+        "last_image_t": 1616957146,
+        "additives_n": 7,
+        "carbon_footprint_from_known_ingredients_debug": "en:milk-chocolate 8.7% x 5.9 = 51.33 g - en:chocolate-pieces 8.7% x 4.9 = 42.63 g - en:rice-flour 5.5% x 1.2 = 6.6 g - ",
+        "producer_fr": "Fabriqué en Belgique par EMB B-8940 pour Interdis.",
+        "pnns_groups_2_tags": [
+            "biscuits-and-cakes",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "segundo",
+            "yuka.R0s0WURxQWx2OE0zZ3ZReHdSbmxvTjk1bjdpVlZrS1ZkK3d6SUE9PQ",
+            "openfoodfacts-contributors",
+            "yuka.YUlraUdZWURqTkpRaDhNNDRDdUlvUFJvM2MrbVkzdXpHZFJCSVE9PQ",
+            "carrefour",
+            "roboto-app",
+            "autorotate-bot",
+            "org-carrefour"
+        ],
+        "customer_service_nl": "Carrefour Product info\n PB 2000 Evere 3 - 1140 BRUSSELS\n Tél: 0800/9.10.11",
+        "sortkey": 1602570058,
+        "categories_old": "Snacks, Snacks sucrés, Biscuits et gâteaux, Gâteaux, Gâteaux au chocolat, Brownies",
+        "generic_name_nl_imported": "Glutenvrije chocoladecakejes met stukjes chocolade op basis van rijstbloem en aardappelzetmeel.",
+        "completeness": 0.6875,
+        "categories_properties": {
+            "ciqual_food_code:en": "23032",
+            "agribalyse_food_code:en": "23032"
+        },
+        "labels_tags": [
+            "en:no-gluten",
+            "en:made-in-belgium",
+            "fr:afdiag"
+        ],
+        "traces_from_user": "(fr) en:nuts",
+        "informers_tags": [
+            "openfoodfacts-contributors",
+            "segundo",
+            "yuka.YUlraUdZWURqTkpRaDhNNDRDdUlvUFJvM2MrbVkzdXpHZFJCSVE9PQ",
+            "teolemon",
+            "carrefour",
+            "roboto-app",
+            "autorotate-bot",
+            "omerfedj",
+            "org-carrefour"
+        ],
+        "nutrition_grades_tags": [
+            "d"
+        ],
+        "brands_imported": "Carrefour",
+        "vitamins_tags": [],
+        "lang": "fr",
+        "origins_lc": "fr",
+        "interface_version_modified": "20150316.jqm2",
+        "customer_service_fr_imported": "Interdis - TSA 91431 - 91343 MASSY Cedex - France",
+        "unique_scans_n": 5,
+        "additives_tags": [
+            "en:e202",
+            "en:e322",
+            "en:e322i",
+            "en:e330",
+            "en:e415",
+            "en:e422",
+            "en:e450",
+            "en:e450i",
+            "en:e500"
+        ],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/356/007/097/6867/nutrition_fr.5.400.jpg",
+        "stores_debug_tags": [],
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "nova_group_debug": " -- additives/en:e202 : 3 -- additives/en:e415 : 4",
+        "traces_tags": [
+            "en:nuts"
+        ],
+        "generic_name_nl": "Glutenvrije chocoladecakejes met stukjes chocolade op basis van rijstbloem en aardappelzetmeel.",
+        "nova_groups": "4",
+        "packaging_tags": [],
+        "allergens_from_ingredients": "Œufs, lait, lait, lactose",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/356/007/097/6867/front_fr.36.100.jpg",
+        "nutrient_levels": {
+            "sugars": "high",
+            "salt": "moderate",
+            "fat": "high",
+            "saturated-fat": "high"
+        },
+        "ingredients_analysis_tags": [
+            "en:palm-oil-free",
+            "en:non-vegan",
+            "en:vegetarian"
+        ],
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "created_t": 1479798954,
+        "nutriscore_data": {
+            "proteins": 5.5,
+            "negative_points": 19,
+            "sugars_points": 7,
+            "sodium_value": 196,
+            "score": 15,
+            "positive_points": 4,
+            "is_water": 0,
+            "saturated_fat_value": 5.3,
+            "proteins_points": 3,
+            "saturated_fat_points": 5,
+            "saturated_fat_ratio": 23.0434782608696,
+            "proteins_value": 5.5,
+            "saturated_fat_ratio_points": 3,
+            "fiber_points": 4,
+            "grade": "d",
+            "is_cheese": 0,
+            "energy": 1804,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 8.7,
+            "fiber": 3.8,
+            "energy_points": 5,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 2,
+            "is_fat": 0,
+            "energy_value": 1804,
+            "is_beverage": 0,
+            "fiber_value": 3.8,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 8.7,
+            "saturated_fat_ratio_value": 23,
+            "sugars_value": 32,
+            "saturated_fat": 5.3,
+            "sodium": 196,
+            "sugars": 32
+        },
+        "amino_acids_prev_tags": [],
+        "nova_group": 4,
+        "nutrition_grade_fr": "d",
+        "data_sources_imported": "Producer - Carrefour, Producers",
+        "scans_n": 6,
+        "nucleotides_tags": [],
+        "ingredients_text_with_allergens_fr": "<span class=\"allergen\">Œufs</span>, sucre, huile de colza, chocolat au <span class=\"allergen\">lait</span> 8,7% (sucre, poudre de <span class=\"allergen\">lait</span> entier, beurre de cacao, pâte de cacao, <span class=\"allergen\">lactose</span>, émulsifiant : lécithines de tournesol, arôme naturel de vanille), pépites de chocolat 8,7% (pâte de cacao, sucre, beurre de cacao), farine de riz 5,5%, amidon de pomme de terre 5,5%, humectant : glycérol, cacao maigre en poudre, sirop de glucose, sirop de sucre inverti, amidon de riz, poudres à lever : diphosphates et carbonates de sodium, acidifiant : acide citrique, conservateur : sorbate de potassium, stabilisant : gomme xanthane. \n Peut contenir des traces de <span class=\"allergen\">fruits à coque</span>.",
+        "images": {
+            "18": {
+                "uploaded_t": 1616957146,
+                "uploader": "org-carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 130,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 32,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 768,
+                        "w": 2365
+                    }
+                }
+            },
+            "nutrition_fr": {
+                "y1": "63.44999694824219",
+                "rev": "5",
+                "y2": "208.4499969482422",
+                "x2": "256.75",
+                "ocr": 1,
+                "x1": "-4.25",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 226,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 57,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 113,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 725,
+                        "w": 1283
+                    }
+                },
+                "angle": "0",
+                "orientation": "0",
+                "normalize": "false",
+                "geometry": "1304x725--21-317",
+                "imgid": "2"
+            },
+            "11": {
+                "uploaded_t": 1553930252,
+                "uploader": "carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 210,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 53,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1146,
+                        "w": 2178
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": "1520974278",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 901
+                    }
+                }
+            },
+            "15": {
+                "uploaded_t": 1616957144,
+                "uploader": "org-carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 173,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 43,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1020,
+                        "w": 2365
+                    }
+                }
+            },
+            "6": {
+                "uploaded_t": 1553930250,
+                "uploader": "carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 180,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 45,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1120,
+                        "w": 2495
+                    }
+                }
+            },
+            "19": {
+                "uploaded_t": 1616957146,
+                "uploader": "org-carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 129,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 32,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 763,
+                        "w": 2365
+                    }
+                }
+            },
+            "9": {
+                "uploaded_t": 1553930251,
+                "uploader": "carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 192,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 48,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1194,
+                        "w": 2491
+                    }
+                }
+            },
+            "17": {
+                "uploaded_t": 1616957145,
+                "uploader": "org-carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 210,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 52,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1241,
+                        "w": 2365
+                    }
+                }
+            },
+            "2": {
+                "uploaded_t": "1481380685",
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2000,
+                        "w": 1500
+                    }
+                }
+            },
+            "14": {
+                "uploaded_t": 1616957143,
+                "uploader": "org-carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 196,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 49,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1161,
+                        "w": 2365
+                    }
+                }
+            },
+            "front_fr": {
+                "y1": "-1",
+                "y2": "-1",
+                "rev": "36",
+                "x2": "-1",
+                "white_magic": "false",
+                "x1": "-1",
+                "sizes": {
+                    "400": {
+                        "h": 211,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 53,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1249,
+                        "w": 2365
+                    },
+                    "200": {
+                        "h": 106,
+                        "w": 200
+                    }
+                },
+                "coordinates_image_size": "400",
+                "angle": 0,
+                "geometry": "0x0--5--5",
+                "normalize": "false",
+                "imgid": "13"
+            },
+            "12": {
+                "uploaded_t": 1599758733,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 901
+                    }
+                }
+            },
+            "7": {
+                "uploaded_t": 1553930250,
+                "uploader": "carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 128,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 32,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 797,
+                        "w": 2493
+                    }
+                }
+            },
+            "10": {
+                "uploaded_t": 1553930252,
+                "uploader": "carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 131,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 33,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 814,
+                        "w": 2492
+                    }
+                }
+            },
+            "16": {
+                "uploaded_t": 1616957145,
+                "uploader": "org-carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 129,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 32,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 761,
+                        "w": 2365
+                    }
+                }
+            },
+            "13": {
+                "uploaded_t": 1616957142,
+                "uploader": "org-carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 211,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 53,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1249,
+                        "w": 2365
+                    }
+                }
+            },
+            "1": {
+                "uploaded_t": "1481380635",
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2000,
+                        "w": 1500
+                    }
+                }
+            },
+            "4": {
+                "uploaded_t": "1520974282",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 81
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 20
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 242
+                    }
+                }
+            },
+            "8": {
+                "uploaded_t": 1553930251,
+                "uploader": "carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 206,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 52,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1289,
+                        "w": 2497
+                    }
+                }
+            },
+            "5": {
+                "uploaded_t": 1553930249,
+                "uploader": "carrefour",
+                "sizes": {
+                    "400": {
+                        "h": 186,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 47,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1031,
+                        "w": 2214
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "y1": "-1",
+                "y2": "-1",
+                "rev": "26",
+                "x2": "-1",
+                "white_magic": null,
+                "x1": "-1",
+                "sizes": {
+                    "400": {
+                        "h": 81,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 20,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 242,
+                        "w": 1200
+                    },
+                    "200": {
+                        "h": 40,
+                        "w": 200
+                    }
+                },
+                "angle": -270,
+                "geometry": "0x0--3--2",
+                "normalize": null,
+                "imgid": "4"
+            }
+        },
+        "owner_fields": {
+            "proteins": 1616937029,
+            "lc": 1616937029,
+            "conservation_conditions_nl": 1616937029,
+            "energy-kcal": 1616937029,
+            "conservation_conditions_fr": 1616937029,
+            "ingredients_text_fr": 1616937029,
+            "product_name_fr": 1616937029,
+            "allergens": 1616937029,
+            "product_name_nl": 1616937029,
+            "customer_service_fr": 1616937029,
+            "labels": 1616937029,
+            "salt": 1616937029,
+            "quantity": 1616937029,
+            "producer_fr": 1616937029,
+            "nutrition_data_prepared_per": 1616937029,
+            "traces": 1616937029,
+            "data_sources": 1616937029,
+            "customer_service_nl": 1616937029,
+            "producer_nl": 1616937029,
+            "saturated-fat": 1616937029,
+            "energy": 1616937029,
+            "fiber": 1616937029,
+            "lang": 1616937029,
+            "nutrition_data_per": 1616937029,
+            "producer_product_id": 1616937029,
+            "generic_name_fr": 1616937029,
+            "generic_name_nl": 1616937029,
+            "energy-kj": 1616937029,
+            "ingredients_text_nl": 1616937029,
+            "countries": 1616937029,
+            "stores": 1616937029,
+            "brands": 1616937029,
+            "obsolete": 1616937029,
+            "sugars": 1616937029,
+            "carbohydrates": 1616937029,
+            "fat": 1616937029
+        },
+        "ingredients_n": 33,
+        "editors_tags": [
+            "yuka.YUlraUdZWURqTkpRaDhNNDRDdUlvUFJvM2MrbVkzdXpHZFJCSVE9PQ",
+            "yuka.R0s0WURxQWx2OE0zZ3ZReHdSbmxvTjk1bjdpVlZrS1ZkK3d6SUE9PQ",
+            "carrefour",
+            "kiliweb",
+            "autorotate-bot",
+            "roboto-app",
+            "openfoodfacts-contributors",
+            "teolemon",
+            "segundo",
+            "org-carrefour",
+            "omerfedj"
+        ],
+        "manufacturing_places_debug_tags": [],
+        "countries_lc": "fr",
+        "allergens_tags": [
+            "en:eggs",
+            "en:milk"
+        ],
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "manufacturing_places": "Belgique",
+        "code": "3560070976867",
+        "codes_tags": [
+            "code-13",
+            "3560070976xxx",
+            "356007097xxxx",
+            "35600709xxxxx",
+            "3560070xxxxxx",
+            "356007xxxxxxx",
+            "35600xxxxxxxx",
+            "3560xxxxxxxxx",
+            "356xxxxxxxxxx",
+            "35xxxxxxxxxxx",
+            "3xxxxxxxxxxxx"
+        ],
+        "customer_service_fr": "Interdis - TSA 91431 - 91343 MASSY Cedex - France",
+        "last_modified_by": "org-carrefour",
+        "labels": "Gluten-free, fr:Afdiag, en:made-in-belgium, en:no-gluten",
+        "entry_dates_tags": [
+            "2016-11-22",
+            "2016-11",
+            "2016"
+        ],
+        "last_edit_dates_tags": [
+            "2021-03-28",
+            "2021-03",
+            "2021"
+        ],
+        "creator": "openfoodfacts-contributors",
+        "conservation_conditions_nl_imported": "Ten minste houdbaar tot / Lotnr.: zie zijkant verpakking.\nDroog bewaren op kamertemperatuur.\n\nSUR LE SACHET individuel: \nTen minste houdbaar tot / Lotnr.: zie zijkant kartonnen verpakking.\nDroog bewaren op kamertemperatuur.",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "et",
+            "biscuit",
+            "au",
+            "terre",
+            "snack",
+            "gluten-free",
+            "carrefour",
+            "base",
+            "petit",
+            "farine",
+            "gateaux",
+            "de",
+            "no",
+            "brownie",
+            "riz",
+            "san",
+            "gluten",
+            "pepite",
+            "sucre",
+            "pomme",
+            "no-gluten",
+            "amidon",
+            "aux",
+            "afdiag",
+            "chocolat",
+            "made-in-belgium"
+        ],
+        "link": "",
+        "countries_imported": "France",
+        "ingredients_debug": [
+            "Œufs",
+            ",",
+            null,
+            null,
+            null,
+            " sucre",
+            ",",
+            null,
+            null,
+            null,
+            " huile de colza",
+            ",",
+            null,
+            null,
+            null,
+            " chocolat au lait 8",
+            ",",
+            null,
+            null,
+            null,
+            "7% ",
+            "(",
+            "(",
+            null,
+            null,
+            "sucre",
+            ",",
+            null,
+            null,
+            null,
+            " poudre de lait entier",
+            ",",
+            null,
+            null,
+            null,
+            " beurre de cacao",
+            ",",
+            null,
+            null,
+            null,
+            " pâte de cacao",
+            ",",
+            null,
+            null,
+            null,
+            " lactose",
+            ",",
+            null,
+            null,
+            null,
+            " émulsifiant ",
+            ":",
+            ":",
+            null,
+            null,
+            "  lécithines de tournesol",
+            ",",
+            null,
+            null,
+            null,
+            " arôme naturel de vanille)",
+            ",",
+            null,
+            null,
+            null,
+            " pépites de chocolat 8",
+            ",",
+            null,
+            null,
+            null,
+            "7% ",
+            "(",
+            "(",
+            null,
+            null,
+            "pâte de cacao",
+            ",",
+            null,
+            null,
+            null,
+            " sucre",
+            ",",
+            null,
+            null,
+            null,
+            " beurre de cacao)",
+            ",",
+            null,
+            null,
+            null,
+            " farine de riz 5",
+            ",",
+            null,
+            null,
+            null,
+            "5%",
+            ",",
+            null,
+            null,
+            null,
+            " amidon de pomme de terre 5",
+            ",",
+            null,
+            null,
+            null,
+            "5%",
+            ",",
+            null,
+            null,
+            null,
+            " humectant ",
+            ":",
+            ":",
+            null,
+            null,
+            "  glycérol",
+            ",",
+            null,
+            null,
+            null,
+            " cacao maigre en poudre",
+            ",",
+            null,
+            null,
+            null,
+            " sirop de glucose",
+            ",",
+            null,
+            null,
+            null,
+            " sirop de sucre inverti",
+            ",",
+            null,
+            null,
+            null,
+            " amidon de riz",
+            ",",
+            null,
+            null,
+            null,
+            " poudres à lever ",
+            ":",
+            ":",
+            null,
+            null,
+            "  diphosphates de sodium",
+            ",",
+            null,
+            null,
+            null,
+            "carbonates de sodium",
+            ",",
+            null,
+            null,
+            null,
+            " acidifiant ",
+            ":",
+            ":",
+            null,
+            null,
+            "  acide citrique",
+            ",",
+            null,
+            null,
+            null,
+            " conservateur ",
+            ":",
+            ":",
+            null,
+            null,
+            "  sorbate de potassium",
+            ",",
+            null,
+            null,
+            null,
+            " stabilisant ",
+            ":",
+            ":",
+            null,
+            null,
+            "  gomme xanthane",
+            ". ",
+            null,
+            null,
+            null,
+            "\n Peut contenir des traces de fruits à coque."
+        ],
+        "labels_lc": "fr",
+        "languages_codes": {
+            "fr": 10,
+            "nl": 7
+        },
+        "packaging": "",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/356/007/097/6867/front_fr.36.400.jpg",
+        "popularity_key": 19900000017,
+        "last_image_dates_tags": [
+            "2021-03-28",
+            "2021-03",
+            "2021"
+        ],
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/356/007/097/6867/front_fr.36.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [
+            "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
+            "en:ecoscore-packaging-packaging-data-missing",
+            "en:ecoscore-production-system-no-label"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-to-be-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed",
+            "en:forest-footprint-computed",
+            "en:forest-footprint-a"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "countries_debug_tags": [],
+        "interface_version_created": "20150316.jqm2",
+        "nutrition_data_per": "100g",
+        "generic_name_fr_debug_tags": [],
+        "product_name_fr_debug_tags": [],
+        "photographers_tags": [
+            "openfoodfacts-contributors",
+            "kiliweb",
+            "carrefour",
+            "org-carrefour"
+        ],
+        "ecoscore_score": 27,
+        "debug_param_sorted_langs": [
+            "fr"
+        ],
+        "other_information_nl": "240g e\nIndividuele zakjes\nPicto GDA\nOntdek het No Gluten gamma van Carrefour!\nOntdek deze glutenvrije brownies. Ideaal als vieruurtje of voor een kleine zoete pauze, dankzij hun vershoudzakjes zijn ze handig mee te nemen. Speciaal bereid voor personen met een glutenintolerantie.\n\nStamp qualité carrefour et logo AFDIAG FR-060-004\n*Glutenvrij\n8 x (picto du sachet)\nLogo AFDIAG",
+        "last_modified_t": 1616957146,
+        "ingredients": [
+            {
+                "percent_max": 54.2,
+                "id": "en:egg",
+                "percent_estimate": 31.45,
+                "percent_min": "8.7",
+                "text": "_Œufs_",
+                "vegan": "no",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 31.45,
+                "id": "en:sugar",
+                "text": "sucre",
+                "percent_min": "8.7",
+                "percent_estimate": 20.075,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": "8.7",
+                "percent_estimate": 16.2833333333333,
+                "vegan": "yes",
+                "from_palm_oil": "no",
+                "vegetarian": "yes",
+                "percent_max": 23.8666666666667,
+                "id": "en:colza-oil",
+                "text": "huile de colza"
+            },
+            {
+                "percent": "8.7",
+                "percent_min": "8.7",
+                "percent_estimate": "8.7",
+                "vegan": "no",
+                "vegetarian": "yes",
+                "percent_max": "8.7",
+                "id": "en:milk-chocolate",
+                "text": "chocolat au _lait_"
+            },
+            {
+                "percent_estimate": "8.7",
+                "percent_min": "8.7",
+                "percent": "8.7",
+                "vegan": "maybe",
+                "vegetarian": "yes",
+                "percent_max": "8.7",
+                "id": "en:chocolate-pieces",
+                "text": "pépites de chocolat"
+            },
+            {
+                "percent_estimate": "5.5",
+                "percent_min": "5.5",
+                "percent": "5.5",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "5.5",
+                "id": "en:rice-flour",
+                "text": "farine de riz"
+            },
+            {
+                "percent_min": "5.5",
+                "percent_estimate": "5.5",
+                "percent": "5.5",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "5.5",
+                "id": "en:potato-starch",
+                "text": "amidon de pomme de terre"
+            },
+            {
+                "percent_max": "5.5",
+                "id": "en:humectant",
+                "text": "humectant",
+                "percent_estimate": 1.89583333333333,
+                "percent_min": 0
+            },
+            {
+                "percent_max": "5.5",
+                "id": "en:fat-reduced-cocoa-powder",
+                "text": "cacao maigre en poudre",
+                "percent_estimate": 0.947916666666664,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": "5.5",
+                "id": "en:glucose-syrup",
+                "percent_min": 0,
+                "percent_estimate": 0.473958333333329,
+                "text": "sirop de glucose",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": "5.5",
+                "id": "en:invert-sugar-syrup",
+                "text": "sirop de sucre inverti",
+                "percent_min": 0,
+                "percent_estimate": 0.236979166666664,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": "5.5",
+                "id": "en:rice-starch",
+                "text": "amidon de riz",
+                "percent_min": 0,
+                "percent_estimate": 0.118489583333329,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 4.92727272727273,
+                "id": "en:raising-agent",
+                "percent_estimate": 0.0592447916666643,
+                "percent_min": 0,
+                "text": "poudres à lever"
+            },
+            {
+                "percent_max": 4.51666666666667,
+                "id": "en:e500",
+                "percent_min": 0,
+                "percent_estimate": 0.0296223958333286,
+                "text": "carbonates de sodium",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 4.16923076923077,
+                "id": "en:acid",
+                "percent_min": 0,
+                "percent_estimate": 0.0148111979166643,
+                "text": "acidifiant"
+            },
+            {
+                "percent_max": 3.87142857142857,
+                "id": "en:preservative",
+                "text": "conservateur",
+                "percent_min": 0,
+                "percent_estimate": 0.0074055989583286
+            },
+            {
+                "percent_max": 3.61333333333333,
+                "id": "en:stabiliser",
+                "text": "stabilisant",
+                "percent_estimate": 0.0074055989583286,
+                "percent_min": 0
+            }
+        ],
+        "product_name_debug_tags": [],
+        "nutriscore_grade": "d",
+        "countries": "France",
+        "stores": "Carrefour",
+        "ciqual_food_name_tags": [
+            "chocolate-cake"
+        ],
+        "other_nutritional_substances_tags": [],
+        "cities_tags": [],
+        "brands": "Carrefour",
+        "categories": "Snacks, Snacks sucrés, Biscuits et gâteaux, Gâteaux, Gâteaux au chocolat, Brownies",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-to-be-completed, en:origins-to-be-completed, en:categories-completed, en:brands-completed, en:packaging-to-be-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:packaging-photo-to-be-selected, en:nutrition-photo-selected, en:ingredients-photo-selected, en:front-photo-selected, en:photos-uploaded",
+        "ingredients_text_with_allergens": "<span class=\"allergen\">Œufs</span>, sucre, huile de colza, chocolat au <span class=\"allergen\">lait</span> 8,7% (sucre, poudre de <span class=\"allergen\">lait</span> entier, beurre de cacao, pâte de cacao, <span class=\"allergen\">lactose</span>, émulsifiant : lécithines de tournesol, arôme naturel de vanille), pépites de chocolat 8,7% (pâte de cacao, sucre, beurre de cacao), farine de riz 5,5%, amidon de pomme de terre 5,5%, humectant : glycérol, cacao maigre en poudre, sirop de glucose, sirop de sucre inverti, amidon de riz, poudres à lever : diphosphates et carbonates de sodium, acidifiant : acide citrique, conservateur : sorbate de potassium, stabilisant : gomme xanthane. \n Peut contenir des traces de <span class=\"allergen\">fruits à coque</span>.",
+        "nutrition_grades": "d",
+        "nutrient_levels_tags": [
+            "en:fat-in-high-quantity",
+            "en:saturated-fat-in-high-quantity",
+            "en:sugars-in-high-quantity",
+            "en:salt-in-moderate-quantity"
+        ],
+        "nutrition_data_per_imported": "100g",
+        "nutrition_data_prepared_per_imported": "100g",
+        "known_ingredients_n": 49,
+        "product_name_fr_imported": "Brownies No Gluten !*",
+        "minerals_prev_tags": [],
+        "product_name": "Brownies No Gluten !*",
+        "serving_size_debug_tags": [],
+        "ingredients_text": "_Œufs_, sucre, huile de colza, chocolat au _lait_ 8,7% (sucre, poudre de _lait_ entier, beurre de cacao, pâte de cacao, _lactose_, émulsifiant : lécithines de tournesol, arôme naturel de vanille), pépites de chocolat 8,7% (pâte de cacao, sucre, beurre de cacao), farine de riz 5,5%, amidon de pomme de terre 5,5%, humectant : glycérol, cacao maigre en poudre, sirop de glucose, sirop de sucre inverti, amidon de riz, poudres à lever : diphosphates et carbonates de sodium, acidifiant : acide citrique, conservateur : sorbate de potassium, stabilisant : gomme xanthane. \n Peut contenir des traces de fruits à coque.",
+        "origins": "",
+        "languages_tags": [
+            "en:french",
+            "en:dutch",
+            "en:2",
+            "en:multilingual"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "_Œufs_, sucre, huile de colza, chocolat au _lait_ 8,7% (sucre, poudre de _lait_ entier, beurre de cacao, pâte de cacao, _lactose_, émulsifiant : lécithines de tournesol, arôme naturel de vanille), pépites de chocolat 8,7% (pâte de cacao, sucre, beurre de cacao), farine de riz 5,5%, amidon de pomme de terre 5,5%, humectant : glycérol, cacao maigre en poudre, sirop de glucose, sirop de sucre inverti, amidon de riz, poudres à lever : diphosphates et carbonates de sodium, acidifiant : acide citrique, conservateur : sorbate de potassium, stabilisant : gomme xanthane. \n Peut contenir des traces de fruits à coque.",
+        "lang_debug_tags": [],
+        "customer_service_nl_imported": "Carrefour Product info\n PB 2000 Evere 3 - 1140 BRUSSELS\n Tél: 0800/9.10.11",
+        "allergens": "",
+        "serving_quantity": "30",
+        "categories_lc": "fr",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/356/007/097/6867/ingredients_fr.26.100.jpg",
+        "obsolete_imported": "0",
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "d",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:unknown",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "warning": "unscored_shape",
+                    "score": 0
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "transportation_score_lu": 0,
+                    "value_it": -5,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_ch": 0,
+                    "epi_value": -5,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 0,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "value_lu": -5,
+                    "transportation_score_nl": 0
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "d",
+            "score": 27,
+            "grade_de": "d",
+            "missing_data_warning": 1,
+            "grade_nl": "d",
+            "score_be": 22,
+            "agribalyse": {
+                "co2_transportation": "0.20313436",
+                "ef_distribution": "0.0098990521",
+                "name_fr": "Brownie au chocolat",
+                "score": 37,
+                "agribalyse_food_code": "23032",
+                "ef_agriculture": "0.6964604099999999",
+                "ef_consumption": "0",
+                "name_en": "Brownie (chocolate cake)",
+                "co2_total": "8.964963",
+                "ef_packaging": "0.018688987",
+                "ef_processing": "0.080710822",
+                "is_beverage": 0,
+                "co2_processing": "0.62389616",
+                "dqr": "2.19",
+                "code": "23032",
+                "co2_consumption": "0",
+                "co2_distribution": "0.029120657",
+                "ef_total": "0.82406316",
+                "co2_agriculture": "7.8023402",
+                "ef_transportation": "0.018011649",
+                "co2_packaging": "0.30174863"
+            },
+            "grade_it": "d",
+            "score_nl": 22,
+            "missing": {
+                "packagings": 1,
+                "labels": 1,
+                "origins": 1
+            },
+            "grade_ie": "d",
+            "score_ch": 22,
+            "score_de": 22,
+            "score_fr": 22,
+            "score_ie": 22,
+            "score_lu": 22,
+            "score_it": 22,
+            "score_es": 22,
+            "grade_es": "d",
+            "grade_ch": "d",
+            "grade_lu": "d",
+            "grade": "d"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/097/6867/nutrition_fr.5.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/097/6867/nutrition_fr.5.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/097/6867/nutrition_fr.5.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/097/6867/ingredients_fr.26.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/097/6867/ingredients_fr.26.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/097/6867/ingredients_fr.26.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/097/6867/front_fr.36.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/097/6867/front_fr.36.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/356/007/097/6867/front_fr.36.200.jpg"
+                }
+            }
+        },
+        "origins_old": "",
+        "rev": 42,
+        "product_name_nl": "Brownies No Gluten !*",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "producer_nl_imported": "Geproduceerd in België door EMB B-8940 voor Interdis.",
+        "last_editor": "org-carrefour",
+        "additives_prev_original_tags": [
+            "en:e322",
+            "en:e422",
+            "en:e450",
+            "en:e500",
+            "en:e330",
+            "en:e202",
+            "en:e415"
+        ],
+        "ingredients_tags": [
+            "en:egg",
+            "en:sugar",
+            "en:colza-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:rapeseed-oil",
+            "en:milk-chocolate",
+            "en:chocolate",
+            "en:chocolate-pieces",
+            "en:rice-flour",
+            "en:flour",
+            "en:rice",
+            "en:potato-starch",
+            "en:starch",
+            "en:humectant",
+            "en:fat-reduced-cocoa-powder",
+            "en:cocoa",
+            "en:cocoa-powder",
+            "en:glucose-syrup",
+            "en:glucose",
+            "en:invert-sugar-syrup",
+            "en:invert-sugar",
+            "en:sugar-syrup",
+            "en:rice-starch",
+            "en:raising-agent",
+            "en:e500",
+            "en:acid",
+            "en:preservative",
+            "en:stabiliser",
+            "en:whole-milk-powder",
+            "en:dairy",
+            "en:milk-powder",
+            "en:cocoa-butter",
+            "en:cocoa-paste",
+            "en:lactose",
+            "en:emulsifier",
+            "en:natural-vanilla-flavouring",
+            "en:flavouring",
+            "en:natural-flavouring",
+            "en:vanilla-flavouring",
+            "en:e422",
+            "en:e450i",
+            "en:e450",
+            "en:e330",
+            "en:e202",
+            "en:e415",
+            "en:sunflower-lecithin",
+            "en:e322",
+            "en:e322i"
+        ],
+        "data_sources_tags": [
+            "producer-carrefour",
+            "producers",
+            "app-yuka",
+            "apps"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/356/007/097/6867/nutrition_fr.5.100.jpg",
+        "producer_nl": "Geproduceerd in België door EMB B-8940 voor Interdis.",
+        "ingredients_from_palm_oil_tags": [],
+        "carbon_footprint_percent_of_known_ingredients": 22.9,
+        "categories_hierarchy": [
+            "en:snacks",
+            "en:sweet-snacks",
+            "en:biscuits-and-cakes",
+            "en:cakes",
+            "en:chocolate-cakes",
+            "en:brownies"
+        ],
+        "quantity_imported": "240 g\n\nSur le sachet, indiquer 30 g",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "d",
+        "producer_product_id_imported": "8924",
+        "languages": {
+            "en:french": 10,
+            "en:dutch": 7
+        },
+        "nutrition_data": "on",
+        "ingredients_text_nl_imported": "_Eieren_, suiker, koolzaadolie, _melk_chocolade 8,7% (suiker, volle_melk_poeder, cacaoboter, cacaomassa, _lactose_, emulgator: zonnebloemlecithinen, natuurlijk vanillearoma), chocoladestukjes 8,7% (cacaomassa, suiker, cacaoboter), rijstbloem 5,5%, aardappelzetmeel 5,5%, bevochtigingsmiddel: glycerol, magerecacaopoeder, glucosestroop, invertsuikerstroop, rijstzetmeel, rijsmiddelen: difosfaten en natriumcarbonaten, voedingszuur: citroenzuur, conserveermiddel: kaliumsorbaat, stabilisator: xanthaangom.\nKan sporen bevatten van noten.",
+        "purchase_places": "",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-23032",
+            "agribalyse-food-code-known",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-23032",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-23032"
+        ],
+        "id": "3560070976867",
+        "sources": [
+            {
+                "import_t": 1553930249,
+                "fields": [
+                    "product_name_fr",
+                    "product_name_nl",
+                    "generic_name_fr",
+                    "generic_name_nl",
+                    "quantity",
+                    "labels",
+                    "other_information_fr",
+                    "other_information_nl",
+                    "conservation_conditions_fr",
+                    "conservation_conditions_nl",
+                    "customer_service_fr",
+                    "customer_service_nl",
+                    "producer_fr",
+                    "producer_nl",
+                    "ingredients_text_fr",
+                    "ingredients_text_nl"
+                ],
+                "id": "carrefour",
+                "manufacturer": "1",
+                "url": "https://www.carrefour.fr",
+                "name": "Carrefour",
+                "images": []
+            },
+            {
+                "import_t": 1567060793,
+                "id": "carrefour",
+                "fields": [
+                    "brands",
+                    "producer_product_id"
+                ],
+                "url": "https://www.carrefour.fr",
+                "manufacturer": "1",
+                "name": "Carrefour",
+                "images": []
+            },
+            {
+                "import_t": 1574493865,
+                "fields": [
+                    "ingredients_text_fr",
+                    "ingredients_text_nl"
+                ],
+                "id": "carrefour",
+                "manufacturer": "1",
+                "url": "https://www.carrefour.fr",
+                "name": "Carrefour",
+                "images": []
+            },
+            {
+                "import_t": 1581233266,
+                "id": "carrefour",
+                "fields": [
+                    "product_name_fr",
+                    "product_name_nl"
+                ],
+                "url": "https://www.carrefour.fr",
+                "manufacturer": "1",
+                "name": "Carrefour",
+                "images": []
+            },
+            {
+                "import_t": 1602570058,
+                "fields": [
+                    "labels"
+                ],
+                "id": "carrefour",
+                "manufacturer": "1",
+                "url": "https://www.carrefour.fr",
+                "name": "Carrefour",
+                "images": []
+            },
+            {
+                "import_t": 1616957141,
+                "id": "org-carrefour",
+                "fields": [
+                    "nutrients.energy-kcal_unit",
+                    "nutrients.energy-kcal_value"
+                ],
+                "url": null,
+                "manufacturer": 1,
+                "name": "carrefour",
+                "images": []
+            }
+        ],
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Sugary snacks",
+        "allergens_from_user": "(fr) ",
+        "labels_imported": "Sans gluten, Afdiag",
+        "additives_debug_tags": [
+            "en-e450i-added"
+        ],
+        "other_information": "240g e\nSachets individuels \nPicto GDA\nDécouvrez la gamme Carrefour No Gluten!\nDécouvrez ces brownies sans gluten. Idéal pour le goûter ou pour une petite pause douceur, vous pourrez les emporter partout grâce à leur sachet fraîcheur. Spécialement formulés pour les personnes ayant une intolérance au gluten. \n\nStamp qualité carrefour et logo AFDIAG FR-060-004\n*Sans Gluten\n8 x (picto du sachet)\nLogo AFDIAG",
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/356/007/097/6867/ingredients_fr.26.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish",
+            "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
+            "en:ecoscore-packaging-packaging-data-missing",
+            "en:ecoscore-production-system-no-label"
+        ],
+        "additives_old_tags": [
+            "en:e1403",
+            "en:e322",
+            "en:e422",
+            "en:e450",
+            "en:e500",
+            "en:e330",
+            "en:e202",
+            "en:e415"
+        ],
+        "origins_hierarchy": [],
+        "labels_hierarchy": [
+            "en:no-gluten",
+            "en:made-in-belgium",
+            "fr:afdiag"
+        ],
+        "ecoscore_tags": [
+            "d"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "other_information_fr": "240g e\nSachets individuels \nPicto GDA\nDécouvrez la gamme Carrefour No Gluten!\nDécouvrez ces brownies sans gluten. Idéal pour le goûter ou pour une petite pause douceur, vous pourrez les emporter partout grâce à leur sachet fraîcheur. Spécialement formulés pour les personnes ayant une intolérance au gluten. \n\nStamp qualité carrefour et logo AFDIAG FR-060-004\n*Sans Gluten\n8 x (picto du sachet)\nLogo AFDIAG",
+        "lc_imported": "fr",
+        "nutrition_score_beverage": 0,
+        "pnns_groups_2": "Biscuits and cakes",
+        "ingredients_text_fr_debug_tags": [],
+        "complete": 0,
+        "product_quantity": "240",
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/356/007/097/6867/front_fr.36.100.jpg",
+        "ingredients_text_debug": "Œufs, sucre, huile de colza, chocolat au lait 8,7% (sucre, poudre de lait entier, beurre de cacao, pâte de cacao, lactose, émulsifiant :  lécithines de tournesol, arôme naturel de vanille), pépites de chocolat 8,7% (pâte de cacao, sucre, beurre de cacao), farine de riz 5,5%, amidon de pomme de terre 5,5%, humectant :  glycérol, cacao maigre en poudre, sirop de glucose, sirop de sucre inverti, amidon de riz, poudres à lever :  diphosphates et carbonates de sodium, acidifiant :  acide citrique, conservateur :  sorbate de potassium, stabilisant :  gomme xanthane. \n Peut contenir des traces de fruits à coque.",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/356/007/097/6867/front_fr.36.400.jpg",
+        "_id": "3560070976867",
+        "producer": "Fabriqué en Belgique par EMB B-8940 pour Interdis.",
+        "countries_tags": [
+            "en:france"
+        ],
+        "serving_size": "30 g",
+        "ingredients_hierarchy": [
+            "en:egg",
+            "en:sugar",
+            "en:colza-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:rapeseed-oil",
+            "en:milk-chocolate",
+            "en:chocolate",
+            "en:chocolate-pieces",
+            "en:rice-flour",
+            "en:flour",
+            "en:rice",
+            "en:potato-starch",
+            "en:starch",
+            "en:humectant",
+            "en:fat-reduced-cocoa-powder",
+            "en:cocoa",
+            "en:cocoa-powder",
+            "en:glucose-syrup",
+            "en:glucose",
+            "en:invert-sugar-syrup",
+            "en:invert-sugar",
+            "en:sugar-syrup",
+            "en:rice-starch",
+            "en:raising-agent",
+            "en:e500",
+            "en:acid",
+            "en:preservative",
+            "en:stabiliser",
+            "en:whole-milk-powder",
+            "en:dairy",
+            "en:milk-powder",
+            "en:cocoa-butter",
+            "en:cocoa-paste",
+            "en:lactose",
+            "en:emulsifier",
+            "en:natural-vanilla-flavouring",
+            "en:flavouring",
+            "en:natural-flavouring",
+            "en:vanilla-flavouring",
+            "en:e422",
+            "en:e450i",
+            "en:e450",
+            "en:e330",
+            "en:e202",
+            "en:e415",
+            "en:sunflower-lecithin",
+            "en:e322",
+            "en:e322i"
+        ],
+        "additives_original_tags": [
+            "en:e322i",
+            "en:e422",
+            "en:e450i",
+            "en:e500",
+            "en:e330",
+            "en:e202",
+            "en:e415"
+        ],
+        "stores_tags": [
+            "carrefour"
+        ],
+        "nutriscore_score": 15,
+        "compared_to_category": "en:brownies",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-to-be-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "expiration_date_debug_tags": [],
+        "ingredients_n_tags": [
+            "33",
+            "31-40"
+        ],
+        "pnns_groups_1_tags": [
+            "sugary-snacks",
+            "known"
+        ],
+        "additives_old_n": 8,
+        "allergens_imported": "Œufs, Lait",
+        "packagings": [
+            {
+                "shape": "en:unknown",
+                "material": "en:unknown"
+            }
+        ],
+        "quantity": "240 g\n\nSur le sachet, indiquer 30 g",
+        "data_quality_errors_tags": [],
+        "data_quality_info_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish"
+        ],
+        "brands_tags": [
+            "carrefour"
+        ],
+        "owners_tags": "org-carrefour",
+        "ingredients_ids_debug": [
+            "oeufs",
+            "sucre",
+            "huile-de-colza",
+            "chocolat-au-lait-8",
+            "7",
+            "sucre",
+            "poudre-de-lait-entier",
+            "beurre-de-cacao",
+            "pate-de-cacao",
+            "lactose",
+            "emulsifiant",
+            "lecithines-de-tournesol",
+            "arome-naturel-de-vanille",
+            "pepites-de-chocolat-8",
+            "7",
+            "pate-de-cacao",
+            "sucre",
+            "beurre-de-cacao",
+            "farine-de-riz-5",
+            "5",
+            "amidon-de-pomme-de-terre-5",
+            "5",
+            "humectant",
+            "glycerol",
+            "cacao-maigre-en-poudre",
+            "sirop-de-glucose",
+            "sirop-de-sucre-inverti",
+            "amidon-de-riz",
+            "poudres-a-lever",
+            "diphosphates-de-sodium",
+            "carbonates-de-sodium",
+            "acidifiant",
+            "acide-citrique",
+            "conservateur",
+            "sorbate-de-potassium",
+            "stabilisant",
+            "gomme-xanthane",
+            "peut-contenir-des-traces-de-fruits-a-coque"
+        ],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [
+            "en:egg",
+            "en:sugar",
+            "en:colza-oil",
+            "en:milk-chocolate",
+            "en:chocolate-pieces",
+            "en:rice-flour",
+            "en:potato-starch",
+            "en:humectant",
+            "en:fat-reduced-cocoa-powder",
+            "en:glucose-syrup",
+            "en:invert-sugar-syrup",
+            "en:rice-starch",
+            "en:raising-agent",
+            "en:e500",
+            "en:acid",
+            "en:preservative",
+            "en:stabiliser",
+            "en:sugar",
+            "en:whole-milk-powder",
+            "en:cocoa-butter",
+            "en:cocoa-paste",
+            "en:lactose",
+            "en:emulsifier",
+            "en:natural-vanilla-flavouring",
+            "en:cocoa-paste",
+            "en:sugar",
+            "en:cocoa-butter",
+            "en:e422",
+            "en:e450i",
+            "en:e330",
+            "en:e202",
+            "en:e415",
+            "en:sunflower-lecithin"
+        ],
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 8.7,
+        "traces": "en:nuts",
+        "product_name_nl_imported": "Brownies No Gluten !*",
+        "data_sources": "Producer - Carrefour, Producers, App - yuka, Apps",
+        "unknown_ingredients_n": 0,
+        "manufacturing_places_tags": [
+            "belgique"
+        ],
+        "ingredients_text_fr_imported": "_Œufs_, sucre, huile de colza, chocolat au _lait_ 8,7% (sucre, poudre de _lait_ entier, beurre de cacao, pâte de cacao, _lactose_, émulsifiant : lécithines de tournesol, arôme naturel de vanille), pépites de chocolat 8,7% (pâte de cacao, sucre, beurre de cacao), farine de riz 5,5%, amidon de pomme de terre 5,5%, humectant : glycérol, cacao maigre en poudre, sirop de glucose, sirop de sucre inverti, amidon de riz, poudres à lever : diphosphates et carbonates de sodium, acidifiant : acide citrique, conservateur : sorbate de potassium, stabilisant : gomme xanthane. \n Peut contenir des traces de fruits à coque.",
+        "conservation_conditions_fr_imported": "A consommer de préférence avant le / n° de lot : voir sur le côté de l'emballage.\nA conserver à température ambiante et à l'abri de l'humidité.\n\nSUR LE SACHET individuel: \nA consommer de préférence avant le / n° de lot : voir sur le côté de l'emballage cartonné\nA conserver à température ambiante et à l'abri de l'humidité.",
+        "quantity_debug_tags": [],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "forest_footprint_data": {
+            "footprint_per_kg": 0.0249503333333333,
+            "ingredients": [
+                {
+                    "processing_factor": "1",
+                    "type": {
+                        "deforestation_risk": "0.68",
+                        "soy_feed_factor": "0.035",
+                        "name": "Oeufs Importés",
+                        "soy_yield": "0.3"
+                    },
+                    "tag_type": "ingredients",
+                    "conditions_tags": [],
+                    "percent_estimate": 31.45,
+                    "percent": 31.45,
+                    "matching_tag_id": "en:egg",
+                    "tag_id": "en:egg",
+                    "footprint_per_kg": 0.0249503333333333
+                }
+            ],
+            "grade": "a"
+        },
+        "lang_imported": "fr",
+        "max_imgid": "19",
+        "emb_codes": "",
+        "traces_imported": "Fruits à coque",
+        "nutrition_data_per_debug_tags": [],
+        "producer_product_id": "8924",
+        "nutriscore_score_opposite": -15,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/356/007/097/6867/front_fr.36.200.jpg",
+        "generic_name_fr": "Petits gâteaux au chocolat et aux pépites de chocolat sans gluten à base de farine de riz et amidon de pomme de terre.",
+        "producer_fr_imported": "Fabriqué en Belgique par EMB B-8940 pour Interdis.",
+        "nutriments": {
+            "carbohydrates_unit": "g",
+            "energy-kj_100g": 1804,
+            "saturated-fat_serving": 1.59,
+            "energy-kcal": 432,
+            "sugars_100g": 32,
+            "proteins_serving": 1.65,
+            "sodium_value": 0.196,
+            "salt_100g": 0.49,
+            "nova-group_serving": 4,
+            "energy_unit": "kJ",
+            "energy-kj_serving": 541,
+            "sugars_unit": "g",
+            "energy-kj_unit": "kJ",
+            "salt": 0.49,
+            "fiber_100g": 3.8,
+            "energy-kcal_100g": 432,
+            "saturated-fat": 5.3,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 8.7,
+            "fat_value": 23,
+            "fiber": 3.8,
+            "nova-group_100g": 4,
+            "energy_value": 1804,
+            "carbon-footprint-from-known-ingredients_serving": 30.2,
+            "fiber_value": 3.8,
+            "fiber_unit": "g",
+            "carbohydrates_serving": 15.3,
+            "sodium_unit": "g",
+            "carbohydrates_100g": 51,
+            "fat": 23,
+            "energy-kcal_unit": "kcal",
+            "salt_serving": 0.147,
+            "proteins": 5.5,
+            "energy_100g": 1804,
+            "sodium_100g": 0.196,
+            "nutrition-score-fr_100g": 15,
+            "salt_unit": "g",
+            "carbohydrates_value": 51,
+            "proteins_unit": "g",
+            "sugars_serving": 9.6,
+            "fat_unit": "g",
+            "salt_value": 0.49,
+            "fiber_serving": 1.14,
+            "proteins_value": 5.5,
+            "saturated-fat_100g": 5.3,
+            "fat_serving": 6.9,
+            "carbon-footprint-from-known-ingredients_100g": 100.56,
+            "nova-group": 4,
+            "energy": 1804,
+            "saturated-fat_value": 5.3,
+            "energy-kcal_value": 432,
+            "energy_serving": 541,
+            "fat_100g": 23,
+            "saturated-fat_unit": "g",
+            "sodium_serving": 0.0588,
+            "energy-kj_value": 1804,
+            "energy-kj": 1804,
+            "carbon-footprint-from-known-ingredients_product": 241,
+            "sugars_value": 32,
+            "proteins_100g": 5.5,
+            "nutrition-score-fr": 15,
+            "sodium": 0.196,
+            "sugars": 32,
+            "carbohydrates": 51,
+            "energy-kcal_serving": 130
+        },
+        "purchase_places_tags": [],
+        "generic_name_fr_imported": "Petits gâteaux au chocolat et aux pépites de chocolat sans gluten à base de farine de riz et amidon de pomme de terre.",
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/356/007/097/6867/ingredients_fr.26.200.jpg",
+        "ingredients_text_nl": "_Eieren_, suiker, koolzaadolie, _melk_chocolade 8,7% (suiker, volle_melk_poeder, cacaoboter, cacaomassa, _lactose_, emulgator: zonnebloemlecithinen, natuurlijk vanillearoma), chocoladestukjes 8,7% (cacaomassa, suiker, cacaoboter), rijstbloem 5,5%, aardappelzetmeel 5,5%, bevochtigingsmiddel: glycerol, magerecacaopoeder, glucosestroop, invertsuikerstroop, rijstzetmeel, rijsmiddelen: difosfaten en natriumcarbonaten, voedingszuur: citroenzuur, conserveermiddel: kaliumsorbaat, stabilisator: xanthaangom.\nKan sporen bevatten van noten.",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/356/007/097/6867/nutrition_fr.5.200.jpg",
+        "conservation_conditions": "A consommer de préférence avant le / n° de lot : voir sur le côté de l'emballage.\nA conserver à température ambiante et à l'abri de l'humidité.\n\nSUR LE SACHET individuel: \nA consommer de préférence avant le / n° de lot : voir sur le côté de l'emballage cartonné\nA conserver à température ambiante et à l'abri de l'humidité.",
+        "owner": "org-carrefour"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/3596710352418.json
+++ b/testdata/product/3596710352418.json
@@ -1,0 +1,1029 @@
+{
+    "status": 1,
+    "code": "3596710352418",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {
+            "ciqual_food_name:fr": "Sauce tomate à la viande ou Sauce bolognaise, préemballée",
+            "ciqual_food_name:en": "Tomato sauce, with meat or Bolognese sauce, prepacked"
+        },
+        "popularity_tags": [
+            "at-least-5-scans-2019",
+            "bottom-25-percent-scans-2019",
+            "top-80-percent-scans-2019",
+            "top-85-percent-scans-2019",
+            "top-90-percent-scans-2019",
+            "top-100000-fr-scans-2019",
+            "top-country-fr-scans-2019",
+            "at-least-5-fr-scans-2019",
+            "top-100000-scans-2020",
+            "at-least-5-scans-2020",
+            "top-75-percent-scans-2020",
+            "top-80-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-100000-fr-scans-2020",
+            "top-country-fr-scans-2020",
+            "at-least-5-fr-scans-2020",
+            "top-50000-be-scans-2020",
+            "top-100000-be-scans-2020"
+        ],
+        "categories_tags": [
+            "en:groceries",
+            "en:meat-based-products",
+            "en:sauces",
+            "en:meat-based-sauces",
+            "en:pasta-sauces",
+            "en:meat-based-pasta-sauces",
+            "en:bolognese-sauces"
+        ],
+        "traces_hierarchy": [
+            "en:milk"
+        ],
+        "allergens_hierarchy": [
+            "en:celery"
+        ],
+        "origins_tags": [],
+        "product_name_fr": "Sauce Bolognaise",
+        "generic_name": "Sauce Bolognaise",
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1510396712,
+        "additives_n": 2,
+        "emb_codes_20141016": "EMB 84029A",
+        "carbon_footprint_from_known_ingredients_debug": "en:tomato-puree 69% x 2.9 = 200.1 g - en:beef-meat 14.2% x 35.8 = 508.36 g - en:vegetable 9.6% x 0.3 = 2.88 g - ",
+        "pnns_groups_2_tags": [
+            "dressings-and-sauces",
+            "known"
+        ],
+        "emb_codes_tags": [
+            "emb-84029a"
+        ],
+        "correctors_tags": [
+            "yuka.SHZrZE9iby8vK3N6c01NeThEL2VvYzk0dzhTS1lVT2xjTm8ySVE9PQ",
+            "openfoodfacts-contributors",
+            "tacite-mass-editor",
+            "teolemon"
+        ],
+        "carbon_footprint_from_meat_or_fish_debug": "en:beef-meat => en:beef-meat 14.2% x 35.8 = 508.36 g",
+        "sortkey": 1547409102,
+        "categories_old": "Epicerie, Produits à la viande, Sauces, Sauces à la viande, Sauces pour pâtes, Sauce tomate à la viande, Sauces bolognaises",
+        "categories_properties": {
+            "ciqual_food_code:en": "11114",
+            "agribalyse_food_code:en": "11114"
+        },
+        "completeness": 0.966666666666667,
+        "traces_from_user": "(fr) en:milk",
+        "labels_tags": [
+            "fr:premier-prix"
+        ],
+        "nutrition_grades_tags": [
+            "b"
+        ],
+        "informers_tags": [
+            "zoubiddaaa",
+            "yuka.SHZrZE9iby8vK3N6c01NeThEL2VvYzk0dzhTS1lVT2xjTm8ySVE9PQ",
+            "kiliweb"
+        ],
+        "lang": "fr",
+        "vitamins_tags": [],
+        "origins_lc": "fr",
+        "interface_version_modified": "20150316.jqm2",
+        "additives_tags": [
+            "en:e14xx",
+            "en:e270"
+        ],
+        "unique_scans_n": 6,
+        "unknown_nutrients_tags": [],
+        "stores_debug_tags": [],
+        "nova_group_debug": " -- ingredients/en:sugar : 3 -- additives/en:e14xx : 4",
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "traces_tags": [
+            "en:milk"
+        ],
+        "packaging_tags": [
+            "bocal-en-verre"
+        ],
+        "nova_groups": "4",
+        "allergens_from_ingredients": "céleri",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-free",
+            "en:non-vegan",
+            "en:non-vegetarian"
+        ],
+        "nutrient_levels": {
+            "sugars": "moderate",
+            "salt": "moderate",
+            "fat": "moderate",
+            "saturated-fat": "low"
+        },
+        "nutriscore_data": {
+            "proteins": 3.4,
+            "negative_points": 6,
+            "sugars_points": 1,
+            "score": 2,
+            "sodium_value": 360,
+            "positive_points": 4,
+            "is_water": 0,
+            "saturated_fat_value": 1.3,
+            "proteins_points": 2,
+            "saturated_fat_points": 1,
+            "saturated_fat_ratio": 36.1111111111111,
+            "proteins_value": 3.4,
+            "saturated_fat_ratio_points": 5,
+            "fiber_points": 0,
+            "grade": "b",
+            "is_cheese": 0,
+            "energy": 368,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 78.6,
+            "fiber": 0,
+            "energy_points": 1,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 2,
+            "sodium_points": 3,
+            "is_fat": 0,
+            "energy_value": 368,
+            "is_beverage": 0,
+            "fiber_value": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 78.6,
+            "saturated_fat_ratio_value": 36.1,
+            "sugars_value": 5.6,
+            "saturated_fat": 1.3,
+            "sodium": 360,
+            "sugars": 5.6
+        },
+        "created_t": 1360420289,
+        "nova_group": 4,
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "b",
+        "nucleotides_tags": [],
+        "scans_n": 8,
+        "images": {
+            "1": {
+                "uploaded_t": "1509477700",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 254
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 63
+                    },
+                    "full": {
+                        "h": 2899,
+                        "w": 1840
+                    }
+                }
+            },
+            "2": {
+                "uploaded_t": "1510396712",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 144,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 36,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 624,
+                        "w": 1731
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "y1": null,
+                "rev": "9",
+                "y2": null,
+                "x2": null,
+                "ocr": 1,
+                "white_magic": "0",
+                "x1": null,
+                "sizes": {
+                    "400": {
+                        "h": 144,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 36,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 72,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 624,
+                        "w": 1731
+                    }
+                },
+                "angle": null,
+                "orientation": "0",
+                "normalize": "0",
+                "geometry": "0x0-0-0",
+                "imgid": "2"
+            }
+        },
+        "ingredients_text_with_allergens_fr": "Purée de tomates 69%, viande de boeuf 14,2%, légumes 9,6% (oignons, carottes, <span class=\"allergen\">céleri</span>), sucre, sel, huile de colza, amidon modifié de pomme de terre, gras de boeuf, acidifiant (acide lactique), arôme, épices, plantes aromatiques, ail",
+        "ingredients_n": 17,
+        "editors_tags": [
+            "teolemon",
+            "yuka.SHZrZE9iby8vK3N6c01NeThEL2VvYzk0dzhTS1lVT2xjTm8ySVE9PQ",
+            "openfoodfacts-contributors",
+            "kiliweb",
+            "tacite-mass-editor",
+            "zoubiddaaa"
+        ],
+        "allergens_tags": [
+            "en:celery"
+        ],
+        "countries_lc": "fr",
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "code": "3596710352418",
+        "codes_tags": [
+            "code-13",
+            "3596710352418",
+            "359671035241x",
+            "35967103524xx",
+            "3596710352xxx",
+            "359671035xxxx",
+            "35967103xxxxx",
+            "3596710xxxxxx",
+            "359671xxxxxxx",
+            "35967xxxxxxxx",
+            "3596xxxxxxxxx",
+            "359xxxxxxxxxx",
+            "35xxxxxxxxxxx",
+            "3xxxxxxxxxxxx"
+        ],
+        "labels": "Premier prix",
+        "last_modified_by": "teolemon",
+        "last_edit_dates_tags": [
+            "2019-01-13",
+            "2019-01",
+            "2019"
+        ],
+        "entry_dates_tags": [
+            "2013-02-09",
+            "2013-02",
+            "2013"
+        ],
+        "creator": "zoubiddaaa",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "pour",
+            "bolognaise",
+            "premier",
+            "sauce",
+            "pouce",
+            "produit",
+            "la",
+            "prix",
+            "auchan",
+            "viande",
+            "pate",
+            "epicerie"
+        ],
+        "amino_acids_tags": [],
+        "ingredients_debug": [
+            "Purée de tomates 69%",
+            ",",
+            null,
+            null,
+            null,
+            " viande de boeuf 14",
+            ",",
+            null,
+            null,
+            null,
+            "2%",
+            ",",
+            null,
+            null,
+            null,
+            " légumes 9",
+            ",",
+            null,
+            null,
+            null,
+            "6% ",
+            "(",
+            "(",
+            null,
+            null,
+            "oignons",
+            ",",
+            null,
+            null,
+            null,
+            " carottes",
+            ",",
+            null,
+            null,
+            null,
+            " céleri)",
+            ",",
+            null,
+            null,
+            null,
+            " sucre",
+            ",",
+            null,
+            null,
+            null,
+            " sel",
+            ",",
+            null,
+            null,
+            null,
+            " huile de colza",
+            ",",
+            null,
+            null,
+            null,
+            " amidon modifié de pomme de terre",
+            ",",
+            null,
+            null,
+            null,
+            " gras de boeuf",
+            ",",
+            null,
+            null,
+            null,
+            " acidifiant ",
+            ":",
+            ":",
+            null,
+            null,
+            " ",
+            "(",
+            "(",
+            null,
+            null,
+            "acide lactique)",
+            ",",
+            null,
+            null,
+            null,
+            " arôme",
+            ",",
+            null,
+            null,
+            null,
+            " épices",
+            ",",
+            null,
+            null,
+            null,
+            " plantes aromatiques",
+            ",",
+            null,
+            null,
+            null,
+            " ail"
+        ],
+        "languages_codes": {
+            "fr": 4
+        },
+        "labels_lc": "fr",
+        "packaging": "Bocal en verre",
+        "minerals_tags": [],
+        "last_image_dates_tags": [
+            "2017-11-11",
+            "2017-11",
+            "2017"
+        ],
+        "popularity_key": 19900000006,
+        "expiration_date": "08/11/15",
+        "data_quality_warnings_tags": [],
+        "misc_tags": [
+            "en:nutrition-no-fiber",
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-no-fiber-or-fruits-vegetables-nuts",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "ecoscore_score": 22,
+        "photographers_tags": [
+            "kiliweb"
+        ],
+        "last_modified_t": 1547409102,
+        "ingredients": [
+            {
+                "percent_min": "69",
+                "percent_estimate": "69",
+                "percent": "69",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "69",
+                "id": "en:crushed-tomato",
+                "text": "Purée de tomates"
+            },
+            {
+                "percent_min": "14.2",
+                "percent_estimate": "14.2",
+                "percent": "14.2",
+                "vegan": "no",
+                "vegetarian": "no",
+                "percent_max": "14.2",
+                "id": "en:beef-meat",
+                "text": "viande de boeuf"
+            },
+            {
+                "percent_min": "9.6",
+                "percent_estimate": "9.6",
+                "percent": "9.6",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "9.6",
+                "id": "en:vegetable",
+                "text": "légumes"
+            },
+            {
+                "percent_max": 7.2,
+                "id": "en:sugar",
+                "text": "sucre",
+                "percent_estimate": 3.96,
+                "percent_min": 0.72,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 5.36,
+                "id": "en:salt",
+                "percent_min": 0,
+                "percent_estimate": 1.62,
+                "text": "sel",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": 0,
+                "percent_estimate": 0.810000000000002,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "from_palm_oil": "no",
+                "percent_max": 4.02,
+                "id": "en:colza-oil",
+                "text": "huile de colza"
+            },
+            {
+                "percent_max": 3.216,
+                "id": "en:e1404",
+                "percent_estimate": 0.405000000000001,
+                "percent_min": 0,
+                "text": "amidon modifié de pomme de terre",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_estimate": 0.202500000000001,
+                "percent_min": 0,
+                "vegan": "no",
+                "from_palm_oil": "no",
+                "vegetarian": "maybe",
+                "percent_max": 2.68,
+                "id": "en:beef-fat",
+                "text": "gras de boeuf"
+            },
+            {
+                "percent_max": 2.29714285714286,
+                "id": "en:acid",
+                "percent_min": 0,
+                "percent_estimate": 0.10125,
+                "text": "acidifiant"
+            },
+            {
+                "percent_max": 2.01,
+                "id": "en:flavouring",
+                "text": "arôme",
+                "percent_min": 0,
+                "percent_estimate": 0.0506249999999966,
+                "vegan": "maybe",
+                "vegetarian": "maybe"
+            },
+            {
+                "percent_max": 1.78666666666667,
+                "id": "en:spice",
+                "text": "épices",
+                "percent_min": 0,
+                "percent_estimate": 0.0253124999999983,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 1.608,
+                "id": "en:herb",
+                "percent_estimate": 0.0126562499999991,
+                "percent_min": 0,
+                "text": "plantes aromatiques",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 1.46181818181818,
+                "id": "en:garlic",
+                "percent_min": 0,
+                "percent_estimate": 0.012656249999992,
+                "text": "ail",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            }
+        ],
+        "nutriscore_grade": "b",
+        "product_name_debug_tags": [],
+        "stores": "Chronodrive, Auchan",
+        "countries": "France",
+        "cities_tags": [
+            "camaret-sur-aigues-vaucluse-france"
+        ],
+        "ciqual_food_name_tags": [
+            "tomato-sauce-with-meat-or-bolognese-sauce-prepacked"
+        ],
+        "other_nutritional_substances_tags": [],
+        "brands": "Pouce,Auchan",
+        "categories": "Epicerie, Produits à la viande, Sauces, Sauces à la viande, Sauces pour pâtes, Sauce tomate à la viande, Sauces bolognaises",
+        "ingredients_text_with_allergens": "Purée de tomates 69%, viande de boeuf 14,2%, légumes 9,6% (oignons, carottes, <span class=\"allergen\">céleri</span>), sucre, sel, huile de colza, amidon modifié de pomme de terre, gras de boeuf, acidifiant (acide lactique), arôme, épices, plantes aromatiques, ail",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:photos-uploaded",
+        "nutrition_grades": "b",
+        "nutrient_levels_tags": [
+            "en:fat-in-moderate-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-moderate-quantity",
+            "en:salt-in-moderate-quantity"
+        ],
+        "known_ingredients_n": 28,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Purée de tomates 69%, viande de boeuf 14,2%, légumes 9,6% (oignons, carottes, céleri), sucre, sel, huile de colza, amidon modifié de pomme de terre, gras de boeuf, acidifiant (acide lactique), arôme, épices, plantes aromatiques, ail",
+        "product_name": "Sauce Bolognaise",
+        "origins": "",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Purée de tomates 69%, viande de boeuf 14,2%, légumes 9,6% (oignons, carottes, céleri), sucre, sel, huile de colza, amidon modifié de pomme de terre, gras de boeuf, acidifiant (acide lactique), arôme, épices, plantes aromatiques, ail",
+        "categories_lc": "fr",
+        "allergens": "",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/359/671/035/2418/ingredients_fr.9.100.jpg",
+        "ecoscore_data": {
+            "grade_be": "e",
+            "status": "known",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -2,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:jar",
+                            "material": "en:glass",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": "81"
+                        }
+                    ],
+                    "warning": "unscored_shape",
+                    "score": 81
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_value": -5,
+                    "transportation_score_ch": 0,
+                    "value_ie": -5,
+                    "transportation_value_de": 0,
+                    "value_fr": -5,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "e",
+            "score": 22,
+            "grade_de": "e",
+            "missing_data_warning": 1,
+            "grade_nl": "e",
+            "score_be": 17,
+            "agribalyse": {
+                "co2_transportation": "0.23999043",
+                "ef_distribution": "0.0091648653",
+                "name_fr": "Sauce tomate à la viande ou Sauce bolognaise, préemballée",
+                "agribalyse_food_code": "11114",
+                "score": 24,
+                "ef_consumption": "0.0064417627",
+                "ef_agriculture": "1.1778623",
+                "name_en": "Tomato sauce, with meat or Bolognese sauce, prepacked",
+                "ef_packaging": "0.021358968",
+                "co2_total": "14.670624",
+                "ef_processing": "0.051069168",
+                "is_beverage": 0,
+                "code": "11114",
+                "co2_processing": "0.23128503",
+                "dqr": "1.98",
+                "co2_consumption": "0.012726077",
+                "ef_total": "1.2838362",
+                "co2_distribution": "0.032692835",
+                "co2_agriculture": "13.967818",
+                "ef_transportation": "0.018750049999999997",
+                "co2_packaging": "0.1959761"
+            },
+            "grade_it": "e",
+            "score_nl": 17,
+            "score_ch": 17,
+            "missing": {
+                "packagings": 1,
+                "labels": 1,
+                "origins": 1
+            },
+            "grade_ie": "e",
+            "score_fr": 17,
+            "score_de": 17,
+            "score_lu": 17,
+            "score_ie": 17,
+            "score_it": 17,
+            "score_es": 17,
+            "grade": "d",
+            "grade_lu": "e",
+            "grade_ch": "e",
+            "grade_es": "e"
+        },
+        "selected_images": {
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/359/671/035/2418/ingredients_fr.9.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/359/671/035/2418/ingredients_fr.9.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/359/671/035/2418/ingredients_fr.9.200.jpg"
+                }
+            }
+        },
+        "rev": 11,
+        "origins_old": "",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "teolemon",
+        "additives_prev_original_tags": [
+            "en:e14xx",
+            "en:e270"
+        ],
+        "data_sources_tags": [
+            "app-yuka",
+            "apps"
+        ],
+        "ingredients_tags": [
+            "en:crushed-tomato",
+            "en:vegetable",
+            "en:tomato",
+            "en:chopped-tomatoes",
+            "en:beef-meat",
+            "en:animal",
+            "en:meat",
+            "en:beef",
+            "en:sugar",
+            "en:salt",
+            "en:colza-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:rapeseed-oil",
+            "en:e1404",
+            "en:beef-fat",
+            "en:fat",
+            "en:animal-fat",
+            "en:acid",
+            "en:flavouring",
+            "en:spice",
+            "en:herb",
+            "en:garlic",
+            "en:root-vegetable",
+            "en:onion",
+            "en:carrot",
+            "en:celery",
+            "en:e270"
+        ],
+        "labels_prev_tags": [
+            "fr:premier-prix"
+        ],
+        "ingredients_from_palm_oil_tags": [],
+        "carbon_footprint_percent_of_known_ingredients": 92.8,
+        "categories_hierarchy": [
+            "en:groceries",
+            "en:meat-based-products",
+            "en:sauces",
+            "en:meat-based-sauces",
+            "en:pasta-sauces",
+            "en:meat-based-pasta-sauces",
+            "en:bolognese-sauces"
+        ],
+        "ecoscore_grade": "d",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "labels_prev_hierarchy": [
+            "fr:Premier prix"
+        ],
+        "ingredients_percent_analysis": 1,
+        "languages": {
+            "en:french": 4
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-11114",
+            "agribalyse-food-code-known",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-11114",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-11114"
+        ],
+        "purchase_places": "Troyes,France",
+        "id": "3596710352418",
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Fat and sauces",
+        "allergens_from_user": "(fr) ",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/359/671/035/2418/ingredients_fr.9.400.jpg",
+        "nutrition_score_warning_no_fiber": 1,
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-more-than-from-meat-or-fish"
+        ],
+        "additives_old_tags": [
+            "en:e14xx",
+            "en:e270"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "ecoscore_tags": [
+            "d"
+        ],
+        "labels_hierarchy": [
+            "fr:Premier prix"
+        ],
+        "origins_hierarchy": [],
+        "complete": 0,
+        "pnns_groups_2": "Dressings and sauces",
+        "nutrition_score_beverage": 0,
+        "new_additives_n": 1,
+        "product_quantity": 420,
+        "ingredients_text_debug": "Purée de tomates 69%, viande de boeuf 14,2%, légumes 9,6% (oignons, carottes, céleri), sucre, sel, huile de colza, amidon modifié de pomme de terre, gras de boeuf, acidifiant : (acide lactique), arôme, épices, plantes aromatiques, ail",
+        "_id": "3596710352418",
+        "countries_tags": [
+            "en:france"
+        ],
+        "ingredients_hierarchy": [
+            "en:crushed-tomato",
+            "en:vegetable",
+            "en:tomato",
+            "en:chopped-tomatoes",
+            "en:beef-meat",
+            "en:animal",
+            "en:meat",
+            "en:beef",
+            "en:sugar",
+            "en:salt",
+            "en:colza-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:rapeseed-oil",
+            "en:e1404",
+            "en:beef-fat",
+            "en:fat",
+            "en:animal-fat",
+            "en:acid",
+            "en:flavouring",
+            "en:spice",
+            "en:herb",
+            "en:garlic",
+            "en:root-vegetable",
+            "en:onion",
+            "en:carrot",
+            "en:celery",
+            "en:e270"
+        ],
+        "stores_tags": [
+            "chronodrive",
+            "auchan"
+        ],
+        "additives_original_tags": [
+            "en:e14xx",
+            "en:e270"
+        ],
+        "nutriscore_score": 2,
+        "compared_to_category": "en:bolognese-sauces",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "17",
+            "11-20"
+        ],
+        "pnns_groups_1_tags": [
+            "fat-and-sauces",
+            "known"
+        ],
+        "additives_old_n": 2,
+        "packagings": [
+            {
+                "shape": "en:jar",
+                "material": "en:glass"
+            }
+        ],
+        "brands_tags": [
+            "pouce",
+            "auchan"
+        ],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-more-than-from-meat-or-fish"
+        ],
+        "data_quality_errors_tags": [],
+        "quantity": "420g",
+        "ingredients_ids_debug": [
+            "puree-de-tomates-69",
+            "viande-de-boeuf-14",
+            "2",
+            "legumes-9",
+            "6",
+            "oignons",
+            "carottes",
+            "celeri",
+            "sucre",
+            "sel",
+            "huile-de-colza",
+            "amidon-modifie-de-pomme-de-terre",
+            "gras-de-boeuf",
+            "acidifiant",
+            "acide-lactique",
+            "arome",
+            "epices",
+            "plantes-aromatiques",
+            "ail"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "en:milk",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 78.6,
+        "ingredients_original_tags": [
+            "en:crushed-tomato",
+            "en:beef-meat",
+            "en:vegetable",
+            "en:sugar",
+            "en:salt",
+            "en:colza-oil",
+            "en:e1404",
+            "en:beef-fat",
+            "en:acid",
+            "en:flavouring",
+            "en:spice",
+            "en:herb",
+            "en:garlic",
+            "en:onion",
+            "en:carrot",
+            "en:celery",
+            "en:e270"
+        ],
+        "data_sources": "App - yuka, Apps",
+        "unknown_ingredients_n": 0,
+        "emb_codes_orig": "EMB 84029A",
+        "checkers_tags": [],
+        "emb_codes": "EMB 84029A",
+        "max_imgid": "2",
+        "editors": [
+            "zoubiddaaa"
+        ],
+        "nutrition_data_per_debug_tags": [],
+        "nutriscore_score_opposite": -2,
+        "brands_debug_tags": [],
+        "generic_name_fr": "Sauce Bolognaise",
+        "nutriments": {
+            "proteins": 3.4,
+            "energy_100g": 368,
+            "carbohydrates_unit": "",
+            "sodium_100g": 0.36,
+            "sugars_100g": 5.6,
+            "energy-kcal": 88,
+            "sodium_value": 0.36,
+            "salt_100g": 0.9,
+            "nova-group_serving": 4,
+            "carbon-footprint-from-meat-or-fish_100g": 508.36,
+            "nutrition-score-fr_100g": 2,
+            "energy_unit": "kcal",
+            "salt_unit": "",
+            "carbohydrates_value": 9.9,
+            "proteins_unit": "",
+            "sugars_unit": "",
+            "fat_unit": "",
+            "salt_value": 0.9,
+            "salt": 0.9,
+            "proteins_value": 3.4,
+            "saturated-fat_100g": 1.3,
+            "energy-kcal_100g": 88,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 78.6,
+            "saturated-fat": 1.3,
+            "fat_value": 3.6,
+            "carbon-footprint-from-known-ingredients_100g": 711.34,
+            "energy": 368,
+            "nova-group": 4,
+            "saturated-fat_value": 1.3,
+            "energy-kcal_value": 88,
+            "nova-group_100g": 4,
+            "fat_100g": 3.6,
+            "saturated-fat_unit": "",
+            "energy_value": 88,
+            "carbon-footprint-from-known-ingredients_product": 2990,
+            "proteins_100g": 3.4,
+            "sugars_value": 5.6,
+            "sodium_unit": "g",
+            "nutrition-score-fr": 2,
+            "sodium": 0.36,
+            "carbohydrates_100g": 9.9,
+            "sugars": 5.6,
+            "carbohydrates": 9.9,
+            "fat": 3.6,
+            "energy-kcal_unit": "kcal",
+            "carbon-footprint-from-meat-or-fish_product": 2140
+        },
+        "purchase_places_tags": [
+            "troyes",
+            "france"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/359/671/035/2418/ingredients_fr.9.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/3800020430781.json
+++ b/testdata/product/3800020430781.json
@@ -1,0 +1,1320 @@
+{
+    "status": 1,
+    "code": "3800020430781",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {
+            "ciqual_food_name:fr": "Chocolat, en tablette -aliment moyen-",
+            "ciqual_food_name:en": "Chocolate bar"
+        },
+        "popularity_tags": [
+            "bottom-25-percent-scans-2020",
+            "bottom-20-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-country-fr-scans-2020"
+        ],
+        "categories_tags": [
+            "en:snacks",
+            "en:sweet-snacks",
+            "en:cocoa-and-its-products",
+            "en:confectioneries",
+            "en:bars",
+            "en:chocolate-candies",
+            "en:chocolate-bars",
+            "en:chocolate-biscuity-bars"
+        ],
+        "traces_hierarchy": [
+            "en:nuts",
+            "en:peanuts"
+        ],
+        "allergens_hierarchy": [
+            "en:gluten",
+            "en:milk"
+        ],
+        "origins_tags": [],
+        "product_name_fr": "Kit Kat Chunky Double Caramel",
+        "generic_name": "Gaufrette croustillante nappée d'un caramel fondant 10,5% et d'un caramel croquant 12,1% et enrobée de chocolat au lait 60%.",
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1418509994,
+        "additives_n": 2,
+        "emb_codes_20141016": "",
+        "pnns_groups_2_tags": [
+            "biscuits-and-cakes",
+            "known"
+        ],
+        "allergens_lc": "en",
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "tacite",
+            "moon-rabbit",
+            "desan",
+            "teolemon",
+            "musarana"
+        ],
+        "sortkey": 1587211836,
+        "categories_old": "Snacks, Snacks sucrés, Confiseries, Barres, Confiseries chocolatées, Barres chocolatées, Barres chocolatées biscuitées",
+        "categories_properties": {
+            "ciqual_food_code:en": "31120"
+        },
+        "completeness": 0.9,
+        "traces_from_user": "(en) en:nuts,en:peanuts",
+        "labels_tags": [
+            "en:sustainable-farming",
+            "en:utz-certified",
+            "fr:nestle-cocoa-plan"
+        ],
+        "nutrition_grades_tags": [
+            "e"
+        ],
+        "informers_tags": [
+            "tacite",
+            "desan",
+            "teolemon"
+        ],
+        "lang": "fr",
+        "vitamins_tags": [],
+        "origins_lc": "fr",
+        "interface_version_modified": "20190830",
+        "additives_tags": [
+            "en:e322",
+            "en:e322i",
+            "en:e500"
+        ],
+        "unique_scans_n": 1,
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/380/002/043/0781/nutrition_fr.7.400.jpg",
+        "unknown_nutrients_tags": [],
+        "nova_group_debug": " -- ingredients/en:sugar : 3 -- ingredients/en:flavouring : 4",
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "traces_tags": [
+            "en:nuts",
+            "en:peanuts"
+        ],
+        "packaging_tags": [
+            "sachet",
+            "plastique"
+        ],
+        "nova_groups": "4",
+        "allergens_from_ingredients": "lait, blé, crème, beurre, lait écrémé, petit-lait, beurre",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/380/002/043/0781/front_fr.5.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:palm-oil",
+            "en:non-vegan",
+            "en:vegetarian-status-unknown"
+        ],
+        "nutrient_levels": {
+            "sugars": "high",
+            "salt": "low",
+            "fat": "high",
+            "saturated-fat": "high"
+        },
+        "nutriscore_data": {
+            "proteins": 6.5,
+            "negative_points": 27,
+            "sugars_points": 10,
+            "sodium_value": 96,
+            "score": 26,
+            "positive_points": 1,
+            "is_water": 0,
+            "saturated_fat_value": 16,
+            "proteins_points": 4,
+            "saturated_fat_points": 10,
+            "saturated_fat_ratio": 57.9710144927536,
+            "proteins_value": 6.5,
+            "saturated_fat_ratio_points": 9,
+            "fiber_points": 1,
+            "grade": "e",
+            "is_cheese": 0,
+            "energy": 2176,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 1,
+            "energy_points": 6,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 1,
+            "is_fat": 0,
+            "energy_value": 2176,
+            "is_beverage": 0,
+            "fiber_value": 1,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 58,
+            "sugars_value": 54.8,
+            "saturated_fat": 16,
+            "sodium": 96.012,
+            "sugars": 54.8
+        },
+        "created_t": 1418509935,
+        "nova_group": 4,
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "e",
+        "nucleotides_tags": [],
+        "scans_n": 1,
+        "images": {
+            "nutrition_fr": {
+                "rev": "7",
+                "white_magic": null,
+                "geometry": "1240x596-0-1982",
+                "sizes": {
+                    "400": {
+                        "h": 192,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 48,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 96,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 596,
+                        "w": 1240
+                    }
+                },
+                "normalize": null,
+                "imgid": "1"
+            },
+            "nutrition": {
+                "rev": "7",
+                "white_magic": null,
+                "geometry": "1240x596-0-1982",
+                "sizes": {
+                    "400": {
+                        "h": 192,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 48,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 96,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 596,
+                        "w": 1240
+                    }
+                },
+                "normalize": null,
+                "imgid": "1"
+            },
+            "ingredients": {
+                "rev": "6",
+                "white_magic": null,
+                "geometry": "2399x245-40-1297",
+                "normalize": null,
+                "sizes": {
+                    "400": {
+                        "h": 41,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 10,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 245,
+                        "w": 2399
+                    },
+                    "200": {
+                        "h": 20,
+                        "w": 200
+                    }
+                },
+                "imgid": "1"
+            },
+            "front_fr": {
+                "rev": "5",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 333,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 83,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1942,
+                        "w": 2334
+                    },
+                    "200": {
+                        "h": 166,
+                        "w": 200
+                    }
+                },
+                "normalize": null,
+                "geometry": "2334x1942-24-628",
+                "imgid": "2"
+            },
+            "1": {
+                "uploaded_t": 1418509936,
+                "uploader": "tacite",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 3264,
+                        "w": 2448
+                    }
+                }
+            },
+            "front": {
+                "rev": "5",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 333,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 83,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1942,
+                        "w": 2334
+                    },
+                    "200": {
+                        "h": 166,
+                        "w": 200
+                    }
+                },
+                "normalize": null,
+                "geometry": "2334x1942-24-628",
+                "imgid": "2"
+            },
+            "2": {
+                "uploaded_t": 1418509994,
+                "uploader": "tacite",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 3264,
+                        "w": 2448
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "rev": "6",
+                "white_magic": null,
+                "geometry": "2399x245-40-1297",
+                "normalize": null,
+                "sizes": {
+                    "400": {
+                        "h": 41,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 10,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 245,
+                        "w": 2399
+                    },
+                    "200": {
+                        "h": 20,
+                        "w": 200
+                    }
+                },
+                "imgid": "1"
+            }
+        },
+        "ingredients_text_with_allergens_fr": "Sucre, lait écrémé en poudre, beurre de cacao, nappage caramel fondant (sirop de glucose-fructose, sirop de glucose, lait concentré sucré (<span class=\"allergen\">lait</span>, sucre), huile de palme, matière grasse de lait anhydre, sel, arôme), farine de <span class=\"allergen\">blé</span>, matière grasse végétale (palme), pâte de cacao, matière grasse de lait anhydre, petit-lait filtré en poudre, éclats de caramel 3% (sucre, sirop de glucose, <span class=\"allergen\">crème</span>, <span class=\"allergen\">beurre</span>), poudre de caramel au lait (<span class=\"allergen\">lait écrémé</span>, sucre, <span class=\"allergen\">petit-lait</span>, <span class=\"allergen\">beurre</span>, arôme naturel de vanille), émulsifiant (lécithine de tournesol), arômes, sel, poudre à lever (carbonates de sodium).",
+        "ingredients_n": 35,
+        "editors_tags": [
+            "teolemon",
+            "tacite",
+            "musarana",
+            "desan",
+            "moon-rabbit"
+        ],
+        "traces_lc": "en",
+        "allergens_tags": [
+            "en:gluten",
+            "en:milk"
+        ],
+        "countries_lc": "en",
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "completed_t": 1418510434,
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "code": "3800020430781",
+        "manufacturing_places": "",
+        "codes_tags": [
+            "code-13",
+            "3800020430xxx",
+            "380002043xxxx",
+            "38000204xxxxx",
+            "3800020xxxxxx",
+            "380002xxxxxxx",
+            "38000xxxxxxxx",
+            "3800xxxxxxxxx",
+            "380xxxxxxxxxx",
+            "38xxxxxxxxxxx",
+            "3xxxxxxxxxxxx"
+        ],
+        "labels": "Sustainable farming,UTZ Certified,fr:Nestlé Cocoa Plan",
+        "last_modified_by": "musarana",
+        "last_edit_dates_tags": [
+            "2020-04-18",
+            "2020-04",
+            "2020"
+        ],
+        "entry_dates_tags": [
+            "2014-12-13",
+            "2014-12",
+            "2014"
+        ],
+        "creator": "tacite",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "nappee",
+            "lait",
+            "10",
+            "chocolat",
+            "kat",
+            "biscuity",
+            "chocolate",
+            "gaufrette",
+            "plan",
+            "croquant",
+            "de",
+            "fondant",
+            "certified",
+            "snack",
+            "sustainable",
+            "double",
+            "candie",
+            "bar",
+            "et",
+            "enrobee",
+            "60",
+            "au",
+            "12",
+            "farming",
+            "confectionerie",
+            "sweet",
+            "nestle",
+            "un",
+            "croustillante",
+            "kit",
+            "chunky",
+            "utz",
+            "caramel",
+            "cocoa"
+        ],
+        "amino_acids_tags": [],
+        "link": "",
+        "ingredients_debug": [
+            "Sucre",
+            ",",
+            null,
+            null,
+            null,
+            " lait écrémé en poudre",
+            ",",
+            null,
+            null,
+            null,
+            " beurre de cacao",
+            ",",
+            null,
+            null,
+            null,
+            " nappage caramel fondant ",
+            "(",
+            "(",
+            null,
+            null,
+            "sirop de glucose-fructose",
+            ",",
+            null,
+            null,
+            null,
+            " sirop de glucose",
+            ",",
+            null,
+            null,
+            null,
+            " lait concentré sucré ",
+            "(",
+            "(",
+            null,
+            null,
+            "lait",
+            ",",
+            null,
+            null,
+            null,
+            " sucre)",
+            ",",
+            null,
+            null,
+            null,
+            " huile de palme",
+            ",",
+            null,
+            null,
+            null,
+            " matière grasse de lait anhydre",
+            ",",
+            null,
+            null,
+            null,
+            " sel",
+            ",",
+            null,
+            null,
+            null,
+            " arôme)",
+            ",",
+            null,
+            null,
+            null,
+            " farine de blé",
+            ",",
+            null,
+            null,
+            null,
+            " matière grasse végétale ",
+            "(",
+            "(",
+            null,
+            null,
+            "palme)",
+            ",",
+            null,
+            null,
+            null,
+            " pâte de cacao",
+            ",",
+            null,
+            null,
+            null,
+            " matière grasse de lait anhydre",
+            ",",
+            null,
+            null,
+            null,
+            " petit-lait filtré en poudre",
+            ",",
+            null,
+            null,
+            null,
+            " éclats de caramel 3% ",
+            "(",
+            "(",
+            null,
+            null,
+            "sucre",
+            ",",
+            null,
+            null,
+            null,
+            " sirop de glucose",
+            ",",
+            null,
+            null,
+            null,
+            " crème",
+            ",",
+            null,
+            null,
+            null,
+            " beurre)",
+            ",",
+            null,
+            null,
+            null,
+            " poudre de caramel au lait ",
+            "(",
+            "(",
+            null,
+            null,
+            "lait écrémé",
+            ",",
+            null,
+            null,
+            null,
+            " sucre",
+            ",",
+            null,
+            null,
+            null,
+            " petit-lait",
+            ",",
+            null,
+            null,
+            null,
+            " beurre",
+            ",",
+            null,
+            null,
+            null,
+            " arôme naturel de vanille)",
+            ",",
+            null,
+            null,
+            null,
+            " émulsifiant ",
+            ":",
+            ":",
+            null,
+            null,
+            " ",
+            "(",
+            "(",
+            null,
+            null,
+            "lécithine de tournesol)",
+            ",",
+            null,
+            null,
+            null,
+            " arômes",
+            ",",
+            null,
+            null,
+            null,
+            " sel",
+            ",",
+            null,
+            null,
+            null,
+            " poudre à lever ",
+            ":",
+            ":",
+            null,
+            null,
+            " ",
+            "(",
+            "(",
+            null,
+            null,
+            "carbonates de sodium)."
+        ],
+        "languages_codes": {
+            "fr": 6
+        },
+        "labels_lc": "en",
+        "packaging": "Sachet,Plastique",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/380/002/043/0781/front_fr.5.400.jpg",
+        "popularity_key": 1,
+        "last_image_dates_tags": [
+            "2014-12-13",
+            "2014-12",
+            "2014"
+        ],
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/380/002/043/0781/front_fr.5.200.jpg",
+        "expiration_date": "03/2015",
+        "data_quality_warnings_tags": [],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-not-computed"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "debug_param_sorted_langs": [
+            "fr"
+        ],
+        "photographers_tags": [
+            "tacite"
+        ],
+        "last_modified_t": 1587211836,
+        "ingredients": [
+            {
+                "percent_max": 73,
+                "id": "en:sugar",
+                "text": "Sucre",
+                "percent_min": 6.66666666666667,
+                "percent_estimate": 39.8333333333333,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 38,
+                "id": "en:skimmed-milk-powder",
+                "percent_min": "3",
+                "percent_estimate": 20.5,
+                "text": "lait écrémé en poudre",
+                "vegan": "no",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 26.3333333333333,
+                "id": "en:cocoa-butter",
+                "percent_estimate": 14.6666666666667,
+                "percent_min": "3",
+                "text": "beurre de cacao",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 20.5,
+                "id": "fr:nappage caramel fondant",
+                "percent_estimate": 11.75,
+                "percent_min": "3",
+                "text": "nappage caramel fondant"
+            },
+            {
+                "percent_max": 17,
+                "id": "en:wheat-flour",
+                "percent_min": "3",
+                "percent_estimate": 8.125,
+                "text": "farine de blé",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": "3",
+                "percent_estimate": 4.0625,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "from_palm_oil": "yes",
+                "percent_max": 14.6666666666667,
+                "id": "en:palm-fat",
+                "text": "matière grasse végétale de palme"
+            },
+            {
+                "percent_max": 13,
+                "id": "en:cocoa-paste",
+                "percent_min": "3",
+                "percent_estimate": 2.03125,
+                "text": "pâte de cacao",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 11.75,
+                "id": "fr:matiere-grasse-de-lait-anhydre",
+                "percent_estimate": 1.015625,
+                "percent_min": "3",
+                "text": "matière grasse de lait anhydre"
+            },
+            {
+                "percent_max": 10.7777777777778,
+                "id": "en:filtered-whey-powder",
+                "text": "petit-lait filtré en poudre",
+                "percent_min": "3",
+                "percent_estimate": 0.5078125,
+                "vegan": "no",
+                "vegetarian": "maybe"
+            },
+            {
+                "percent_max": "3",
+                "id": "fr:eclats-de-caramel",
+                "text": "éclats de caramel",
+                "percent": "3",
+                "percent_min": "3",
+                "percent_estimate": -2.4921875
+            },
+            {
+                "percent_max": "3",
+                "id": "fr:caramel-au-lait",
+                "processing": "en:powdered",
+                "percent_estimate": 0,
+                "percent_min": 0,
+                "text": "caramel au lait"
+            },
+            {
+                "percent_max": "3",
+                "id": "en:emulsifier",
+                "percent_estimate": 0,
+                "percent_min": 0,
+                "text": "émulsifiant"
+            },
+            {
+                "percent_max": "3",
+                "id": "en:flavouring",
+                "percent_estimate": 0,
+                "percent_min": 0,
+                "text": "arômes",
+                "vegan": "maybe",
+                "vegetarian": "maybe"
+            },
+            {
+                "percent_max": "3",
+                "id": "en:salt",
+                "text": "sel",
+                "percent_estimate": 0,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": "3",
+                "id": "en:raising-agent",
+                "text": "poudre à lever",
+                "percent_estimate": 0,
+                "percent_min": 0
+            }
+        ],
+        "nutriscore_grade": "e",
+        "stores": "Cora",
+        "countries": "France",
+        "cities_tags": [],
+        "ciqual_food_name_tags": [
+            "chocolate-bar"
+        ],
+        "other_nutritional_substances_tags": [],
+        "brands": "Nestlé",
+        "categories": "Snacks, Snacks sucrés, Confiseries, Barres, Confiseries chocolatées, Barres chocolatées, Barres chocolatées biscuitées",
+        "ingredients_text_with_allergens": "Sucre, lait écrémé en poudre, beurre de cacao, nappage caramel fondant (sirop de glucose-fructose, sirop de glucose, lait concentré sucré (<span class=\"allergen\">lait</span>, sucre), huile de palme, matière grasse de lait anhydre, sel, arôme), farine de <span class=\"allergen\">blé</span>, matière grasse végétale (palme), pâte de cacao, matière grasse de lait anhydre, petit-lait filtré en poudre, éclats de caramel 3% (sucre, sirop de glucose, <span class=\"allergen\">crème</span>, <span class=\"allergen\">beurre</span>), poudre de caramel au lait (<span class=\"allergen\">lait écrémé</span>, sucre, <span class=\"allergen\">petit-lait</span>, <span class=\"allergen\">beurre</span>, arôme naturel de vanille), émulsifiant (lécithine de tournesol), arômes, sel, poudre à lever (carbonates de sodium).",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "nutrition_grades": "e",
+        "nutrient_levels_tags": [
+            "en:fat-in-high-quantity",
+            "en:saturated-fat-in-high-quantity",
+            "en:sugars-in-high-quantity",
+            "en:salt-in-low-quantity"
+        ],
+        "known_ingredients_n": 44,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Sucre, lait écrémé en poudre, beurre de cacao, nappage caramel fondant (sirop de glucose-fructose, sirop de glucose, lait concentré sucré (lait, sucre), huile de palme, matière grasse de lait anhydre, sel, arôme), farine de blé, matière grasse végétale (palme), pâte de cacao, matière grasse de lait anhydre, petit-lait filtré en poudre, éclats de caramel 3% (sucre, sirop de glucose, crème, beurre), poudre de caramel au lait (lait écrémé, sucre, petit-lait, beurre, arôme naturel de vanille), émulsifiant (lécithine de tournesol), arômes, sel, poudre à lever (carbonates de sodium).",
+        "product_name": "Kit Kat Chunky Double Caramel",
+        "origins": "",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Sucre, lait écrémé en poudre, beurre de cacao, nappage caramel fondant (sirop de glucose-fructose, sirop de glucose, lait concentré sucré (lait, sucre), huile de palme, matière grasse de lait anhydre, sel, arôme), farine de blé, matière grasse végétale (palme), pâte de cacao, matière grasse de lait anhydre, petit-lait filtré en poudre, éclats de caramel 3% (sucre, sirop de glucose, crème, beurre), poudre de caramel au lait (lait écrémé, sucre, petit-lait, beurre, arôme naturel de vanille), émulsifiant (lécithine de tournesol), arômes, sel, poudre à lever (carbonates de sodium).",
+        "categories_lc": "fr",
+        "serving_quantity": 21,
+        "allergens": "en:gluten,en:milk",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/380/002/043/0781/ingredients_fr.6.100.jpg",
+        "ecoscore_data": {
+            "agribalyse": {
+                "warning": "missing_agribalyse_match"
+            },
+            "status": "unknown",
+            "missing_agribalyse_match_warning": 1,
+            "adjustments": {
+                "production_system": {
+                    "value": 10,
+                    "label": "en:utz-certified"
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:bag",
+                            "material": "en:plastic",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": "0"
+                        }
+                    ],
+                    "score": 0
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "transportation_score_lu": 0,
+                    "value_it": -5,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_ch": 0,
+                    "epi_value": -5,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 0,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "threatened_species": {
+                    "ingredient": "en:palm-oil",
+                    "value": -10
+                }
+            },
+            "missing": {
+                "agb_category": 1,
+                "origins": 1
+            }
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/380/002/043/0781/nutrition_fr.7.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/380/002/043/0781/nutrition_fr.7.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/380/002/043/0781/nutrition_fr.7.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/380/002/043/0781/ingredients_fr.6.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/380/002/043/0781/ingredients_fr.6.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/380/002/043/0781/ingredients_fr.6.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/380/002/043/0781/front_fr.5.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/380/002/043/0781/front_fr.5.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/380/002/043/0781/front_fr.5.200.jpg"
+                }
+            }
+        },
+        "rev": 13,
+        "origins_old": "",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 1,
+        "last_editor": "musarana",
+        "additives_prev_original_tags": [
+            "en:e322",
+            "en:e500"
+        ],
+        "ingredients_tags": [
+            "en:sugar",
+            "en:skimmed-milk-powder",
+            "en:dairy",
+            "en:milk-powder",
+            "en:cocoa-butter",
+            "en:cocoa",
+            "fr:nappage-caramel-fondant",
+            "en:wheat-flour",
+            "en:cereal",
+            "en:flour",
+            "en:wheat",
+            "en:cereal-flour",
+            "en:palm-fat",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:palm-oil-and-fat",
+            "en:cocoa-paste",
+            "fr:matiere-grasse-de-lait-anhydre",
+            "en:filtered-whey-powder",
+            "en:whey",
+            "en:whey-powder",
+            "fr:eclats-de-caramel",
+            "fr:caramel-au-lait",
+            "en:emulsifier",
+            "en:flavouring",
+            "en:salt",
+            "en:raising-agent",
+            "en:glucose-fructose-syrup",
+            "en:glucose",
+            "en:fructose",
+            "en:glucose-syrup",
+            "en:sweetened-condensed-milk",
+            "en:milk",
+            "en:condensed-milk",
+            "en:palm-oil",
+            "en:cream",
+            "en:butter",
+            "en:skimmed-milk",
+            "en:natural-vanilla-flavouring",
+            "en:natural-flavouring",
+            "en:vanilla-flavouring",
+            "en:sunflower-lecithin",
+            "en:e322",
+            "en:e322i",
+            "en:e500"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/380/002/043/0781/nutrition_fr.7.100.jpg",
+        "ingredients_from_palm_oil_tags": [
+            "huile-de-palme"
+        ],
+        "categories_hierarchy": [
+            "en:snacks",
+            "en:sweet-snacks",
+            "en:cocoa-and-its-products",
+            "en:confectioneries",
+            "en:bars",
+            "en:chocolate-candies",
+            "en:chocolate-bars",
+            "en:chocolate-biscuity-bars"
+        ],
+        "ecoscore_grade": "unknown",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ingredients_percent_analysis": 1,
+        "nutrition_data": "on",
+        "languages": {
+            "en:french": 6
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-31120",
+            "ciqual-food-code-known",
+            "agribalyse-unknown"
+        ],
+        "purchase_places": "Courrières,France",
+        "id": "3800020430781",
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Sugary snacks",
+        "nutrition_data_prepared": "",
+        "allergens_from_user": "(en) en:gluten,en:milk",
+        "additives_debug_tags": [
+            "en-e322i-added"
+        ],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/380/002/043/0781/ingredients_fr.6.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "additives_old_tags": [
+            "en:e1403",
+            "en:e322",
+            "en:e500"
+        ],
+        "ingredients_from_palm_oil_n": 1,
+        "ecoscore_tags": [
+            "unknown"
+        ],
+        "labels_hierarchy": [
+            "en:sustainable-farming",
+            "en:utz-certified",
+            "fr:Nestlé Cocoa Plan"
+        ],
+        "origins_hierarchy": [],
+        "complete": 1,
+        "pnns_groups_2": "Biscuits and cakes",
+        "nutrition_score_beverage": 0,
+        "new_additives_n": 1,
+        "product_quantity": 168,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/380/002/043/0781/front_fr.5.100.jpg",
+        "ingredients_text_debug": "Sucre, lait écrémé en poudre, beurre de cacao, nappage caramel fondant (sirop de glucose-fructose, sirop de glucose, lait concentré sucré (lait, sucre), huile de palme, matière grasse de lait anhydre, sel, arôme), farine de blé, matière grasse végétale (palme), pâte de cacao, matière grasse de lait anhydre, petit-lait filtré en poudre, éclats de caramel 3% (sucre, sirop de glucose, crème, beurre), poudre de caramel au lait (lait écrémé, sucre, petit-lait, beurre, arôme naturel de vanille), émulsifiant : (lécithine de tournesol), arômes, sel, poudre à lever : (carbonates de sodium).",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/380/002/043/0781/front_fr.5.400.jpg",
+        "_id": "3800020430781",
+        "countries_tags": [
+            "en:france"
+        ],
+        "ingredients_hierarchy": [
+            "en:sugar",
+            "en:skimmed-milk-powder",
+            "en:dairy",
+            "en:milk-powder",
+            "en:cocoa-butter",
+            "en:cocoa",
+            "fr:nappage caramel fondant",
+            "en:wheat-flour",
+            "en:cereal",
+            "en:flour",
+            "en:wheat",
+            "en:cereal-flour",
+            "en:palm-fat",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:palm-oil-and-fat",
+            "en:cocoa-paste",
+            "fr:matiere-grasse-de-lait-anhydre",
+            "en:filtered-whey-powder",
+            "en:whey",
+            "en:whey-powder",
+            "fr:eclats-de-caramel",
+            "fr:caramel-au-lait",
+            "en:emulsifier",
+            "en:flavouring",
+            "en:salt",
+            "en:raising-agent",
+            "en:glucose-fructose-syrup",
+            "en:glucose",
+            "en:fructose",
+            "en:glucose-syrup",
+            "en:sweetened-condensed-milk",
+            "en:milk",
+            "en:condensed-milk",
+            "en:palm-oil",
+            "en:cream",
+            "en:butter",
+            "en:skimmed-milk",
+            "en:natural-vanilla-flavouring",
+            "en:natural-flavouring",
+            "en:vanilla-flavouring",
+            "en:sunflower-lecithin",
+            "en:e322",
+            "en:e322i",
+            "en:e500"
+        ],
+        "serving_size": "21g",
+        "stores_tags": [
+            "cora"
+        ],
+        "additives_original_tags": [
+            "en:e322i",
+            "en:e500"
+        ],
+        "nutriscore_score": 26,
+        "compared_to_category": "en:chocolate-biscuity-bars",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "35",
+            "31-40"
+        ],
+        "pnns_groups_1_tags": [
+            "sugary-snacks",
+            "known"
+        ],
+        "additives_old_n": 3,
+        "packagings": [
+            {
+                "shape": "en:bag",
+                "material": "en:plastic"
+            }
+        ],
+        "brands_tags": [
+            "nestle"
+        ],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "data_quality_errors_tags": [],
+        "quantity": "168g",
+        "ingredients_ids_debug": [
+            "sucre",
+            "lait-ecreme-en-poudre",
+            "beurre-de-cacao",
+            "nappage-caramel-fondant",
+            "sirop-de-glucose-fructose",
+            "sirop-de-glucose",
+            "lait-concentre-sucre",
+            "lait",
+            "sucre",
+            "huile-de-palme",
+            "matiere-grasse-de-lait-anhydre",
+            "sel",
+            "arome",
+            "farine-de-ble",
+            "matiere-grasse-vegetale",
+            "palme",
+            "pate-de-cacao",
+            "matiere-grasse-de-lait-anhydre",
+            "petit-lait-filtre-en-poudre",
+            "eclats-de-caramel-3",
+            "sucre",
+            "sirop-de-glucose",
+            "creme",
+            "beurre",
+            "poudre-de-caramel-au-lait",
+            "lait-ecreme",
+            "sucre",
+            "petit-lait",
+            "beurre",
+            "arome-naturel-de-vanille",
+            "emulsifiant",
+            "lecithine-de-tournesol",
+            "aromes",
+            "sel",
+            "poudre-a-lever",
+            "carbonates-de-sodium"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "en:nuts,en:peanuts",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "ingredients_original_tags": [
+            "en:sugar",
+            "en:skimmed-milk-powder",
+            "en:cocoa-butter",
+            "fr:nappage caramel fondant",
+            "en:wheat-flour",
+            "en:palm-fat",
+            "en:cocoa-paste",
+            "fr:matiere-grasse-de-lait-anhydre",
+            "en:filtered-whey-powder",
+            "fr:eclats-de-caramel",
+            "fr:caramel-au-lait",
+            "en:emulsifier",
+            "en:flavouring",
+            "en:salt",
+            "en:raising-agent",
+            "en:glucose-fructose-syrup",
+            "en:glucose-syrup",
+            "en:sweetened-condensed-milk",
+            "en:palm-oil",
+            "fr:matiere-grasse-de-lait-anhydre",
+            "en:salt",
+            "en:flavouring",
+            "en:sugar",
+            "en:glucose-syrup",
+            "en:cream",
+            "en:butter",
+            "en:skimmed-milk",
+            "en:sugar",
+            "en:whey",
+            "en:butter",
+            "en:natural-vanilla-flavouring",
+            "en:sunflower-lecithin",
+            "en:e500",
+            "en:milk",
+            "en:sugar"
+        ],
+        "unknown_ingredients_n": 1,
+        "manufacturing_places_tags": [],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "emb_codes": "",
+        "max_imgid": "2",
+        "editors": [
+            "tacite"
+        ],
+        "nutriscore_score_opposite": -26,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/380/002/043/0781/front_fr.5.200.jpg",
+        "generic_name_fr": "Gaufrette croustillante nappée d'un caramel fondant 10,5% et d'un caramel croquant 12,1% et enrobée de chocolat au lait 60%.",
+        "nutriments": {
+            "proteins": 6.5,
+            "salt_serving": 0.0504,
+            "energy_100g": 2176,
+            "carbohydrates_unit": "g",
+            "saturated-fat_serving": 3.36,
+            "energy-kj_100g": 2176,
+            "sodium_100g": 0.096012,
+            "sugars_100g": 54.8,
+            "sodium_value": 0.096012,
+            "proteins_serving": 1.36,
+            "salt_100g": 0.24003,
+            "nova-group_serving": 4,
+            "nutrition-score-fr_100g": 26,
+            "energy_unit": "kJ",
+            "energy-kj_serving": 457,
+            "salt_unit": "g",
+            "proteins_unit": "g",
+            "carbohydrates_value": 61,
+            "sugars_unit": "g",
+            "sugars_serving": 11.5,
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt_value": 0.24003,
+            "salt": 0.24003,
+            "fiber_serving": 0.21,
+            "proteins_value": 6.5,
+            "saturated-fat_100g": 16,
+            "fat_serving": 5.8,
+            "fiber_100g": 1,
+            "saturated-fat": 16,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "fat_value": 27.6,
+            "energy": 2176,
+            "nova-group": 4,
+            "fiber": 1,
+            "saturated-fat_value": 16,
+            "nova-group_100g": 4,
+            "fat_100g": 27.6,
+            "energy_serving": 457,
+            "saturated-fat_unit": "g",
+            "energy_value": 2176,
+            "sodium_serving": 0.0202,
+            "energy-kj_value": 2176,
+            "fiber_value": 1,
+            "fiber_unit": "g",
+            "energy-kj": 2176,
+            "proteins_100g": 6.5,
+            "sugars_value": 54.8,
+            "carbohydrates_serving": 12.8,
+            "sodium_unit": "g",
+            "nutrition-score-fr": 26,
+            "sodium": 0.096012,
+            "carbohydrates_100g": 61,
+            "sugars": 54.8,
+            "carbohydrates": 61,
+            "fat": 27.6
+        },
+        "purchase_places_tags": [
+            "courrieres",
+            "france"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/380/002/043/0781/ingredients_fr.6.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/380/002/043/0781/nutrition_fr.7.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/4000539770708.json
+++ b/testdata/product/4000539770708.json
@@ -1,0 +1,1437 @@
+{
+    "status": 1,
+    "code": "4000539770708",
+    "product": {
+        "lc": "de",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "traces_debug_tags": [],
+        "popularity_tags": [
+            "top-100000-scans-2019",
+            "at-least-5-scans-2019",
+            "bottom-25-percent-scans-2019",
+            "top-80-percent-scans-2019",
+            "top-85-percent-scans-2019",
+            "top-90-percent-scans-2019",
+            "top-50000-de-scans-2019",
+            "top-100000-de-scans-2019",
+            "top-country-de-scans-2019",
+            "top-50000-scans-2020",
+            "top-100000-scans-2020",
+            "at-least-5-scans-2020",
+            "at-least-10-scans-2020",
+            "top-75-percent-scans-2020",
+            "top-80-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-5000-de-scans-2020",
+            "top-10000-de-scans-2020",
+            "top-50000-de-scans-2020",
+            "top-100000-de-scans-2020",
+            "top-country-de-scans-2020",
+            "at-least-5-de-scans-2020",
+            "top-500-us-scans-2020",
+            "top-1000-us-scans-2020",
+            "top-5000-us-scans-2020",
+            "top-10000-us-scans-2020",
+            "top-50000-us-scans-2020",
+            "top-100000-us-scans-2020",
+            "top-500-eg-scans-2020",
+            "top-1000-eg-scans-2020",
+            "top-5000-eg-scans-2020",
+            "top-10000-eg-scans-2020",
+            "top-50000-eg-scans-2020",
+            "top-100000-eg-scans-2020",
+            "top-1000-ae-scans-2020",
+            "top-5000-ae-scans-2020",
+            "top-10000-ae-scans-2020",
+            "top-50000-ae-scans-2020",
+            "top-100000-ae-scans-2020"
+        ],
+        "categories_tags": [
+            "en:snacks",
+            "en:sweet-snacks",
+            "en:cocoa-and-its-products",
+            "en:confectioneries",
+            "en:christmas-foods-and-drinks",
+            "en:chocolates",
+            "en:christmas-sweets",
+            "en:chocolate-molds",
+            "en:milk-chocolates",
+            "en:chocolate-scupltures",
+            "en:christmas-chocolates",
+            "en:chocolate-santa-clauses"
+        ],
+        "traces_hierarchy": [
+            "en:nuts"
+        ],
+        "allergens_hierarchy": [
+            "en:gluten",
+            "en:milk",
+            "en:soybeans"
+        ],
+        "product_name_fr": "Père Noël Chocolat au Lait",
+        "generic_name": "",
+        "origins_tags": [],
+        "languages_hierarchy": [
+            "en:english",
+            "en:french",
+            "en:german"
+        ],
+        "last_image_t": 1554159243,
+        "additives_n": 0,
+        "pnns_groups_2_tags": [
+            "chocolate-products",
+            "known"
+        ],
+        "countries_beforescanbot": "Österreich, Frankreich, Schweiz",
+        "emb_codes_tags": [],
+        "ingredients_text_with_allergens_en": "sugar, cocoa butter, milk powder, cocoa mass, <span class=\"allergen\">lactose</span>, skimmed milk powder, emulsifier (<span class=\"allergen\">soy lecithin</span>), barley malt extract, flavouring,",
+        "correctors_tags": [
+            "twoflower",
+            "openfood-ch-import",
+            "tacite-mass-editor",
+            "yuka.ZHYwbFFZcGZoL1FJeGRwa3h4S013ZkJyMThPU1dtTHVGL0FOSVE9PQ",
+            "beniben",
+            "yukafix",
+            "sebleouf",
+            "date-limite-app",
+            "foodrepo",
+            "inf",
+            "adinos",
+            "scanbot"
+        ],
+        "sortkey": 1608644704,
+        "generic_name_de": "",
+        "categories_old": "Snacks, Sweet snacks, Confectioneries, Christmas foods and drinks, Chocolates, Christmas sweets, Chocolate molds, Milk chocolates, Chocolate Scupltures, Chocolate Santa Clauses, en:christmas-chocolates",
+        "completeness": 0.8875,
+        "categories_properties": {
+            "agribalyse_proxy_food_code:en": "31004"
+        },
+        "labels_tags": [
+            "en:green-dot",
+            "en:made-in-germany"
+        ],
+        "traces_from_user": "(de) en:nuts",
+        "informers_tags": [
+            "twoflower",
+            "openfood-ch-import",
+            "yuka.ZHYwbFFZcGZoL1FJeGRwa3h4S013ZkJyMThPU1dtTHVGL0FOSVE9PQ",
+            "openfoodfacts-contributors",
+            "beniben",
+            "foodrepo",
+            "inf"
+        ],
+        "nutrition_grades_tags": [
+            "e"
+        ],
+        "vitamins_tags": [],
+        "lang": "de",
+        "origins_lc": "de",
+        "interface_version_modified": "20150316.jqm2",
+        "unique_scans_n": 13,
+        "additives_tags": [],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/400/053/977/0708/nutrition_de.9.400.jpg",
+        "unknown_nutrients_tags": [],
+        "stores_debug_tags": [],
+        "nova_group_debug": " -- ingredients/en:sugar : 3 -- ingredients/en:lactose : 4",
+        "countries_hierarchy": [
+            "en:austria",
+            "en:france",
+            "en:germany",
+            "en:switzerland"
+        ],
+        "traces_tags": [
+            "en:nuts"
+        ],
+        "nova_groups": "4",
+        "packaging_tags": [
+            "aluminium",
+            "metal"
+        ],
+        "allergens_from_ingredients": "Milchpulver, Milchzucker, Sojalecithin, Magermilchpulver, Gerstenmalzextrakt",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/400/053/977/0708/front_de.4.100.jpg",
+        "nutrient_levels": {
+            "sugars": "high",
+            "salt": "low",
+            "fat": "high",
+            "saturated-fat": "high"
+        },
+        "ingredients_analysis_tags": [
+            "en:palm-oil-free",
+            "en:non-vegan",
+            "en:maybe-vegetarian"
+        ],
+        "created_t": 1481491617,
+        "nutriscore_data": {
+            "proteins": 7.2,
+            "negative_points": 26,
+            "sugars_points": 10,
+            "score": 26,
+            "sodium_value": 80,
+            "positive_points": 0,
+            "is_water": 0,
+            "saturated_fat_value": 20,
+            "proteins_points": 4,
+            "saturated_fat_points": 10,
+            "saturated_fat_ratio": 60.6060606060606,
+            "proteins_value": 7.2,
+            "saturated_fat_ratio_points": 9,
+            "fiber_points": 0,
+            "grade": "e",
+            "is_cheese": 0,
+            "energy": 2294,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 0,
+            "energy_points": 6,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 0,
+            "is_fat": 0,
+            "energy_value": 2294,
+            "is_beverage": 0,
+            "fiber_value": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 60.6,
+            "sugars_value": 55,
+            "saturated_fat": 20,
+            "sodium": 80,
+            "sugars": 55
+        },
+        "amino_acids_prev_tags": [],
+        "nova_group": 4,
+        "nutrition_grade_fr": "e",
+        "purchase_places_debug_tags": [],
+        "scans_n": 16,
+        "nucleotides_tags": [],
+        "ingredients_text_with_allergens_fr": "Sucre, beurre de cacao, poudre de <span class=\"allergen\">lait</span>, pâte de cacao, <span class=\"allergen\">lactose</span>, poudre de <span class=\"allergen\">lait</span> écrémé, émulsifiant (lécithine de <span class=\"allergen\">soja</span>), extrait de malt d'<span class=\"allergen\">orge</span>, arôme.",
+        "images": {
+            "nutrition_fr": {
+                "y1": "24.5078125",
+                "y2": "168.84375",
+                "rev": "24",
+                "x2": "309.68359375",
+                "white_magic": "false",
+                "x1": "165.37890625",
+                "ocr": 1,
+                "sizes": {
+                    "400": {
+                        "h": 361,
+                        "w": 361
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 361,
+                        "w": 361
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 200
+                    }
+                },
+                "angle": "0",
+                "orientation": "0",
+                "geometry": "361x361-413-61",
+                "normalize": "false",
+                "imgid": "7"
+            },
+            "11": {
+                "uploaded_t": 1554159242,
+                "uploader": "foodrepo",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 563,
+                        "w": 1000
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": "1481491629",
+                "uploader": "twoflower",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 164
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 41
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 491
+                    }
+                }
+            },
+            "6": {
+                "uploaded_t": 1486510514,
+                "uploader": "openfood-ch-import",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 563,
+                        "w": 1000
+                    }
+                }
+            },
+            "9": {
+                "uploaded_t": "1526140694",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 379,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 95,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 1265
+                    }
+                }
+            },
+            "nutrition_de": {
+                "y1": "217.89999389648438",
+                "y2": "295.8999938964844",
+                "rev": "9",
+                "x2": "151.25",
+                "white_magic": "false",
+                "x1": "73.25",
+                "ocr": 1,
+                "sizes": {
+                    "400": {
+                        "h": 234,
+                        "w": 233
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 234,
+                        "w": 233
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 199
+                    }
+                },
+                "angle": "0",
+                "orientation": "0",
+                "geometry": "233x234-219-653",
+                "normalize": "false",
+                "imgid": "3"
+            },
+            "2": {
+                "uploaded_t": "1481491625",
+                "uploader": "twoflower",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 159
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 40
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 477
+                    }
+                }
+            },
+            "front_de": {
+                "y1": -1,
+                "y2": -1,
+                "rev": "4",
+                "x2": -1,
+                "white_magic": null,
+                "x1": -1,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 159
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 40
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 80
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 477
+                    }
+                },
+                "angle": 0,
+                "geometry": "0x0--3--3",
+                "normalize": null,
+                "imgid": "2"
+            },
+            "12": {
+                "uploaded_t": 1554159242,
+                "uploader": "foodrepo",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 563,
+                        "w": 1000
+                    }
+                }
+            },
+            "front_fr": {
+                "y1": "1.3515625",
+                "rev": "21",
+                "y2": "226.54296875",
+                "x2": "240.90625",
+                "white_magic": "false",
+                "x1": "132.77734375",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 194
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 48
+                    },
+                    "full": {
+                        "h": 560,
+                        "w": 271
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 97
+                    }
+                },
+                "angle": "0",
+                "normalize": "false",
+                "geometry": "271x563-331-3",
+                "imgid": "5"
+            },
+            "7": {
+                "uploaded_t": 1486510515,
+                "uploader": "openfood-ch-import",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 563,
+                        "w": 1000
+                    }
+                }
+            },
+            "10": {
+                "uploaded_t": 1554159242,
+                "uploader": "foodrepo",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 563,
+                        "w": 1000
+                    }
+                }
+            },
+            "13": {
+                "uploaded_t": 1554159243,
+                "uploader": "foodrepo",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 563,
+                        "w": 1000
+                    }
+                }
+            },
+            "1": {
+                "uploaded_t": "1481491617",
+                "uploader": "twoflower",
+                "sizes": {
+                    "400": {
+                        "h": 309,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 77,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 427,
+                        "w": 553
+                    }
+                }
+            },
+            "ingredients_de": {
+                "y1": "121.38333129882812",
+                "rev": "8",
+                "y2": "247.38333129882812",
+                "x2": "163.25",
+                "ocr": 1,
+                "x1": "25.25",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 253,
+                        "w": 278
+                    },
+                    "100": {
+                        "h": 91,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 182,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 253,
+                        "w": 278
+                    }
+                },
+                "angle": "0",
+                "orientation": "0",
+                "normalize": "false",
+                "geometry": "278x253-50-244",
+                "imgid": "4"
+            },
+            "4": {
+                "uploaded_t": "1481491633",
+                "uploader": "twoflower",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 314
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 78
+                    },
+                    "full": {
+                        "h": 805,
+                        "w": 631
+                    }
+                }
+            },
+            "8": {
+                "uploaded_t": 1486510515,
+                "uploader": "openfood-ch-import",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 563,
+                        "w": 1000
+                    }
+                }
+            },
+            "5": {
+                "uploaded_t": 1486510514,
+                "uploader": "openfood-ch-import",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 563,
+                        "w": 1000
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "y1": "67.1953125",
+                "rev": "22",
+                "y2": "261.2890625",
+                "x2": "379.3671875",
+                "ocr": 1,
+                "x1": "58.75390625",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 243,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 61,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 121,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 615,
+                        "w": 1014
+                    }
+                },
+                "angle": "0",
+                "orientation": "0",
+                "normalize": "true",
+                "geometry": "1014x615-185-212",
+                "imgid": "9"
+            }
+        },
+        "ingredients_n": 10,
+        "editors_tags": [
+            "inf",
+            "foodrepo",
+            "yuka.ZHYwbFFZcGZoL1FJeGRwa3h4S013ZkJyMThPU1dtTHVGL0FOSVE9PQ",
+            "beniben",
+            "date-limite-app",
+            "openfoodfacts-contributors",
+            "twoflower",
+            "openfood-ch-import",
+            "scanbot",
+            "kiliweb",
+            "tacite-mass-editor",
+            "yukafix",
+            "sebleouf",
+            "adinos"
+        ],
+        "manufacturing_places_debug_tags": [],
+        "allergens_tags": [
+            "en:gluten",
+            "en:milk",
+            "en:soybeans"
+        ],
+        "countries_lc": "de",
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "emb_codes_debug_tags": [],
+        "manufacturing_places": "Deutschland,Allemagne",
+        "code": "4000539770708",
+        "codes_tags": [
+            "code-13",
+            "4000539770xxx",
+            "400053977xxxx",
+            "40005397xxxxx",
+            "4000539xxxxxx",
+            "400053xxxxxxx",
+            "40005xxxxxxxx",
+            "4000xxxxxxxxx",
+            "400xxxxxxxxxx",
+            "40xxxxxxxxxxx",
+            "4xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "scanbot",
+        "labels": "Grüner Punkt, Hergestellt in Deutschland",
+        "entry_dates_tags": [
+            "2016-12-11",
+            "2016-12",
+            "2016"
+        ],
+        "last_edit_dates_tags": [
+            "2021-01-19",
+            "2021-01",
+            "2021"
+        ],
+        "creator": "twoflower",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "sprüngli",
+            "mold",
+            "christmas-chocolate",
+            "noël",
+            "lait",
+            "confectionerie",
+            "snack",
+            "in",
+            "and",
+            "milk",
+            "au",
+            "lindt",
+            "punkt",
+            "santa",
+            "drink",
+            "chocolat",
+            "scuplture",
+            "christma",
+            "sweet",
+            "père",
+            "hergestellt",
+            "clause",
+            "deutschland",
+            "chocolate",
+            "food",
+            "grüner"
+        ],
+        "link": "",
+        "ingredients_debug": [
+            "Zucker",
+            ",",
+            null,
+            null,
+            null,
+            " Kakaobutter",
+            ",",
+            null,
+            null,
+            null,
+            " _Milchpulver_",
+            ",",
+            null,
+            null,
+            null,
+            " Kakaomasse",
+            ",",
+            null,
+            null,
+            null,
+            " _Milchzucker_",
+            ",",
+            null,
+            null,
+            null,
+            " Magermilchpulver",
+            ",",
+            null,
+            null,
+            null,
+            " Emulgator ",
+            "(",
+            "(",
+            null,
+            null,
+            "_Sojalecithin_)",
+            ",",
+            null,
+            null,
+            null,
+            " Gerstenmalzextrakt",
+            ",",
+            null,
+            null,
+            null,
+            " Aroma."
+        ],
+        "labels_lc": "de",
+        "languages_codes": {
+            "de": 5,
+            "fr": 5,
+            "en": 1
+        },
+        "packaging": "Aluminium,Métal",
+        "ingredients_text_en": "sugar, cocoa butter, milk powder, cocoa mass, lactose, skimmed milk powder, emulsifier (soy lecithin), barley malt extract, flavouring,",
+        "packaging_debug_tags": [],
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/400/053/977/0708/front_de.4.400.jpg",
+        "last_image_dates_tags": [
+            "2019-04-02",
+            "2019-04",
+            "2019"
+        ],
+        "popularity_key": 19950000013,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/400/053/977/0708/front_de.4.200.jpg",
+        "expiration_date": "20/04/2018",
+        "data_quality_warnings_tags": [
+            "en:ingredients-en-ending-comma",
+            "en:ingredients-de-ending-comma"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "generic_name_de_debug_tags": [],
+        "generic_name_fr_debug_tags": [],
+        "photographers_tags": [
+            "twoflower",
+            "openfood-ch-import",
+            "kiliweb",
+            "foodrepo"
+        ],
+        "product_name_fr_debug_tags": [],
+        "debug_param_sorted_langs": [
+            "de",
+            "fr"
+        ],
+        "ecoscore_score": 21,
+        "last_modified_t": 1611050930,
+        "ingredients": [
+            {
+                "percent_max": 100,
+                "id": "en:sugar",
+                "percent_estimate": 55.5555555555556,
+                "percent_min": 11.1111111111111,
+                "text": "Zucker",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 50,
+                "id": "en:cocoa-butter",
+                "text": "Kakaobutter",
+                "percent_estimate": 22.2222222222222,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 33.3333333333333,
+                "id": "en:milk-powder",
+                "text": "_Milchpulver_",
+                "percent_min": 0,
+                "percent_estimate": 11.1111111111111,
+                "vegan": "no",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 25,
+                "id": "en:cocoa-paste",
+                "percent_estimate": 5.55555555555556,
+                "percent_min": 0,
+                "text": "Kakaomasse",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 20,
+                "id": "en:lactose",
+                "text": "_Milchzucker_",
+                "percent_estimate": 2.77777777777778,
+                "percent_min": 0,
+                "vegan": "no",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 16.6666666666667,
+                "id": "en:skimmed-milk-powder",
+                "text": "Magermilchpulver",
+                "percent_min": 0,
+                "percent_estimate": 1.38888888888889,
+                "vegan": "no",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 14.2857142857143,
+                "id": "en:emulsifier",
+                "percent_estimate": 0.694444444444443,
+                "percent_min": 0,
+                "text": "Emulgator"
+            },
+            {
+                "percent_max": 12.5,
+                "id": "en:barley-malt-extract",
+                "percent_estimate": 0.347222222222221,
+                "percent_min": 0,
+                "text": "Gerstenmalzextrakt",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 11.1111111111111,
+                "id": "en:flavouring",
+                "percent_min": 0,
+                "percent_estimate": 0.347222222222229,
+                "text": "Aroma",
+                "vegan": "maybe",
+                "vegetarian": "maybe"
+            }
+        ],
+        "nutriscore_grade": "e",
+        "product_name_de": "Père Noël Chocolat au Lait",
+        "stores": "",
+        "countries": "Österreich, Frankreich, Schweiz, en:germany",
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "other_nutritional_substances_tags": [],
+        "cities_tags": [],
+        "brands": "Lindt,Lindt & Sprüngli",
+        "categories": "Imbiss, Süßer Snack, Süßwaren, Weihnachtliches Essen und Getränke, Schokoladen, Weihnachtssüßigkeiten, Schokoladenformteile, Milchschokoladen, Schokoladenfiguren, Weihnachtsschokolade, Schokoladenweihnachtsmänner",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-to-be-completed, en:characteristics-to-be-completed, en:origins-to-be-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:packaging-photo-to-be-selected, en:nutrition-photo-selected, en:ingredients-photo-selected, en:front-photo-selected, en:photos-uploaded",
+        "ingredients_text_with_allergens": "Zucker, Kakaobutter, <span class=\"allergen\">Milchpulver</span>, Kakaomasse, <span class=\"allergen\">Milchzucker</span>, <span class=\"allergen\">Magermilchpulver</span>, Emulgator (<span class=\"allergen\">Sojalecithin</span>), <span class=\"allergen\">Gerstenmalzextrakt</span>, Aroma,",
+        "nutrition_grades": "e",
+        "nutrient_levels_tags": [
+            "en:fat-in-high-quantity",
+            "en:saturated-fat-in-high-quantity",
+            "en:sugars-in-high-quantity",
+            "en:salt-in-low-quantity"
+        ],
+        "known_ingredients_n": 17,
+        "minerals_prev_tags": [],
+        "product_name": "Père Noël Chocolat au Lait",
+        "ingredients_text": "Zucker, Kakaobutter, _Milchpulver_, Kakaomasse, _Milchzucker_, Magermilchpulver, Emulgator (_Sojalecithin_), Gerstenmalzextrakt, Aroma,",
+        "serving_size_debug_tags": [],
+        "origins": "",
+        "languages_tags": [
+            "en:english",
+            "en:french",
+            "en:german",
+            "en:3",
+            "en:multilingual"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Sucre, beurre de cacao, poudre de _lait_, pâte de cacao, _lactose_, poudre de _lait_ écrémé, émulsifiant (lécithine de _soja_), extrait de malt d'_orge_, arôme.",
+        "lang_debug_tags": [],
+        "categories_lc": "de",
+        "allergens": "en:milk,en:soybeans",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/400/053/977/0708/ingredients_de.8.100.jpg",
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "e",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -3,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:heavy-aluminium",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": "72"
+                        }
+                    ],
+                    "warning": "unspecified_shape",
+                    "score": 72
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_ch": 0,
+                    "epi_value": -5,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 0,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "e",
+            "score": 21,
+            "grade_de": "e",
+            "missing_data_warning": 1,
+            "grade_nl": "e",
+            "score_be": 16,
+            "agribalyse": {
+                "co2_transportation": "0.33427006",
+                "ef_distribution": "0.0045906531",
+                "name_fr": "Chocolat au lait, tablette",
+                "score": 24,
+                "agribalyse_food_code": "31004",
+                "ef_agriculture": "1.0783151999999998",
+                "ef_consumption": "0",
+                "name_en": "Milk chocolate bar",
+                "co2_total": "17.574537",
+                "ef_packaging": "0.015600638000000002",
+                "ef_processing": "0.15156988000000002",
+                "is_beverage": 0,
+                "agribalyse_proxy_food_code": "31004",
+                "dqr": "2.99",
+                "co2_processing": "1.6191263",
+                "code": "31004",
+                "co2_consumption": "0",
+                "co2_distribution": "0.014104999",
+                "ef_total": "1.282654",
+                "co2_agriculture": "15.499614",
+                "ef_transportation": "0.03230215",
+                "co2_packaging": "0.10291973"
+            },
+            "grade_it": "e",
+            "score_nl": 16,
+            "missing": {
+                "packagings": 1,
+                "labels": 1,
+                "origins": 1
+            },
+            "grade_ie": "e",
+            "score_ch": 16,
+            "score_de": 16,
+            "score_fr": 16,
+            "score_ie": 16,
+            "score_lu": 16,
+            "score_it": 16,
+            "score_es": 16,
+            "grade_ch": "e",
+            "grade_es": "e",
+            "grade": "d",
+            "grade_lu": "e"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "de": "https://static.openfoodfacts.net/images/products/400/053/977/0708/nutrition_de.9.400.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/400/053/977/0708/nutrition_fr.24.400.jpg"
+                },
+                "thumb": {
+                    "de": "https://static.openfoodfacts.net/images/products/400/053/977/0708/nutrition_de.9.100.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/400/053/977/0708/nutrition_fr.24.100.jpg"
+                },
+                "small": {
+                    "de": "https://static.openfoodfacts.net/images/products/400/053/977/0708/nutrition_de.9.200.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/400/053/977/0708/nutrition_fr.24.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "de": "https://static.openfoodfacts.net/images/products/400/053/977/0708/ingredients_de.8.400.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/400/053/977/0708/ingredients_fr.22.400.jpg"
+                },
+                "thumb": {
+                    "de": "https://static.openfoodfacts.net/images/products/400/053/977/0708/ingredients_de.8.100.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/400/053/977/0708/ingredients_fr.22.100.jpg"
+                },
+                "small": {
+                    "de": "https://static.openfoodfacts.net/images/products/400/053/977/0708/ingredients_de.8.200.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/400/053/977/0708/ingredients_fr.22.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "de": "https://static.openfoodfacts.net/images/products/400/053/977/0708/front_de.4.400.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/400/053/977/0708/front_fr.21.400.jpg"
+                },
+                "thumb": {
+                    "de": "https://static.openfoodfacts.net/images/products/400/053/977/0708/front_de.4.100.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/400/053/977/0708/front_fr.21.100.jpg"
+                },
+                "small": {
+                    "de": "https://static.openfoodfacts.net/images/products/400/053/977/0708/front_de.4.200.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/400/053/977/0708/front_fr.21.200.jpg"
+                }
+            }
+        },
+        "rev": 40,
+        "origins_old": "",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "scanbot",
+        "additives_prev_original_tags": [],
+        "data_sources_tags": [
+            "database-foodrepo-openfood-ch",
+            "databases",
+            "app-yuka",
+            "apps"
+        ],
+        "ingredients_tags": [
+            "en:sugar",
+            "en:cocoa-butter",
+            "en:cocoa",
+            "en:milk-powder",
+            "en:dairy",
+            "en:cocoa-paste",
+            "en:lactose",
+            "en:skimmed-milk-powder",
+            "en:emulsifier",
+            "en:barley-malt-extract",
+            "en:cereal",
+            "en:malt",
+            "en:malted-barley",
+            "en:flavouring",
+            "en:soya-lecithin",
+            "en:e322",
+            "en:e322i"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/400/053/977/0708/nutrition_de.9.100.jpg",
+        "ingredients_from_palm_oil_tags": [],
+        "nutrition_data_prepared_per_debug_tags": [],
+        "categories_hierarchy": [
+            "en:snacks",
+            "en:sweet-snacks",
+            "en:cocoa-and-its-products",
+            "en:confectioneries",
+            "en:christmas-foods-and-drinks",
+            "en:chocolates",
+            "en:christmas-sweets",
+            "en:chocolate-molds",
+            "en:milk-chocolates",
+            "en:chocolate-scupltures",
+            "en:christmas-chocolates",
+            "en:chocolate-santa-clauses"
+        ],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "d",
+        "ingredients_percent_analysis": 1,
+        "nutrition_data": "on",
+        "languages": {
+            "en:german": 5,
+            "en:english": 1,
+            "en:french": 5
+        },
+        "purchase_places": "France,Suisse",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-31004",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-unknown",
+            "agribalyse-known",
+            "agribalyse-31004"
+        ],
+        "id": "4000539770708",
+        "sources": [
+            {
+                "import_t": 1486510515,
+                "fields": [
+                    "countries",
+                    "nutrients.fat",
+                    "nutrients.saturated-fat",
+                    "nutrients.carbohydrates",
+                    "nutrients.energy",
+                    "nutrients.sugars",
+                    "nutrients.fiber",
+                    "nutrients.proteins",
+                    "nutrients.salt"
+                ],
+                "id": "openfood-ch",
+                "url": "https://www.openfood.ch/en/products/15511",
+                "images": [
+                    "5",
+                    "6",
+                    "7",
+                    "8"
+                ]
+            },
+            {
+                "import_t": 1548767967,
+                "fields": [],
+                "manufacturer": "0",
+                "url": "https://www.foodrepo.org/ch/products/15511",
+                "images": [],
+                "source_licence_url": "https://creativecommons.org/licenses/by/4.0/",
+                "id": "openfood-ch",
+                "name": "FoodRepo",
+                "source_licence": "Creative Commons Attribution 4.0 International License"
+            }
+        ],
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Sugary snacks",
+        "allergens_from_user": "(de) en:milk,en:soybeans",
+        "nutrition_data_prepared": "",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/400/053/977/0708/ingredients_de.8.400.jpg",
+        "labels_old": "Grüner Punkt, Hergestellt in Deutschland",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:quantity-contains-e",
+            "en:ingredients-en-ending-comma",
+            "en:ingredients-de-ending-comma"
+        ],
+        "additives_old_tags": [],
+        "origins_hierarchy": [],
+        "ecoscore_tags": [
+            "d"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "labels_hierarchy": [
+            "en:green-dot",
+            "en:made-in-germany"
+        ],
+        "nutrition_score_beverage": 0,
+        "pnns_groups_2": "Chocolate products",
+        "complete": 0,
+        "ingredients_text_fr_debug_tags": [],
+        "product_quantity": "125",
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/400/053/977/0708/front_de.4.100.jpg",
+        "ingredients_text_debug": "Zucker, Kakaobutter, _Milchpulver_, Kakaomasse, _Milchzucker_, Magermilchpulver, Emulgator (_Sojalecithin_), Gerstenmalzextrakt, Aroma.",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/400/053/977/0708/front_de.4.400.jpg",
+        "_id": "4000539770708",
+        "countries_tags": [
+            "en:austria",
+            "en:france",
+            "en:germany",
+            "en:switzerland"
+        ],
+        "ingredients_hierarchy": [
+            "en:sugar",
+            "en:cocoa-butter",
+            "en:cocoa",
+            "en:milk-powder",
+            "en:dairy",
+            "en:cocoa-paste",
+            "en:lactose",
+            "en:skimmed-milk-powder",
+            "en:emulsifier",
+            "en:barley-malt-extract",
+            "en:cereal",
+            "en:malt",
+            "en:malted-barley",
+            "en:flavouring",
+            "en:soya-lecithin",
+            "en:e322",
+            "en:e322i"
+        ],
+        "additives_original_tags": [],
+        "stores_tags": [],
+        "nutriscore_score": 26,
+        "compared_to_category": "en:chocolate-santa-clauses",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "expiration_date_debug_tags": [],
+        "ingredients_n_tags": [
+            "10",
+            "1-10"
+        ],
+        "pnns_groups_1_tags": [
+            "sugary-snacks",
+            "known"
+        ],
+        "additives_old_n": 0,
+        "packagings": [
+            {
+                "material": "en:aluminium"
+            }
+        ],
+        "quantity": "125 g e",
+        "data_quality_info_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:quantity-contains-e"
+        ],
+        "brands_tags": [
+            "lindt",
+            "lindt-sprungli"
+        ],
+        "data_quality_errors_tags": [],
+        "link_debug_tags": [],
+        "ingredients_ids_debug": [
+            "zucker",
+            "kakaobutter",
+            "milchpulver",
+            "kakaomasse",
+            "milchzucker",
+            "magermilchpulver",
+            "emulgator",
+            "sojalecithin",
+            "gerstenmalzextrakt",
+            "aroma"
+        ],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [
+            "en:sugar",
+            "en:cocoa-butter",
+            "en:milk-powder",
+            "en:cocoa-paste",
+            "en:lactose",
+            "en:skimmed-milk-powder",
+            "en:emulsifier",
+            "en:barley-malt-extract",
+            "en:flavouring",
+            "en:soya-lecithin"
+        ],
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "traces": "en:nuts",
+        "data_sources": "Database - FoodRepo / openfood.ch, Databases, App - yuka, Apps",
+        "unknown_ingredients_n": 0,
+        "manufacturing_places_tags": [
+            "deutschland",
+            "allemagne"
+        ],
+        "quantity_debug_tags": [],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "max_imgid": "13",
+        "emb_codes": "",
+        "nutrition_data_per_debug_tags": [],
+        "ingredients_text_with_allergens_de": "Zucker, Kakaobutter, <span class=\"allergen\">Milchpulver</span>, Kakaomasse, <span class=\"allergen\">Milchzucker</span>, <span class=\"allergen\">Magermilchpulver</span>, Emulgator (<span class=\"allergen\">Sojalecithin</span>), <span class=\"allergen\">Gerstenmalzextrakt</span>, Aroma,",
+        "allergens_debug_tags": [],
+        "nutriscore_score_opposite": -26,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/400/053/977/0708/front_de.4.200.jpg",
+        "generic_name_fr": "",
+        "nutriments": {
+            "proteins": 7.2,
+            "energy_100g": 2294,
+            "carbohydrates_unit": "g",
+            "energy-kj_100g": 2294,
+            "sodium_100g": 0.08,
+            "sugars_100g": 55,
+            "sodium_value": 0.08,
+            "nova-group_serving": 4,
+            "salt_100g": 0.2,
+            "nutrition-score-fr_100g": 26,
+            "energy_unit": "kJ",
+            "salt_unit": "g",
+            "proteins_unit": "g",
+            "cocoa_100g": 30,
+            "carbohydrates_value": 55,
+            "sugars_unit": "g",
+            "cocoa_serving": 30,
+            "energy-kj_unit": "kJ",
+            "cocoa_label": "0",
+            "fat_unit": "g",
+            "salt_value": 0.2,
+            "salt": 0.2,
+            "proteins_value": 7.2,
+            "saturated-fat_100g": 20,
+            "fiber_100g": 0,
+            "saturated-fat": 20,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "fat_value": 33,
+            "energy": 2294,
+            "nova-group": 4,
+            "fiber": 0,
+            "saturated-fat_value": 20,
+            "nova-group_100g": 4,
+            "fat_100g": 33,
+            "saturated-fat_unit": "g",
+            "energy_value": 2294,
+            "energy-kj_value": 2294,
+            "fiber_value": 0,
+            "fiber_unit": "g",
+            "cocoa_unit": "g",
+            "energy-kj": 2294,
+            "cocoa": 30,
+            "cocoa_value": 30,
+            "sugars_value": 55,
+            "proteins_100g": 7.2,
+            "sodium_unit": "g",
+            "nutrition-score-fr": 26,
+            "sodium": 0.08,
+            "carbohydrates_100g": 55,
+            "sugars": 55,
+            "carbohydrates": 55,
+            "fat": 33
+        },
+        "purchase_places_tags": [
+            "france",
+            "suisse"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/400/053/977/0708/ingredients_de.8.200.jpg",
+        "ingredients_text_de": "Zucker, Kakaobutter, _Milchpulver_, Kakaomasse, _Milchzucker_, Magermilchpulver, Emulgator (_Sojalecithin_), Gerstenmalzextrakt, Aroma,",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/400/053/977/0708/nutrition_de.9.200.jpg",
+        "product_name_de_debug_tags": []
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/4388858946739.json
+++ b/testdata/product/4388858946739.json
@@ -1,0 +1,1072 @@
+{
+    "status": 1,
+    "code": "4388858946739",
+    "product": {
+        "lc": "de",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "traces_debug_tags": [],
+        "popularity_tags": [
+            "bottom-25-percent-scans-2019",
+            "top-80-percent-scans-2019",
+            "top-85-percent-scans-2019",
+            "top-90-percent-scans-2019",
+            "top-10000-de-scans-2019",
+            "top-50000-de-scans-2019",
+            "top-100000-de-scans-2019",
+            "top-country-de-scans-2019",
+            "bottom-25-percent-scans-2020",
+            "bottom-20-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-50000-de-scans-2020",
+            "top-100000-de-scans-2020",
+            "top-country-de-scans-2020"
+        ],
+        "categories_tags": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:cereals-and-potatoes",
+            "en:seeds",
+            "en:cereals-and-their-products",
+            "en:cereal-grains",
+            "en:rices",
+            "en:long-grain-rices"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "origins_tags": [],
+        "generic_name": "",
+        "languages_hierarchy": [
+            "en:german"
+        ],
+        "last_image_t": 1619091166,
+        "additives_n": 0,
+        "pnns_groups_2_tags": [
+            "cereals",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "smias",
+            "anticultist",
+            "hangy",
+            "freddii",
+            "date-limite-app",
+            "roboto-app",
+            "prepperapp",
+            "kiliweb",
+            "yuka.sY2b0xO6T85zoF3NwEKvlkAeVsb5sxOZCh7luRWt_oqlLqPmStYsyZXaIqs"
+        ],
+        "generic_name_de": "",
+        "sortkey": 1591437103,
+        "product_name_en_debug_tags": [],
+        "categories_old": "Pflanzliche Lebensmittel und Getränke, Pflanzliche Lebensmittel, Getreide und Kartoffeln, Samen, Getreideprodukte, Getreidekörner, Reise, Langkornreis",
+        "completeness": 0.8875,
+        "categories_properties": {
+            "agribalyse_proxy_food_code:en": "9101"
+        },
+        "labels_tags": [
+            "en:organic"
+        ],
+        "traces_from_user": "(de) ",
+        "informers_tags": [
+            "smias",
+            "anticultist",
+            "hangy",
+            "freddii",
+            "date-limite-app",
+            "roboto-app",
+            "yuka.sY2b0xO6T85zoF3NwEKvlnUXDeCB_hn6FUf6xl2Jyd7UPJi0W91S-pL-Eas"
+        ],
+        "generic_name_en_debug_tags": [],
+        "nutrition_grades_tags": [
+            "b"
+        ],
+        "lang": "de",
+        "vitamins_tags": [],
+        "origins_lc": "de",
+        "interface_version_modified": "20150316.jqm2",
+        "ingredients_text_en_debug_tags": [],
+        "additives_tags": [],
+        "unique_scans_n": 1,
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/438/885/894/6739/nutrition_de.46.400.jpg",
+        "generic_name_en": "",
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:germany"
+        ],
+        "nova_group_debug": "no nova group if too many ingredients are unknown: 1 out of 1",
+        "traces_tags": [],
+        "packaging_tags": [
+            "plastik"
+        ],
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/438/885/894/6739/front_de.31.100.jpg",
+        "nutrient_levels": {
+            "salt": "low",
+            "sugars": "low",
+            "fat": "low",
+            "saturated-fat": "low"
+        },
+        "ingredients_analysis_tags": [
+            "en:palm-oil-content-unknown",
+            "en:vegan-status-unknown",
+            "en:vegetarian-status-unknown"
+        ],
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "created_t": 1479970284,
+        "nutriscore_data": {
+            "proteins": 7.7,
+            "negative_points": 4,
+            "sugars_points": 0,
+            "score": 0,
+            "sodium_value": 0,
+            "positive_points": 4,
+            "saturated_fat_value": 0.2,
+            "is_water": 0,
+            "proteins_points": 4,
+            "saturated_fat_points": 0,
+            "saturated_fat_ratio": 22.2222222222222,
+            "proteins_value": 7.7,
+            "saturated_fat_ratio_points": 3,
+            "fiber_points": 0,
+            "grade": "b",
+            "is_cheese": 0,
+            "energy": 1506,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 0,
+            "energy_points": 4,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 0,
+            "is_fat": 0,
+            "energy_value": 1506,
+            "is_beverage": 0,
+            "fiber_value": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 22.2,
+            "sugars_value": 0.5,
+            "saturated_fat": 0.2,
+            "sodium": 0,
+            "sugars": 0.5
+        },
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "b",
+        "purchase_places_debug_tags": [],
+        "scans_n": 1,
+        "nucleotides_tags": [],
+        "images": {
+            "11": {
+                "uploaded_t": 1611948351,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 335
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 84
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 1006
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": "1479970301",
+                "uploader": "smias",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2666,
+                        "w": 2000
+                    }
+                }
+            },
+            "15": {
+                "uploaded_t": 1619091166,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 328
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 82
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 984
+                    }
+                }
+            },
+            "6": {
+                "uploaded_t": "1481873149",
+                "uploader": "smias",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "9": {
+                "uploaded_t": 1585571834,
+                "uploader": "date-limite-app",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1000,
+                        "w": 1000
+                    }
+                }
+            },
+            "nutrition_de": {
+                "y1": "-1",
+                "y2": "-1",
+                "rev": "46",
+                "x2": "-1",
+                "x1": "-1",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 328
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 82
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 984
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 164
+                    }
+                },
+                "coordinates_image_size": "full",
+                "angle": 0,
+                "normalize": null,
+                "geometry": "0x0--1--1",
+                "imgid": "15"
+            },
+            "2": {
+                "uploaded_t": "1479970291",
+                "uploader": "smias",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "front_de": {
+                "y1": "-1",
+                "y2": "-1",
+                "rev": "31",
+                "x2": "-1",
+                "x1": "-1",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 266
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 67
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 133
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 799
+                    }
+                },
+                "coordinates_image_size": "full",
+                "angle": 0,
+                "geometry": "0x0--1--1",
+                "normalize": null,
+                "imgid": "10"
+            },
+            "14": {
+                "uploaded_t": 1616586474,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 353,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 88,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 1361
+                    }
+                }
+            },
+            "12": {
+                "uploaded_t": 1612120671,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 330,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 83,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 1454
+                    }
+                }
+            },
+            "7": {
+                "uploaded_t": 1570973091,
+                "uploader": "date-limite-app",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 235
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 59
+                    },
+                    "full": {
+                        "h": 400,
+                        "w": 235
+                    }
+                }
+            },
+            "10": {
+                "uploaded_t": 1611948350,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 266
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 67
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 799
+                    }
+                }
+            },
+            "1": {
+                "uploaded_t": "1479970284",
+                "uploader": "smias",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "13": {
+                "uploaded_t": 1614537804,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 348,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 87,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 1381
+                    }
+                }
+            },
+            "ingredients_de": {
+                "y1": "64.45001220703126",
+                "y2": "87.45001220703126",
+                "rev": "17",
+                "x2": "219.50000000000003",
+                "white_magic": "false",
+                "x1": "41.50000000000001",
+                "sizes": {
+                    "400": {
+                        "h": 52,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 13,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 26,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 115,
+                        "w": 890
+                    }
+                },
+                "angle": "90",
+                "normalize": "false",
+                "geometry": "890x115-207-322",
+                "imgid": "2"
+            },
+            "4": {
+                "uploaded_t": "1481873138",
+                "uploader": "smias",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "8": {
+                "uploaded_t": 1578853332,
+                "uploader": "date-limite-app",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 1333,
+                        "w": 1000
+                    }
+                }
+            },
+            "5": {
+                "uploaded_t": "1481873144",
+                "uploader": "smias",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            }
+        },
+        "ingredients_n": "1",
+        "manufacturing_places_debug_tags": [],
+        "editors_tags": [
+            "prepperapp",
+            "roboto-app",
+            "freddii",
+            "yuka.sY2b0xO6T85zoF3NwEKvlhR6Y9yCsBT-Lzr4iEylnIuEI8H1Y8Nd-4HjEqs",
+            "yuka.sY2b0xO6T85zoF3NwEKvlmEfS4fhuDKUMD_kx1Wr7Ou1FZ31UPJq_I3QFas",
+            "yuka.sY2b0xO6T85zoF3NwEKvlhNLQYvijT3pPTrvgmKsne-2EpbjZI5L75HjF6s",
+            "hangy",
+            "smias",
+            "yuka.sY2b0xO6T85zoF3NwEKvlmxCUfX8n2vWFyDmwB2K_oeNI83nbI1z3bb9NKg",
+            "kiliweb",
+            "yuka.sY2b0xO6T85zoF3NwEKvlkAeVsb5sxOZCh7luRWt_oqlLqPmStYsyZXaIqs",
+            "date-limite-app",
+            "yuka.sY2b0xO6T85zoF3NwEKvlnUXDeCB_hn6FUf6xl2Jyd7UPJi0W91S-pL-Eas",
+            "anticultist"
+        ],
+        "countries_lc": "en",
+        "allergens_tags": [],
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "emb_codes_debug_tags": [],
+        "code": "4388858946739",
+        "manufacturing_places": "",
+        "codes_tags": [
+            "code-13",
+            "4388858946xxx",
+            "438885894xxxx",
+            "43888589xxxxx",
+            "4388858xxxxxx",
+            "438885xxxxxxx",
+            "43888xxxxxxxx",
+            "4388xxxxxxxxx",
+            "438xxxxxxxxxx",
+            "43xxxxxxxxxxx",
+            "4xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "kiliweb",
+        "labels": "Bio",
+        "last_edit_dates_tags": [
+            "2021-04-22",
+            "2021-04",
+            "2021"
+        ],
+        "entry_dates_tags": [
+            "2016-11-24",
+            "2016-11",
+            "2016"
+        ],
+        "creator": "smias",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "langkornrei",
+            "getränke",
+            "spitzenrei",
+            "getreideprodukte",
+            "samen",
+            "reise",
+            "und",
+            "langkorn",
+            "lebensmittel",
+            "bio",
+            "kartoffeln",
+            "getreide",
+            "getreidekörner",
+            "ja",
+            "pflanzliche"
+        ],
+        "amino_acids_tags": [],
+        "link": "",
+        "ingredients_debug": [
+            "Paraboiled Langkorn Spitzenreis"
+        ],
+        "languages_codes": {
+            "de": 5
+        },
+        "labels_lc": "de",
+        "packaging": "Plastik",
+        "ingredients_text_en": "",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/438/885/894/6739/front_de.31.400.jpg",
+        "last_image_dates_tags": [
+            "2021-04-22",
+            "2021-04",
+            "2021"
+        ],
+        "popularity_key": 13,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/438/885/894/6739/front_de.31.200.jpg",
+        "expiration_date": "31.10.2018",
+        "data_quality_warnings_tags": [
+            "en:ingredients-unknown-score-above-0",
+            "en:ingredients-100-percent-unknown",
+            "en:serving-quantity-under-1g",
+            "en:serving-quantity-less-than-product-quantity-divided-by-1000",
+            "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
+            "en:ecoscore-packaging-packaging-data-missing",
+            "en:ecoscore-production-system-no-label"
+        ],
+        "misc_tags": [
+            "en:nutrition-no-fiber",
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-no-fiber-or-fruits-vegetables-nuts",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "generic_name_de_debug_tags": [],
+        "ecoscore_score": 64,
+        "photographers_tags": [
+            "smias",
+            "date-limite-app",
+            "kiliweb"
+        ],
+        "debug_param_sorted_langs": [
+            "de"
+        ],
+        "last_modified_t": 1619091167,
+        "ingredients": [
+            {
+                "percent_max": 100,
+                "id": "de:Paraboiled Langkorn Spitzenreis",
+                "text": "Paraboiled Langkorn Spitzenreis",
+                "percent_estimate": 100,
+                "percent_min": 100
+            }
+        ],
+        "ingredients_text_de_debug_tags": [],
+        "nutriscore_grade": "b",
+        "countries": "Deutschland",
+        "stores": "Rewe, Alnatura",
+        "product_name_de": "Langkorn Spitzenreis",
+        "other_nutritional_substances_tags": [],
+        "cities_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "brands": "ja!",
+        "categories": "Pflanzliche Lebensmittel und Getränke, Pflanzliche Lebensmittel, Getreide und Kartoffeln, Samen, Getreideprodukte, Getreidekörner, Reise, Langkornreis",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-to-be-completed, en:characteristics-to-be-completed, en:origins-to-be-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:packaging-photo-to-be-selected, en:nutrition-photo-selected, en:ingredients-photo-selected, en:front-photo-selected, en:photos-uploaded",
+        "ingredients_text_with_allergens": "Paraboiled Langkorn Spitzenreis",
+        "nutrition_grades": "b",
+        "nutrient_levels_tags": [
+            "en:fat-in-low-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-low-quantity",
+            "en:salt-in-low-quantity"
+        ],
+        "known_ingredients_n": 0,
+        "minerals_prev_tags": [],
+        "serving_size_debug_tags": [],
+        "ingredients_text": "Paraboiled Langkorn Spitzenreis",
+        "product_name": "Langkorn Spitzenreis",
+        "origins": "",
+        "languages_tags": [
+            "en:german",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "lang_debug_tags": [],
+        "serving_quantity": "0",
+        "categories_lc": "de",
+        "allergens": "",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/438/885/894/6739/ingredients_de.17.100.jpg",
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "c",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:unknown",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "warning": "packaging_data_missing",
+                    "score": 0
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_value": -5,
+                    "transportation_score_ch": 0,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 0,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "c",
+            "score": 64,
+            "grade_de": "c",
+            "missing_data_warning": 1,
+            "grade_nl": "c",
+            "score_be": 59,
+            "agribalyse": {
+                "co2_transportation": "0.34443618",
+                "ef_distribution": "0.011252758",
+                "name_fr": "Riz blanc étuvé, cru",
+                "score": 74,
+                "ef_consumption": "0",
+                "ef_agriculture": "0.24879545",
+                "name_en": "Rice, parboiled, raw",
+                "co2_total": "2.1617032",
+                "ef_packaging": "0.019987624",
+                "ef_processing": "0",
+                "is_beverage": 0,
+                "co2_processing": "0",
+                "code": "9101",
+                "agribalyse_proxy_food_code": "9101",
+                "dqr": "3.61",
+                "co2_consumption": "0",
+                "ef_total": "0.31474413",
+                "co2_distribution": "0.030159429",
+                "co2_agriculture": "1.5176977",
+                "ef_transportation": "0.034708291",
+                "co2_packaging": "0.26940995"
+            },
+            "grade_it": "c",
+            "score_nl": 59,
+            "grade_ie": "c",
+            "score_ch": 59,
+            "missing": {
+                "packagings": 1,
+                "labels": 1,
+                "origins": 1
+            },
+            "score_de": 59,
+            "score_fr": 59,
+            "score_ie": 59,
+            "score_lu": 59,
+            "score_it": 59,
+            "score_es": 59,
+            "grade": "b",
+            "grade_lu": "c",
+            "grade_ch": "c",
+            "grade_es": "c"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "de": "https://static.openfoodfacts.net/images/products/438/885/894/6739/nutrition_de.46.400.jpg"
+                },
+                "thumb": {
+                    "de": "https://static.openfoodfacts.net/images/products/438/885/894/6739/nutrition_de.46.100.jpg"
+                },
+                "small": {
+                    "de": "https://static.openfoodfacts.net/images/products/438/885/894/6739/nutrition_de.46.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "de": "https://static.openfoodfacts.net/images/products/438/885/894/6739/ingredients_de.17.400.jpg"
+                },
+                "thumb": {
+                    "de": "https://static.openfoodfacts.net/images/products/438/885/894/6739/ingredients_de.17.100.jpg"
+                },
+                "small": {
+                    "de": "https://static.openfoodfacts.net/images/products/438/885/894/6739/ingredients_de.17.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "de": "https://static.openfoodfacts.net/images/products/438/885/894/6739/front_de.31.400.jpg"
+                },
+                "thumb": {
+                    "de": "https://static.openfoodfacts.net/images/products/438/885/894/6739/front_de.31.100.jpg"
+                },
+                "small": {
+                    "de": "https://static.openfoodfacts.net/images/products/438/885/894/6739/front_de.31.200.jpg"
+                }
+            }
+        },
+        "rev": 46,
+        "origins_old": "",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "kiliweb",
+        "additives_prev_original_tags": [],
+        "ingredients_tags": [
+            "de:paraboiled-langkorn-spitzenreis"
+        ],
+        "data_sources_tags": [
+            "app-yuka",
+            "apps"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/438/885/894/6739/nutrition_de.46.100.jpg",
+        "product_name_en": "",
+        "ingredients_from_palm_oil_tags": [],
+        "nutrition_data_prepared_per_debug_tags": [],
+        "categories_hierarchy": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:cereals-and-potatoes",
+            "en:seeds",
+            "en:cereals-and-their-products",
+            "en:cereal-grains",
+            "en:rices",
+            "en:long-grain-rices"
+        ],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "b",
+        "nutrition_data": "on",
+        "languages": {
+            "en:german": 5
+        },
+        "purchase_places": "",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-9101",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-unknown",
+            "agribalyse-known",
+            "agribalyse-9101"
+        ],
+        "id": "4388858946739",
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Cereals and potatoes",
+        "allergens_from_user": "(de) ",
+        "nutrition_data_prepared": "",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/438/885/894/6739/ingredients_de.17.400.jpg",
+        "nutrition_score_warning_no_fiber": 1,
+        "labels_old": "Bio",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:ingredients-unknown-score-above-0",
+            "en:ingredients-100-percent-unknown",
+            "en:serving-quantity-under-1g",
+            "en:serving-quantity-less-than-product-quantity-divided-by-1000",
+            "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
+            "en:ecoscore-packaging-packaging-data-missing",
+            "en:ecoscore-production-system-no-label"
+        ],
+        "additives_old_tags": [],
+        "origins_hierarchy": [],
+        "labels_hierarchy": [
+            "en:organic"
+        ],
+        "ecoscore_tags": [
+            "b"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "pnns_groups_2": "Cereals",
+        "complete": 0,
+        "nutrition_score_beverage": 0,
+        "product_quantity": "400",
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/438/885/894/6739/front_de.31.100.jpg",
+        "ingredients_text_debug": "Paraboiled Langkorn Spitzenreis",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/438/885/894/6739/front_de.31.400.jpg",
+        "_id": "4388858946739",
+        "countries_tags": [
+            "en:germany"
+        ],
+        "ingredients_hierarchy": [
+            "de:Paraboiled Langkorn Spitzenreis"
+        ],
+        "serving_size": "62.5",
+        "additives_original_tags": [],
+        "stores_tags": [
+            "rewe",
+            "alnatura"
+        ],
+        "nutriscore_score": 0,
+        "compared_to_category": "en:long-grain-rices",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "expiration_date_debug_tags": [],
+        "ingredients_n_tags": [
+            "1",
+            "1-10"
+        ],
+        "pnns_groups_1_tags": [
+            "cereals-and-potatoes",
+            "known"
+        ],
+        "additives_old_n": 0,
+        "packagings": [
+            {
+                "shape": "en:unknown",
+                "material": "en:unknown"
+            }
+        ],
+        "data_quality_info_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "quantity": "400g",
+        "data_quality_errors_tags": [],
+        "brands_tags": [
+            "ja"
+        ],
+        "link_debug_tags": [],
+        "ingredients_ids_debug": [
+            "paraboiled-langkorn-spitzenreis"
+        ],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [
+            "de:Paraboiled Langkorn Spitzenreis"
+        ],
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "traces": "",
+        "data_sources": "App - yuka, Apps",
+        "unknown_ingredients_n": "1",
+        "manufacturing_places_tags": [],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "emb_codes": "",
+        "max_imgid": "15",
+        "ingredients_text_with_allergens_de": "Paraboiled Langkorn Spitzenreis",
+        "nutriscore_score_opposite": 0,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/438/885/894/6739/front_de.31.200.jpg",
+        "nutriments": {
+            "proteins": 7.7,
+            "energy_100g": 1506,
+            "carbohydrates_unit": "g",
+            "energy-kj_100g": 1506,
+            "sodium_100g": 0,
+            "sugars_100g": 0.5,
+            "energy-kcal": 355,
+            "sodium_value": 0,
+            "salt_100g": 0,
+            "nutrition-score-fr_100g": 0,
+            "energy_unit": "kJ",
+            "salt_unit": "g",
+            "carbohydrates_value": 78.2,
+            "proteins_unit": "g",
+            "sugars_unit": "g",
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt": 0,
+            "salt_value": 0,
+            "proteins_value": 7.7,
+            "saturated-fat_100g": 0.2,
+            "energy-kcal_100g": 355,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "saturated-fat": 0.2,
+            "fat_value": 0.9,
+            "energy": 1506,
+            "saturated-fat_value": 0.2,
+            "energy-kcal_value": 355,
+            "fat_100g": 0.9,
+            "saturated-fat_unit": "g",
+            "energy_value": 1506,
+            "energy-kj_value": 1506,
+            "energy-kj": 1506,
+            "proteins_100g": 7.7,
+            "sugars_value": 0.5,
+            "nutrition-score-fr": 0,
+            "sodium_unit": "g",
+            "carbohydrates_100g": 78.2,
+            "sodium": 0,
+            "sugars": 0.5,
+            "carbohydrates": 78.2,
+            "fat": 0.9,
+            "energy-kcal_unit": "kcal"
+        },
+        "purchase_places_tags": [],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/438/885/894/6739/ingredients_de.17.200.jpg",
+        "ingredients_text_de": "Paraboiled Langkorn Spitzenreis",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/438/885/894/6739/nutrition_de.46.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/5010251168577.json
+++ b/testdata/product/5010251168577.json
@@ -1,0 +1,852 @@
+{
+    "status": 1,
+    "code": "5010251168577",
+    "product": {
+        "lc": "en",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "categories_tags": [
+            "en:dairies",
+            "en:milks",
+            "en:whole-milks"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "origins_tags": [],
+        "generic_name": "",
+        "languages_hierarchy": [
+            "en:english"
+        ],
+        "last_image_t": 1415480731,
+        "additives_n": 0,
+        "emb_codes_20141016": "UK EX001 EC",
+        "pnns_groups_2_tags": [
+            "milk-and-yogurt",
+            "known"
+        ],
+        "emb_codes_tags": [
+            "uk-ex001-ec"
+        ],
+        "correctors_tags": [
+            "tacinte"
+        ],
+        "ingredients_text_with_allergens_en": "Organically produced pasteurised homogenised whole milk",
+        "sortkey": 1415913971,
+        "categories_old": "Dairies, Milks, Whole milks",
+        "completeness": 0.9,
+        "categories_properties": {
+            "agribalyse_proxy_food_code:en": "19024"
+        },
+        "traces_from_user": "(en) ",
+        "labels_tags": [
+            "en:organic",
+            "en:eu-organic",
+            "en:assured-food-standards",
+            "en:gb-org-05",
+            "en:soil-association-organic"
+        ],
+        "nutrition_grades_tags": [
+            "b"
+        ],
+        "informers_tags": [
+            "tacinte"
+        ],
+        "vitamins_tags": [],
+        "lang": "en",
+        "origins_lc": "en",
+        "interface_version_modified": "20120622",
+        "additives_tags": [],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/501/025/116/8577/nutrition_en.11.400.jpg",
+        "unknown_nutrients_tags": [],
+        "generic_name_en": "",
+        "nova_group_debug": "no nova group if too many ingredients are unknown: 1 out of 1",
+        "countries_hierarchy": [
+            "en:united-kingdom"
+        ],
+        "traces_tags": [],
+        "packaging_tags": [
+            "plastic",
+            "bottle"
+        ],
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/501/025/116/8577/front_en.7.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-content-unknown",
+            "en:vegan-status-unknown",
+            "en:vegetarian-status-unknown"
+        ],
+        "nutrient_levels": {
+            "sugars": "low",
+            "salt": "low",
+            "fat": "moderate",
+            "saturated-fat": "moderate"
+        },
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "nutriscore_data": {
+            "proteins": 3.4,
+            "negative_points": 3,
+            "sugars_points": 1,
+            "sodium_value": 0,
+            "score": 1,
+            "positive_points": 2,
+            "is_water": 0,
+            "saturated_fat_value": 2.6,
+            "proteins_points": 2,
+            "saturated_fat_points": 2,
+            "saturated_fat_ratio": 65,
+            "proteins_value": 3.4,
+            "saturated_fat_ratio_points": 10,
+            "fiber_points": 0,
+            "grade": "b",
+            "is_cheese": 0,
+            "energy": 286,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 0,
+            "energy_points": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 0,
+            "is_fat": 0,
+            "energy_value": 286,
+            "is_beverage": 0,
+            "fiber_value": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 65,
+            "sugars_value": 4.7,
+            "saturated_fat": 2.6,
+            "sodium": 0,
+            "sugars": 4.7
+        },
+        "created_t": 1415480593,
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "b",
+        "nucleotides_tags": [],
+        "images": {
+            "front_en": {
+                "rev": "7",
+                "white_magic": null,
+                "geometry": "927x1885-524-272",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 197
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 49
+                    },
+                    "full": {
+                        "h": 1885,
+                        "w": 927
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 98
+                    }
+                },
+                "normalize": "checked",
+                "imgid": "3"
+            },
+            "nutrition": {
+                "rev": "11",
+                "white_magic": null,
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 231,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 58,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 115,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 318,
+                        "w": 551
+                    }
+                },
+                "geometry": "551x318-984-1438",
+                "imgid": "2"
+            },
+            "ingredients": {
+                "rev": "8",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 84,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 21,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 42,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 123,
+                        "w": 583
+                    }
+                },
+                "normalize": "checked",
+                "geometry": "583x123-965-1315",
+                "imgid": "2"
+            },
+            "3": {
+                "uploaded_t": 1415480731,
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2592,
+                        "w": 1944
+                    }
+                }
+            },
+            "nutrition_en": {
+                "rev": "11",
+                "white_magic": null,
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 231,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 58,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 115,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 318,
+                        "w": 551
+                    }
+                },
+                "geometry": "551x318-984-1438",
+                "imgid": "2"
+            },
+            "ingredients_en": {
+                "rev": "8",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 84,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 21,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 42,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 123,
+                        "w": 583
+                    }
+                },
+                "normalize": "checked",
+                "geometry": "583x123-965-1315",
+                "imgid": "2"
+            },
+            "1": {
+                "uploaded_t": 1415480593,
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2592,
+                        "w": 1944
+                    }
+                }
+            },
+            "front": {
+                "rev": "7",
+                "white_magic": null,
+                "geometry": "927x1885-524-272",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 197
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 49
+                    },
+                    "full": {
+                        "h": 1885,
+                        "w": 927
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 98
+                    }
+                },
+                "normalize": "checked",
+                "imgid": "3"
+            },
+            "2": {
+                "uploaded_t": 1415480729,
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2592,
+                        "w": 1944
+                    }
+                }
+            }
+        },
+        "ingredients_n": 1,
+        "editors_tags": [
+            "tacinte"
+        ],
+        "countries_lc": "en",
+        "allergens_tags": [],
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "completed_t": 1415913971,
+        "manufacturing_places": "",
+        "code": "5010251168577",
+        "codes_tags": [
+            "code-13",
+            "5010251168577",
+            "501025116857x",
+            "50102511685xx",
+            "5010251168xxx",
+            "501025116xxxx",
+            "50102511xxxxx",
+            "5010251xxxxxx",
+            "501025xxxxxxx",
+            "50102xxxxxxxx",
+            "5010xxxxxxxxx",
+            "501xxxxxxxxxx",
+            "50xxxxxxxxxxx",
+            "5xxxxxxxxxxxx"
+        ],
+        "labels": "Organic, EU Organic, Assured Food Standards, GB-ORG-05, Soil Association Organic \n \n \n",
+        "last_modified_by": "tacinte",
+        "last_edit_dates_tags": [
+            "2014-11-13",
+            "2014-11",
+            "2014"
+        ],
+        "entry_dates_tags": [
+            "2014-11-08",
+            "2014-11",
+            "2014"
+        ],
+        "creator": "tacinte",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "standard",
+            "soil",
+            "milk",
+            "whole",
+            "gb-org-05",
+            "assured",
+            "organic",
+            "morrison",
+            "eu",
+            "association",
+            "british",
+            "food"
+        ],
+        "link": "",
+        "ingredients_debug": [
+            "Organically produced pasteurised homogenised whole milk"
+        ],
+        "languages_codes": {
+            "en": 5
+        },
+        "labels_lc": "en",
+        "packaging": "plastic,bottle",
+        "ingredients_text_en": "Organically produced pasteurised homogenised whole milk",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/501/025/116/8577/front_en.7.400.jpg",
+        "popularity_key": 0,
+        "last_image_dates_tags": [
+            "2014-11-08",
+            "2014-11",
+            "2014"
+        ],
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/501/025/116/8577/front_en.7.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [
+            "en:ingredients-unknown-score-above-0",
+            "en:ingredients-100-percent-unknown",
+            "en:nutrition-value-very-low-for-category-salt"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "ecoscore_score": 59,
+        "photographers_tags": [
+            "tacinte"
+        ],
+        "last_modified_t": 1415913971,
+        "ingredients": [
+            {
+                "percent_max": 100,
+                "id": "en:pasteurised homogenised whole milk",
+                "percent_min": 100,
+                "percent_estimate": 100,
+                "text": "pasteurised homogenised whole milk",
+                "labels": "en:organic"
+            }
+        ],
+        "nutriscore_grade": "b",
+        "countries": "United Kingdom",
+        "stores": "Morrisons",
+        "cities_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "other_nutritional_substances_tags": [],
+        "brands": "Morrisons,Morrisons Organic",
+        "categories": "Dairies, Milks, Whole milks",
+        "ingredients_text_with_allergens": "Organically produced pasteurised homogenised whole milk",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-to-be-completed, en:packaging-code-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "nutrition_grades": "b",
+        "nutrient_levels_tags": [
+            "en:fat-in-moderate-quantity",
+            "en:saturated-fat-in-moderate-quantity",
+            "en:sugars-in-low-quantity",
+            "en:salt-in-low-quantity"
+        ],
+        "known_ingredients_n": 0,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Organically produced pasteurised homogenised whole milk",
+        "product_name": "British Whole Milk",
+        "origins": "",
+        "languages_tags": [
+            "en:english",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "allergens": "",
+        "categories_lc": "en",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/501/025/116/8577/ingredients_en.8.100.jpg",
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "c",
+            "adjustments": {
+                "production_system": {
+                    "value": 15,
+                    "label": "en:eu-organic"
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:bottle",
+                            "material": "en:plastic",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": "0"
+                        }
+                    ],
+                    "score": 0
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_ch": 0,
+                    "epi_value": -5,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 0,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "c",
+            "score": 59,
+            "grade_de": "c",
+            "missing_data_warning": 1,
+            "grade_nl": "c",
+            "score_be": 54,
+            "agribalyse": {
+                "co2_transportation": "0.10315961",
+                "ef_distribution": "0.004287772",
+                "name_fr": "Lait entier, pasteurisé",
+                "score": 54,
+                "ef_agriculture": "0.10502456",
+                "ef_consumption": "0",
+                "name_en": "Milk, whole, pasteurised",
+                "co2_total": "1.4865868",
+                "ef_packaging": "0.014723027999999999",
+                "ef_processing": "0.0014905525",
+                "is_beverage": 1,
+                "agribalyse_proxy_food_code": "19024",
+                "co2_processing": "0.01061493",
+                "dqr": "2.03",
+                "code": "19024",
+                "co2_consumption": "0",
+                "co2_distribution": "0.012078628",
+                "ef_total": "0.13351659",
+                "co2_agriculture": "1.1888463",
+                "ef_transportation": "0.0079906595",
+                "co2_packaging": "0.17188731"
+            },
+            "grade_it": "c",
+            "score_nl": 54,
+            "grade_ie": "c",
+            "missing": {
+                "origins": 1
+            },
+            "score_ch": 54,
+            "score_de": 54,
+            "score_fr": 54,
+            "score_ie": 54,
+            "score_lu": 54,
+            "score_it": 54,
+            "score_es": 54,
+            "grade_es": "c",
+            "grade_ch": "c",
+            "grade": "c",
+            "grade_lu": "c"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/501/025/116/8577/nutrition_en.11.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/501/025/116/8577/nutrition_en.11.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/501/025/116/8577/nutrition_en.11.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/501/025/116/8577/ingredients_en.8.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/501/025/116/8577/ingredients_en.8.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/501/025/116/8577/ingredients_en.8.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/501/025/116/8577/front_en.7.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/501/025/116/8577/front_en.7.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/501/025/116/8577/front_en.7.200.jpg"
+                }
+            }
+        },
+        "origins_old": "",
+        "rev": 14,
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "tacinte",
+        "additives_prev_original_tags": [],
+        "ingredients_tags": [
+            "en:pasteurised-homogenised-whole-milk"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/501/025/116/8577/nutrition_en.11.100.jpg",
+        "labels_prev_tags": [
+            "en:organic",
+            "en:eu-organic",
+            "en:assured-food-standards",
+            "en:gb-org-05",
+            "en:soil-association-organic"
+        ],
+        "product_name_en": "British Whole Milk",
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:dairies",
+            "en:milks",
+            "en:whole-milks"
+        ],
+        "ecoscore_grade": "c",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "labels_prev_hierarchy": [
+            "en:organic",
+            "en:eu-organic",
+            "en:assured-food-standards",
+            "en:gb-org-05",
+            "en:soil-association-organic"
+        ],
+        "languages": {
+            "en:english": 5
+        },
+        "ingredients_percent_analysis": 1,
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-19024",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-unknown",
+            "agribalyse-known",
+            "agribalyse-19024"
+        ],
+        "purchase_places": "United Kingdom,Liverpool",
+        "id": "5010251168577",
+        "no_nutrition_data": null,
+        "pnns_groups_1": "Milk and dairy products",
+        "allergens_from_user": "(en) ",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/501/025/116/8577/ingredients_en.8.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:ingredients-unknown-score-above-0",
+            "en:ingredients-100-percent-unknown",
+            "en:nutrition-value-very-low-for-category-salt"
+        ],
+        "additives_old_tags": [],
+        "labels_hierarchy": [
+            "en:organic",
+            "en:eu-organic",
+            "en:assured-food-standards",
+            "en:gb-org-05",
+            "en:soil-association-organic"
+        ],
+        "ecoscore_tags": [
+            "c"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "origins_hierarchy": [],
+        "complete": 1,
+        "nutrition_score_beverage": 0,
+        "pnns_groups_2": "Milk and yogurt",
+        "new_additives_n": 0,
+        "product_quantity": 568,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/501/025/116/8577/front_en.7.100.jpg",
+        "ingredients_text_debug": "Organically produced pasteurised homogenised whole milk",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/501/025/116/8577/front_en.7.400.jpg",
+        "_id": "5010251168577",
+        "countries_tags": [
+            "en:united-kingdom"
+        ],
+        "ingredients_hierarchy": [
+            "en:pasteurised homogenised whole milk"
+        ],
+        "stores_tags": [
+            "morrisons"
+        ],
+        "additives_original_tags": [],
+        "nutriscore_score": 1,
+        "compared_to_category": "en:whole-milks",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "1",
+            "1-10"
+        ],
+        "pnns_groups_1_tags": [
+            "milk-and-dairy-products",
+            "known"
+        ],
+        "additives_old_n": 0,
+        "packagings": [
+            {
+                "shape": "en:bottle",
+                "material": "en:plastic"
+            }
+        ],
+        "data_quality_errors_tags": [],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "brands_tags": [
+            "morrisons",
+            "morrisons-organic"
+        ],
+        "quantity": "1 pint, 568 ml",
+        "ingredients_ids_debug": [
+            "organically-produced-pasteurised-homogenised-whole-milk"
+        ],
+        "vitamins_prev_tags": [],
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "traces": "",
+        "ingredients_original_tags": [
+            "en:pasteurised homogenised whole milk"
+        ],
+        "unknown_ingredients_n": "1",
+        "manufacturing_places_tags": [],
+        "emb_codes_orig": "UK EX001 EC",
+        "checkers_tags": [],
+        "emb_codes": "UK EX001 EC",
+        "max_imgid": "3",
+        "editors": [
+            "tacinte"
+        ],
+        "nutriscore_score_opposite": -1,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/501/025/116/8577/front_en.7.200.jpg",
+        "nutriments": {
+            "proteins": 3.4,
+            "energy_100g": 286,
+            "carbohydrates_unit": "g",
+            "energy-kj_100g": 286,
+            "sodium_100g": 0,
+            "sugars_100g": 4.7,
+            "sodium_value": 0,
+            "salt_100g": 0,
+            "vitamin-b12_unit": "µg",
+            "nutrition-score-fr_100g": 1,
+            "energy_unit": "kJ",
+            "salt_unit": "g",
+            "carbohydrates_value": 4.7,
+            "proteins_unit": "g",
+            "sugars_unit": "g",
+            "calcium_unit": "mg",
+            "calcium_label": "0",
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt_value": 0,
+            "salt": 0,
+            "proteins_value": 3.4,
+            "saturated-fat_100g": 2.6,
+            "fiber_100g": 0,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "saturated-fat": 2.6,
+            "fat_value": 4,
+            "energy": 286,
+            "calcium_value": 122,
+            "fiber": 0,
+            "saturated-fat_value": 2.6,
+            "vitamin-b12": 9e-07,
+            "fat_100g": 4,
+            "vitamin-b12_label": "0",
+            "vitamin-b12_value": 0.9,
+            "saturated-fat_unit": "g",
+            "energy_value": 286,
+            "calcium": 0.122,
+            "energy-kj_value": 286,
+            "fiber_value": 0,
+            "fiber_unit": "g",
+            "energy-kj": 286,
+            "proteins_100g": 3.4,
+            "sugars_value": 4.7,
+            "vitamin-b12_100g": 9e-07,
+            "calcium_100g": 0.122,
+            "sodium_unit": "g",
+            "nutrition-score-fr": 1,
+            "sodium": 0,
+            "carbohydrates_100g": 4.7,
+            "sugars": 4.7,
+            "carbohydrates": 4.7,
+            "fat": 4
+        },
+        "purchase_places_tags": [
+            "united-kingdom",
+            "liverpool"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/501/025/116/8577/ingredients_en.8.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/501/025/116/8577/nutrition_en.11.200.jpg",
+        "additives_tags_n": null
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/5015821151720.json
+++ b/testdata/product/5015821151720.json
@@ -1,0 +1,945 @@
+{
+    "status": 1,
+    "code": "5015821151720",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {
+            "ciqual_food_name:fr": "Epice -aliment moyen-",
+            "ciqual_food_name:en": "Spice -average-"
+        },
+        "categories_tags": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:groceries",
+            "en:condiments",
+            "en:spices",
+            "fr:curry",
+            "fr:chutney",
+            "fr:sauce-piquante"
+        ],
+        "traces_hierarchy": [
+            "en:nuts",
+            "en:peanuts"
+        ],
+        "informers": [
+            "lechatpito"
+        ],
+        "allergens_hierarchy": [],
+        "product_name_fr": "Chutney épicé à la mangue",
+        "generic_name": "Chutney",
+        "origins_tags": [
+            "en:united-kingdom",
+            "fr:lankashire"
+        ],
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1531080750,
+        "emb_codes_20141016": "",
+        "additives_n": 2,
+        "carbon_footprint_from_known_ingredients_debug": "en:mango 39% x 0.8 = 31.2 g - ",
+        "pnns_groups_2_tags": [
+            "unknown",
+            "missing-association"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "lechatpito",
+            "openfoodfacts-contributors"
+        ],
+        "sortkey": 1531080751,
+        "categories_old": "Aliments et boissons à base de végétaux, Aliments d'origine végétale, Epicerie, Condiments, Epices, Curry, Chutney, Sauce piquante",
+        "categories_properties": {
+            "ciqual_food_code:en": "11081",
+            "agribalyse_proxy_food_code:en": "11005"
+        },
+        "completeness": 0.9,
+        "labels_tags": [],
+        "traces_from_user": "(fr) en:nuts,en:peanuts",
+        "informers_tags": [
+            "lechatpito",
+            "yuka.Yjc4RU42SWNoZFlveXN4aDFUcmNwb3BJNmFXclpGbXFFTklOSVE9PQ",
+            "kiliweb"
+        ],
+        "nutrition_grades_tags": [
+            "not-applicable"
+        ],
+        "lang": "fr",
+        "vitamins_tags": [],
+        "origins_lc": "fr",
+        "interface_version_modified": "20150316.jqm2",
+        "additives_tags": [
+            "en:e260",
+            "en:e330"
+        ],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/501/582/115/1720/nutrition_fr.13.400.jpg",
+        "unknown_nutrients_tags": [],
+        "nova_group_debug": " -- ingredients/en:sugar : 3",
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "traces_tags": [
+            "en:nuts",
+            "en:peanuts"
+        ],
+        "nova_groups": "3",
+        "packaging_tags": [
+            "bocal-en-verre",
+            "bocal"
+        ],
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/501/582/115/1720/front_fr.5.100.jpg",
+        "nutrient_levels": {
+            "salt": "high",
+            "sugars": "high",
+            "saturated-fat": "low",
+            "fat": "low"
+        },
+        "ingredients_analysis_tags": [
+            "en:palm-oil-free",
+            "en:vegan",
+            "en:vegetarian"
+        ],
+        "created_t": 1350666585,
+        "nova_group": 3,
+        "amino_acids_prev_tags": [],
+        "nucleotides_tags": [],
+        "ingredients_text_with_allergens_fr": "Sucre, Mangue (39%), Sel, Epices, Acidifiants: Acide Acétique, Acide citrique, Ail, Piments rouges séchés",
+        "images": {
+            "nutrition_fr": {
+                "y1": null,
+                "y2": null,
+                "rev": "13",
+                "x2": null,
+                "x1": null,
+                "white_magic": "0",
+                "ocr": 1,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 343
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 86
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 1030
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 172
+                    }
+                },
+                "angle": null,
+                "orientation": null,
+                "geometry": "0x0-0-0",
+                "normalize": "0",
+                "imgid": "3"
+            },
+            "1": {
+                "uploaded_t": 1350667022,
+                "uploader": "lechatpito",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 480,
+                        "w": 640
+                    }
+                }
+            },
+            "front_fr": {
+                "rev": "5",
+                "white_magic": null,
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 271
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 68
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 135
+                    },
+                    "full": {
+                        "h": 471,
+                        "w": 319
+                    }
+                },
+                "geometry": "319x471-76-4",
+                "imgid": "1"
+            },
+            "front": {
+                "rev": "5",
+                "white_magic": null,
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 271
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 68
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 135
+                    },
+                    "full": {
+                        "h": 471,
+                        "w": 319
+                    }
+                },
+                "geometry": "319x471-76-4",
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": 1531080745,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 378,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 94,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 1271
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": 1531080750,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 343
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 86
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 1030
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "y1": null,
+                "rev": "10",
+                "y2": null,
+                "x2": null,
+                "ocr": 1,
+                "x1": null,
+                "white_magic": "0",
+                "sizes": {
+                    "400": {
+                        "h": 378,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 94,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 1271
+                    },
+                    "200": {
+                        "h": 189,
+                        "w": 200
+                    }
+                },
+                "angle": null,
+                "orientation": "0",
+                "normalize": "0",
+                "geometry": "0x0-0-0",
+                "imgid": "2"
+            }
+        },
+        "ingredients_n": 9,
+        "editors_tags": [
+            "lechatpito",
+            "yuka.Yjc4RU42SWNoZFlveXN4aDFUcmNwb3BJNmFXclpGbXFFTklOSVE9PQ",
+            "kiliweb",
+            "openfoodfacts-contributors"
+        ],
+        "allergens_tags": [],
+        "countries_lc": "fr",
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "completed_t": 1531080751,
+        "nova_groups_tags": [
+            "en:3-processed-foods"
+        ],
+        "code": "5015821151720",
+        "codes_tags": [
+            "code-13",
+            "5015821151720",
+            "501582115172x",
+            "50158211517xx",
+            "5015821151xxx",
+            "501582115xxxx",
+            "50158211xxxxx",
+            "5015821xxxxxx",
+            "501582xxxxxxx",
+            "50158xxxxxxxx",
+            "5015xxxxxxxxx",
+            "501xxxxxxxxxx",
+            "50xxxxxxxxxxx",
+            "5xxxxxxxxxxxx"
+        ],
+        "last_modified_by": null,
+        "labels": "",
+        "entry_dates_tags": [
+            "2012-10-19",
+            "2012-10",
+            "2012"
+        ],
+        "last_edit_dates_tags": [
+            "2018-07-08",
+            "2018-07",
+            "2018"
+        ],
+        "creator": "lechatpito",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "uni",
+            "epice",
+            "mangue",
+            "piquante",
+            "lankashire",
+            "royaume",
+            "chutney",
+            "la",
+            "curry",
+            "sauce",
+            "patak"
+        ],
+        "amino_acids_tags": [],
+        "ingredients_debug": [
+            "Sucre",
+            ",",
+            null,
+            null,
+            null,
+            " Mangue ",
+            "(",
+            "(",
+            null,
+            null,
+            "39%)",
+            ",",
+            null,
+            null,
+            null,
+            " Sel",
+            ",",
+            null,
+            null,
+            null,
+            " Epices",
+            ",",
+            null,
+            null,
+            null,
+            " Acidifiants ",
+            ":",
+            ":",
+            null,
+            null,
+            "  Acide Acétique",
+            ",",
+            null,
+            null,
+            null,
+            " Acide citrique",
+            ",",
+            null,
+            null,
+            null,
+            " Ail",
+            ",",
+            null,
+            null,
+            null,
+            " Piments rouges séchés"
+        ],
+        "labels_lc": "fr",
+        "languages_codes": {
+            "fr": 6
+        },
+        "packaging": "Bocal en verre,Bocal",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/501/582/115/1720/front_fr.5.400.jpg",
+        "last_image_dates_tags": [
+            "2018-07-08",
+            "2018-07",
+            "2018"
+        ],
+        "popularity_key": 0,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/501/582/115/1720/front_fr.5.200.jpg",
+        "expiration_date": "08/11/2014",
+        "data_quality_warnings_tags": [
+            "en:nutrition-value-very-high-for-category-sugars"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutriscore-not-computed",
+            "en:nutriscore-not-applicable",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "lechatpito",
+            "kiliweb"
+        ],
+        "ecoscore_score": 80,
+        "last_modified_t": 1531080751,
+        "ingredients": [
+            {
+                "percent_max": 61,
+                "id": "en:sugar",
+                "percent_estimate": 50,
+                "percent_min": "39",
+                "text": "Sucre",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_estimate": "39",
+                "percent_min": "39",
+                "percent": "39",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "39",
+                "id": "en:mango",
+                "text": "Mangue"
+            },
+            {
+                "percent_max": 22,
+                "id": "en:salt",
+                "text": "Sel",
+                "percent_min": 0,
+                "percent_estimate": 5.5,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 11,
+                "id": "en:spice",
+                "percent_min": 0,
+                "percent_estimate": 2.75,
+                "text": "Epices",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 7.33333333333333,
+                "id": "en:acid",
+                "text": "Acidifiants",
+                "percent_min": 0,
+                "percent_estimate": 1.375
+            },
+            {
+                "percent_max": 5.5,
+                "id": "en:e330",
+                "text": "Acide citrique",
+                "percent_min": 0,
+                "percent_estimate": 0.6875,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 4.4,
+                "id": "en:garlic",
+                "percent_min": 0,
+                "percent_estimate": 0.34375,
+                "text": "Ail",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": 0,
+                "percent_estimate": 0.34375,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": 3.66666666666667,
+                "id": "en:red-chili-pepper",
+                "processing": "en:dried",
+                "text": "Piments rouges"
+            }
+        ],
+        "product_name_debug_tags": [],
+        "stores": "",
+        "countries": "France",
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "spice-average"
+        ],
+        "cities_tags": [],
+        "brands": "Patak's",
+        "categories": "Aliments et boissons à base de végétaux, Aliments d'origine végétale, Epicerie, Condiments, Epices, Curry, Chutney, Sauce piquante",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "ingredients_text_with_allergens": "Sucre, Mangue (39%), Sel, Epices, Acidifiants: Acide Acétique, Acide citrique, Ail, Piments rouges séchés",
+        "nutrient_levels_tags": [
+            "en:fat-in-low-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-high-quantity",
+            "en:salt-in-high-quantity"
+        ],
+        "known_ingredients_n": 13,
+        "minerals_prev_tags": [],
+        "product_name": "Chutney épicé à la mangue",
+        "ingredients_text": "Sucre, Mangue (39%), Sel, Epices, Acidifiants: Acide Acétique, Acide citrique, Ail, Piments rouges séchés",
+        "origins": "Lankashire,Royaume Uni",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Sucre, Mangue (39%), Sel, Epices, Acidifiants: Acide Acétique, Acide citrique, Ail, Piments rouges séchés",
+        "categories_lc": "fr",
+        "allergens": "",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/501/582/115/1720/ingredients_fr.10.100.jpg",
+        "photographers": [
+            "lechatpito"
+        ],
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "a",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_es": 2,
+                    "transportation_value_fr": 11,
+                    "transportation_value_be": 11,
+                    "transportation_value_ch": 5,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:united-kingdom",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_be": 73,
+                    "epi_score": 97,
+                    "transportation_score_ch": 34,
+                    "epi_value": 5,
+                    "transportation_score_ie": 79,
+                    "value_nl": 15,
+                    "value_ie": 17,
+                    "transportation_value_de": 8,
+                    "value_fr": 16,
+                    "value_be": 16,
+                    "value_es": 7,
+                    "transportation_score_it": 17,
+                    "transportation_value_ie": 12,
+                    "transportation_score_de": 51,
+                    "transportation_score_fr": 76,
+                    "origins_from_origins_field": [
+                        "en:united-kingdom"
+                    ],
+                    "transportation_value_lu": 9,
+                    "transportation_value_nl": 10,
+                    "value_ch": 10,
+                    "transportation_score_es": 13,
+                    "value_de": 13,
+                    "transportation_value_it": 3,
+                    "transportation_score_lu": 63,
+                    "value_it": 8,
+                    "value_lu": 14,
+                    "transportation_score_nl": 67
+                },
+                "packaging": {
+                    "value": -2,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:jar",
+                            "material": "en:glass",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": "81"
+                        }
+                    ],
+                    "score": 81,
+                    "warning": "unscored_shape"
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "a",
+            "score": 80,
+            "grade_de": "a",
+            "missing_data_warning": 1,
+            "grade_nl": "a",
+            "score_be": 96,
+            "agribalyse": {
+                "co2_transportation": "0.17690961",
+                "ef_distribution": "0.017006818",
+                "name_fr": "Curry, poudre",
+                "score": 82,
+                "agribalyse_food_code": "11005",
+                "ef_agriculture": "0.18139168",
+                "ef_consumption": "0",
+                "name_en": "Curry, powder",
+                "co2_total": "0.46985556",
+                "ef_packaging": "0.051649676000000005",
+                "ef_processing": "0",
+                "is_beverage": 0,
+                "agribalyse_proxy_food_code": "11005",
+                "dqr": "4.11",
+                "co2_processing": "0",
+                "code": "11005",
+                "co2_consumption": "0",
+                "co2_distribution": "0.045015886",
+                "ef_total": "0.2638027",
+                "co2_agriculture": "-0.24897679",
+                "ef_transportation": "0.01375452",
+                "co2_packaging": "0.49690685"
+            },
+            "grade_it": "a",
+            "score_nl": 95,
+            "missing": {
+                "packagings": 1,
+                "labels": 1
+            },
+            "grade_ie": "a",
+            "score_ch": 90,
+            "score_de": 93,
+            "score_fr": 96,
+            "score_ie": 97,
+            "score_lu": 94,
+            "score_it": 88,
+            "score_es": 87,
+            "grade_ch": "a",
+            "grade_es": "a",
+            "grade": "a",
+            "grade_lu": "a"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/501/582/115/1720/nutrition_fr.13.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/501/582/115/1720/nutrition_fr.13.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/501/582/115/1720/nutrition_fr.13.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/501/582/115/1720/ingredients_fr.10.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/501/582/115/1720/ingredients_fr.10.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/501/582/115/1720/ingredients_fr.10.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/501/582/115/1720/front_fr.5.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/501/582/115/1720/front_fr.5.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/501/582/115/1720/front_fr.5.200.jpg"
+                }
+            }
+        },
+        "rev": 13,
+        "origins_old": "Lankashire,Royaume Uni",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": null,
+        "additives_prev_original_tags": [
+            "en:e260",
+            "en:e330"
+        ],
+        "data_sources_tags": [
+            "app-yuka",
+            "apps"
+        ],
+        "ingredients_tags": [
+            "en:sugar",
+            "en:mango",
+            "en:fruit",
+            "en:salt",
+            "en:spice",
+            "en:acid",
+            "en:e330",
+            "en:garlic",
+            "en:vegetable",
+            "en:root-vegetable",
+            "en:red-chili-pepper",
+            "en:chili-pepper",
+            "en:e260"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/501/582/115/1720/nutrition_fr.13.100.jpg",
+        "labels_prev_tags": [],
+        "ingredients_from_palm_oil_tags": [],
+        "carbon_footprint_percent_of_known_ingredients": 39,
+        "categories_hierarchy": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:groceries",
+            "en:condiments",
+            "en:spices",
+            "fr:curry",
+            "fr:Chutney",
+            "fr:Sauce piquante"
+        ],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "a",
+        "labels_prev_hierarchy": [],
+        "ingredients_percent_analysis": 1,
+        "languages": {
+            "en:french": 6
+        },
+        "purchase_places": "France,Hérault,Montpellier",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-11005",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-11081",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-11005"
+        ],
+        "id": "5015821151720",
+        "no_nutrition_data": "",
+        "pnns_groups_1": "unknown",
+        "allergens_from_user": "(fr) ",
+        "checkers": [],
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/501/582/115/1720/ingredients_fr.10.400.jpg",
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish",
+            "en:nutrition-value-very-high-for-category-sugars"
+        ],
+        "additives_old_tags": [
+            "en:e260",
+            "en:e330"
+        ],
+        "origins_hierarchy": [
+            "en:united-kingdom",
+            "fr:Lankashire"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "ecoscore_tags": [
+            "a"
+        ],
+        "labels_hierarchy": [],
+        "pnns_groups_2": "unknown",
+        "nutrition_score_beverage": 0,
+        "complete": 1,
+        "product_quantity": 250,
+        "new_additives_n": 2,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/501/582/115/1720/front_fr.5.100.jpg",
+        "ingredients_text_debug": "Sucre, Mangue (39%), Sel, Epices, Acidifiants :  Acide Acétique, Acide citrique, Ail, Piments rouges séchés",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/501/582/115/1720/front_fr.5.400.jpg",
+        "_id": "5015821151720",
+        "countries_tags": [
+            "en:france"
+        ],
+        "ingredients_hierarchy": [
+            "en:sugar",
+            "en:mango",
+            "en:fruit",
+            "en:salt",
+            "en:spice",
+            "en:acid",
+            "en:e330",
+            "en:garlic",
+            "en:vegetable",
+            "en:root-vegetable",
+            "en:red-chili-pepper",
+            "en:chili-pepper",
+            "en:e260"
+        ],
+        "additives_original_tags": [
+            "en:e260",
+            "en:e330"
+        ],
+        "stores_tags": [],
+        "compared_to_category": "fr:curry",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "correctors": [
+            "lechatpito"
+        ],
+        "ingredients_n_tags": [
+            "9",
+            "1-10"
+        ],
+        "pnns_groups_1_tags": [
+            "unknown",
+            "missing-association"
+        ],
+        "additives_old_n": 2,
+        "nutrition_score_debug": "no nutriscore for category en:spices",
+        "packagings": [
+            {
+                "shape": "en:jar",
+                "material": "en:glass"
+            }
+        ],
+        "quantity": "250 ml",
+        "brands_tags": [
+            "patak-s"
+        ],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish"
+        ],
+        "data_quality_errors_tags": [],
+        "ingredients_ids_debug": [
+            "sucre",
+            "mangue",
+            "39",
+            "sel",
+            "epices",
+            "acidifiants",
+            "acide-acetique",
+            "acide-citrique",
+            "ail",
+            "piments-rouges-seches"
+        ],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [
+            "en:sugar",
+            "en:mango",
+            "en:salt",
+            "en:spice",
+            "en:acid",
+            "en:e330",
+            "en:garlic",
+            "en:red-chili-pepper",
+            "en:e260"
+        ],
+        "traces": "en:nuts,en:peanuts",
+        "data_sources": "App - yuka, Apps",
+        "unknown_ingredients_n": 0,
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "max_imgid": "3",
+        "emb_codes": "",
+        "nutrition_data_per_debug_tags": [],
+        "editors": [
+            "lechatpito"
+        ],
+        "image_small_url": "https://static.openfoodfacts.net/images/products/501/582/115/1720/front_fr.5.200.jpg",
+        "generic_name_fr": "Chutney",
+        "nutriments": {
+            "proteins": 0.5,
+            "energy_100g": 1054,
+            "carbohydrates_unit": "",
+            "sodium_100g": 1,
+            "sugars_100g": 59.8,
+            "energy-kcal": 252,
+            "sodium_value": 1,
+            "nova-group_serving": 3,
+            "salt_100g": 2.5,
+            "energy_unit": "kcal",
+            "salt_unit": "",
+            "proteins_unit": "",
+            "carbohydrates_value": 60.6,
+            "sugars_unit": "",
+            "fat_unit": "",
+            "salt_value": 2.5,
+            "salt": 2.5,
+            "proteins_value": 0.5,
+            "saturated-fat_100g": 0.1,
+            "energy-kcal_100g": 252,
+            "saturated-fat": 0.1,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 39,
+            "carbon-footprint-from-known-ingredients_100g": 31.2,
+            "fat_value": 0.3,
+            "energy": 1054,
+            "nova-group": 3,
+            "saturated-fat_value": 0.1,
+            "energy-kcal_value": 252,
+            "nova-group_100g": 3,
+            "fat_100g": 0.3,
+            "saturated-fat_unit": "",
+            "energy_value": 252,
+            "carbon-footprint-from-known-ingredients_product": 78,
+            "sugars_value": 59.8,
+            "proteins_100g": 0.5,
+            "sodium_unit": "g",
+            "sodium": 1,
+            "carbohydrates_100g": 60.6,
+            "sugars": 59.8,
+            "carbohydrates": 60.6,
+            "energy-kcal_unit": "kcal",
+            "fat": 0.3
+        },
+        "purchase_places_tags": [
+            "france",
+            "herault",
+            "montpellier"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/501/582/115/1720/ingredients_fr.10.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/501/582/115/1720/nutrition_fr.13.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/5050854517631.json
+++ b/testdata/product/5050854517631.json
@@ -1,0 +1,779 @@
+{
+    "status": 1,
+    "code": "5050854517631",
+    "product": {
+        "lc": "en",
+        "traces_from_ingredients": "",
+        "category_properties": {
+            "ciqual_food_name:fr": "Miel",
+            "ciqual_food_name:en": "Honey"
+        },
+        "categories_tags": [
+            "en:spreads",
+            "en:breakfasts",
+            "en:bee-products",
+            "en:farming-products",
+            "en:sweet-spreads",
+            "en:sweeteners",
+            "en:honeys",
+            "en:acacia-honeys"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "origins_tags": [
+            "en:european-union",
+            "en:non-european-union"
+        ],
+        "generic_name": "",
+        "languages_hierarchy": [
+            "en:english"
+        ],
+        "last_image_t": 1419561939,
+        "additives_n": 0,
+        "emb_codes_20141016": "",
+        "pnns_groups_2_tags": [
+            "sweets",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "tacinte",
+            "roboto-app"
+        ],
+        "ingredients_text_with_allergens_en": "Acacia Honey",
+        "sortkey": 1575646733,
+        "categories_old": "Spreads, Breakfasts, Bee products, Farming products, Sweet spreads, Sweeteners, Honeys, Acacia honeys",
+        "completeness": 0.8,
+        "categories_properties": {
+            "ciqual_food_code:en": "31008",
+            "agribalyse_food_code:en": "31008"
+        },
+        "traces_from_user": "(en) ",
+        "labels_tags": [],
+        "nutrition_grades_tags": [
+            "not-applicable"
+        ],
+        "informers_tags": [
+            "tacinte"
+        ],
+        "vitamins_tags": [],
+        "lang": "en",
+        "origins_lc": "en",
+        "interface_version_modified": "20150316.jqm2",
+        "additives_tags": [],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/505/085/451/7631/nutrition_en.7.400.jpg",
+        "unknown_nutrients_tags": [],
+        "generic_name_en": "",
+        "nova_group_debug": " -- categories/en:honeys : 2",
+        "countries_hierarchy": [
+            "en:united-kingdom"
+        ],
+        "traces_tags": [],
+        "packaging_tags": [
+            "bottle-plastic"
+        ],
+        "nova_groups": "2",
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/505/085/451/7631/front_en.5.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-free",
+            "en:non-vegan",
+            "en:vegetarian"
+        ],
+        "nutrient_levels": {
+            "sugars": "high",
+            "salt": "low",
+            "fat": "low",
+            "saturated-fat": "low"
+        },
+        "created_t": 1419561875,
+        "amino_acids_prev_tags": [],
+        "nova_group": 2,
+        "nucleotides_tags": [],
+        "images": {
+            "front_en": {
+                "rev": "5",
+                "white_magic": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 213
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 53
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 106
+                    },
+                    "full": {
+                        "h": 2353,
+                        "w": 1251
+                    }
+                },
+                "normalize": "checked",
+                "geometry": "1251x2353-401-64",
+                "imgid": "2"
+            },
+            "nutrition": {
+                "rev": "7",
+                "white_magic": null,
+                "geometry": "395x285-609-1296",
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 285,
+                        "w": 395
+                    },
+                    "100": {
+                        "h": 72,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 285,
+                        "w": 395
+                    },
+                    "200": {
+                        "h": 144,
+                        "w": 200
+                    }
+                },
+                "imgid": "1"
+            },
+            "ingredients": {
+                "rev": "6",
+                "white_magic": null,
+                "geometry": "538x156-712-1049",
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 116,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 29,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 58,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 156,
+                        "w": 538
+                    }
+                },
+                "imgid": "1"
+            },
+            "nutrition_en": {
+                "rev": "7",
+                "white_magic": null,
+                "geometry": "395x285-609-1296",
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 285,
+                        "w": 395
+                    },
+                    "100": {
+                        "h": 72,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 285,
+                        "w": 395
+                    },
+                    "200": {
+                        "h": 144,
+                        "w": 200
+                    }
+                },
+                "imgid": "1"
+            },
+            "ingredients_en": {
+                "rev": "6",
+                "white_magic": null,
+                "geometry": "538x156-712-1049",
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 116,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 29,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 58,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 156,
+                        "w": 538
+                    }
+                },
+                "imgid": "1"
+            },
+            "1": {
+                "uploaded_t": 1419561876,
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2592,
+                        "w": 1944
+                    }
+                }
+            },
+            "front": {
+                "rev": "5",
+                "white_magic": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 213
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 53
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 106
+                    },
+                    "full": {
+                        "h": 2353,
+                        "w": 1251
+                    }
+                },
+                "normalize": "checked",
+                "geometry": "1251x2353-401-64",
+                "imgid": "2"
+            },
+            "2": {
+                "uploaded_t": 1419561939,
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2592,
+                        "w": 1944
+                    }
+                }
+            }
+        },
+        "ingredients_n": 1,
+        "editors_tags": [
+            "roboto-app",
+            "tacinte"
+        ],
+        "countries_lc": "en",
+        "allergens_tags": [],
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "completed_t": 1419563335,
+        "nova_groups_tags": [
+            "en:2-processed-culinary-ingredients"
+        ],
+        "manufacturing_places": "United Kingdom",
+        "code": "5050854517631",
+        "codes_tags": [
+            "code-13",
+            "5050854517xxx",
+            "505085451xxxx",
+            "50508545xxxxx",
+            "5050854xxxxxx",
+            "505085xxxxxxx",
+            "50508xxxxxxxx",
+            "5050xxxxxxxxx",
+            "505xxxxxxxxxx",
+            "50xxxxxxxxxxx",
+            "5xxxxxxxxxxxx"
+        ],
+        "labels": "",
+        "last_modified_by": "roboto-app",
+        "last_edit_dates_tags": [
+            "2019-12-06",
+            "2019-12",
+            "2019"
+        ],
+        "entry_dates_tags": [
+            "2014-12-26",
+            "2014-12",
+            "2014"
+        ],
+        "creator": "tacinte",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "sweetener",
+            "asda",
+            "and",
+            "spread",
+            "product",
+            "acacia",
+            "breakfast",
+            "miels-d-acacia",
+            "bee",
+            "non",
+            "pure",
+            "honey",
+            "eu",
+            "sweet",
+            "farming"
+        ],
+        "link": "",
+        "ingredients_debug": [
+            "Acacia Honey"
+        ],
+        "languages_codes": {
+            "en": 5
+        },
+        "labels_lc": "en",
+        "packaging": "bottle - plastic",
+        "ingredients_text_en": "Acacia Honey",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/505/085/451/7631/front_en.5.400.jpg",
+        "last_image_dates_tags": [
+            "2014-12-26",
+            "2014-12",
+            "2014"
+        ],
+        "popularity_key": 0,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/505/085/451/7631/front_en.5.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [],
+        "misc_tags": [
+            "en:nutriscore-not-computed",
+            "en:nutriscore-not-applicable",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "ecoscore_score": 72,
+        "photographers_tags": [
+            "tacinte"
+        ],
+        "last_modified_t": 1575646733,
+        "ingredients": [
+            {
+                "percent_max": 100,
+                "id": "en:acacia-honey",
+                "percent_min": 100,
+                "percent_estimate": 100,
+                "text": "Acacia Honey",
+                "vegan": "no",
+                "vegetarian": "yes"
+            }
+        ],
+        "countries": "United Kingdom",
+        "stores": "Asda",
+        "cities_tags": [],
+        "ciqual_food_name_tags": [
+            "honey"
+        ],
+        "other_nutritional_substances_tags": [],
+        "brands": "Asda",
+        "categories": "Spreads, Breakfasts, Bee products, Farming products, Sweet spreads, Sweeteners, Honeys, Acacia honeys",
+        "ingredients_text_with_allergens": "Acacia Honey",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "nutrient_levels_tags": [
+            "en:fat-in-low-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-high-quantity",
+            "en:salt-in-low-quantity"
+        ],
+        "known_ingredients_n": 2,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Acacia Honey",
+        "product_name": "Pure Acacia Honey",
+        "origins": "EU and non EU",
+        "languages_tags": [
+            "en:english",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "allergens": "",
+        "categories_lc": "en",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/505/085/451/7631/ingredients_en.6.100.jpg",
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "b",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_value": -5,
+                    "transportation_score_ch": 0,
+                    "value_ie": -5,
+                    "transportation_value_de": 0,
+                    "value_fr": -5,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:bottle",
+                            "material": "en:plastic",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": "0"
+                        }
+                    ],
+                    "score": 0
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "b",
+            "score": 72,
+            "grade_de": "b",
+            "missing_data_warning": 1,
+            "grade_nl": "b",
+            "score_be": 67,
+            "agribalyse": {
+                "co2_transportation": "0.10682376",
+                "ef_distribution": "0.0033692282000000002",
+                "name_fr": "Miel",
+                "score": 82,
+                "agribalyse_food_code": "31008",
+                "ef_agriculture": "0.23224057",
+                "ef_consumption": "0",
+                "name_en": "Honey",
+                "co2_total": "1.1495103",
+                "ef_packaging": "0.020453713999999998",
+                "ef_processing": "0",
+                "is_beverage": 0,
+                "co2_processing": "0",
+                "dqr": "3.68",
+                "code": "31008",
+                "co2_consumption": "0",
+                "co2_distribution": "0.010649056",
+                "ef_total": "0.26433796000000004",
+                "co2_agriculture": "0.84338911",
+                "ef_transportation": "0.0082744467",
+                "co2_packaging": "0.18864842"
+            },
+            "grade_it": "b",
+            "score_nl": 67,
+            "grade_ie": "b",
+            "missing": {
+                "labels": 1,
+                "origins": 1
+            },
+            "score_ch": 67,
+            "score_de": 67,
+            "score_fr": 67,
+            "score_ie": 67,
+            "score_lu": 67,
+            "score_it": 67,
+            "score_es": 67,
+            "grade_ch": "b",
+            "grade_es": "b",
+            "grade": "b",
+            "grade_lu": "b"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/505/085/451/7631/nutrition_en.7.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/505/085/451/7631/nutrition_en.7.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/505/085/451/7631/nutrition_en.7.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/505/085/451/7631/ingredients_en.6.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/505/085/451/7631/ingredients_en.6.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/505/085/451/7631/ingredients_en.6.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/505/085/451/7631/front_en.5.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/505/085/451/7631/front_en.5.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/505/085/451/7631/front_en.5.200.jpg"
+                }
+            }
+        },
+        "origins_old": "EU and non EU",
+        "rev": 9,
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "roboto-app",
+        "additives_prev_original_tags": [],
+        "ingredients_tags": [
+            "en:acacia-honey",
+            "en:honey"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/505/085/451/7631/nutrition_en.7.100.jpg",
+        "labels_prev_tags": [],
+        "product_name_en": "Pure Acacia Honey",
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:spreads",
+            "en:breakfasts",
+            "en:bee-products",
+            "en:farming-products",
+            "en:sweet-spreads",
+            "en:sweeteners",
+            "en:honeys",
+            "en:acacia-honeys"
+        ],
+        "ecoscore_grade": "b",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "labels_prev_hierarchy": [],
+        "languages": {
+            "en:english": 5
+        },
+        "ingredients_percent_analysis": 1,
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-31008",
+            "agribalyse-food-code-known",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-31008",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-31008"
+        ],
+        "purchase_places": "Liverpool,United Kingdom",
+        "id": "5050854517631",
+        "no_nutrition_data": null,
+        "pnns_groups_1": "Sugary snacks",
+        "allergens_from_user": "(en) ",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/505/085/451/7631/ingredients_en.6.400.jpg",
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "additives_old_tags": [],
+        "labels_hierarchy": [],
+        "ecoscore_tags": [
+            "b"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "origins_hierarchy": [
+            "en:european-union",
+            "en:non-european-union"
+        ],
+        "complete": 1,
+        "nutrition_score_beverage": 0,
+        "pnns_groups_2": "Sweets",
+        "new_additives_n": 0,
+        "product_quantity": 250,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/505/085/451/7631/front_en.5.100.jpg",
+        "ingredients_text_debug": "Acacia Honey",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/505/085/451/7631/front_en.5.400.jpg",
+        "_id": "5050854517631",
+        "countries_tags": [
+            "en:united-kingdom"
+        ],
+        "ingredients_hierarchy": [
+            "en:acacia-honey",
+            "en:honey"
+        ],
+        "stores_tags": [
+            "asda"
+        ],
+        "additives_original_tags": [],
+        "compared_to_category": "fr:miels-d-acacia",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "1",
+            "1-10"
+        ],
+        "pnns_groups_1_tags": [
+            "sugary-snacks",
+            "known"
+        ],
+        "nutrition_score_debug": "no nutriscore for category en:honeys",
+        "additives_old_n": 0,
+        "packagings": [
+            {
+                "shape": "en:bottle",
+                "material": "en:plastic"
+            }
+        ],
+        "data_quality_errors_tags": [],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "brands_tags": [
+            "asda"
+        ],
+        "quantity": "250 g",
+        "ingredients_ids_debug": [
+            "acacia-honey"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "ingredients_original_tags": [
+            "en:acacia-honey"
+        ],
+        "unknown_ingredients_n": 0,
+        "manufacturing_places_tags": [
+            "united-kingdom"
+        ],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "emb_codes": "",
+        "max_imgid": "2",
+        "editors": [
+            "tacinte"
+        ],
+        "image_small_url": "https://static.openfoodfacts.net/images/products/505/085/451/7631/front_en.5.200.jpg",
+        "nutriments": {
+            "proteins": 0.1,
+            "energy_100g": 1450,
+            "carbohydrates_unit": "g",
+            "energy-kj_100g": 1450,
+            "sodium_100g": 0,
+            "sugars_100g": 82.1,
+            "sodium_value": 0,
+            "salt_100g": 0,
+            "nova-group_serving": 2,
+            "energy_unit": "kJ",
+            "salt_unit": "g",
+            "proteins_unit": "g",
+            "carbohydrates_value": 84.3,
+            "sugars_unit": "g",
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt": 0,
+            "salt_value": 0,
+            "proteins_value": 0.1,
+            "saturated-fat_100g": 0.2,
+            "fiber_100g": 0.1,
+            "saturated-fat": 0.2,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "fat_value": 0.4,
+            "nova-group": 2,
+            "energy": 1450,
+            "fiber": 0.1,
+            "saturated-fat_value": 0.2,
+            "nova-group_100g": 2,
+            "fat_100g": 0.4,
+            "saturated-fat_unit": "g",
+            "energy_value": 1450,
+            "energy-kj_value": 1450,
+            "fiber_value": 0.1,
+            "fiber_unit": "g",
+            "energy-kj": 1450,
+            "proteins_100g": 0.1,
+            "sugars_value": 82.1,
+            "sodium_unit": "g",
+            "carbohydrates_100g": 84.3,
+            "sodium": 0,
+            "sugars": 82.1,
+            "carbohydrates": 84.3,
+            "fat": 0.4
+        },
+        "purchase_places_tags": [
+            "liverpool",
+            "united-kingdom"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/505/085/451/7631/ingredients_en.6.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/505/085/451/7631/nutrition_en.7.200.jpg",
+        "additives_tags_n": null
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/5054070608074.json
+++ b/testdata/product/5054070608074.json
@@ -1,0 +1,468 @@
+{
+    "status": 1,
+    "code": "5054070608074",
+    "product": {
+        "lc": "fi",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "categories_tags": [],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "languages_hierarchy": [
+            "en:finnish"
+        ],
+        "last_image_t": 1418570470,
+        "emb_codes_20141016": "",
+        "pnns_groups_2_tags": [
+            "unknown",
+            "missing-category"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "tacinte"
+        ],
+        "sortkey": 1572642551,
+        "completeness": 0.166666666666667,
+        "categories_properties": {},
+        "labels_tags": [],
+        "traces_from_user": "(fi) ",
+        "informers_tags": [
+            "tacinte",
+            "teolemon",
+            "fix-missing-lang-bot"
+        ],
+        "nutrition_grades_tags": [
+            "unknown"
+        ],
+        "vitamins_tags": [],
+        "lang": "fi",
+        "interface_version_modified": "20150316.jqm2",
+        "additives_tags": [],
+        "categories_prev_tags": [],
+        "unknown_nutrients_tags": [],
+        "nova_group_debug": "no nova group when the product does not have ingredients",
+        "countries_hierarchy": [
+            "en:united-kingdom"
+        ],
+        "traces_tags": [],
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/505/407/060/8074/front_fi.3.100.jpg",
+        "nutrient_levels": {},
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "created_t": 1418570423,
+        "amino_acids_prev_tags": [],
+        "nucleotides_tags": [],
+        "images": {
+            "1": {
+                "uploaded_t": 1418570423,
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2666,
+                        "w": 2000
+                    }
+                }
+            },
+            "4": {
+                "uploaded_t": 1418570470,
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2666,
+                        "w": 2000
+                    }
+                }
+            },
+            "front": {
+                "rev": "3",
+                "white_magic": null,
+                "normalize": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2666,
+                        "w": 2000
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 150
+                    }
+                },
+                "geometry": "0x0--6--6",
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": 1418570437,
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2666,
+                        "w": 2000
+                    }
+                }
+            },
+            "front_fi": {
+                "rev": "3",
+                "white_magic": null,
+                "normalize": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2666,
+                        "w": 2000
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 150
+                    }
+                },
+                "geometry": "0x0--6--6",
+                "imgid": "1"
+            },
+            "3": {
+                "uploaded_t": 1418570452,
+                "uploader": "tacinte",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2666,
+                        "w": 2000
+                    }
+                }
+            }
+        },
+        "editors_tags": [
+            "tacinte",
+            "fix-missing-lang-bot",
+            "teolemon"
+        ],
+        "countries_lc": "fi",
+        "allergens_tags": [],
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "code": "5054070608074",
+        "codes_tags": [
+            "code-13",
+            "5054070608xxx",
+            "505407060xxxx",
+            "50540706xxxxx",
+            "5054070xxxxxx",
+            "505407xxxxxxx",
+            "50540xxxxxxxx",
+            "5054xxxxxxxxx",
+            "505xxxxxxxxxx",
+            "50xxxxxxxxxxx",
+            "5xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "fix-missing-lang-bot",
+        "entry_dates_tags": [
+            "2014-12-14",
+            "2014-12",
+            "2014"
+        ],
+        "last_edit_dates_tags": [
+            "2019-11-01",
+            "2019-11",
+            "2019"
+        ],
+        "creator": "tacinte",
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "asda"
+        ],
+        "ingredients_debug": [],
+        "languages_codes": {
+            "fi": 1
+        },
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/505/407/060/8074/front_fi.3.400.jpg",
+        "popularity_key": 0,
+        "last_image_dates_tags": [
+            "2014-12-14",
+            "2014-12",
+            "2014"
+        ],
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/505/407/060/8074/front_fi.3.200.jpg",
+        "data_quality_warnings_tags": [],
+        "labels_debug_tags": [],
+        "misc_tags": [
+            "en:nutriscore-not-computed",
+            "en:nutriscore-missing-category",
+            "en:ecoscore-not-computed"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-to-be-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:categories-to-be-completed",
+            "en:brands-completed",
+            "en:packaging-to-be-completed",
+            "en:quantity-to-be-completed",
+            "en:product-name-to-be-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "tacinte"
+        ],
+        "last_modified_t": 1572642551,
+        "ingredients": [],
+        "countries": "Yhdistynyt kuningaskunta",
+        "stores": "Asda",
+        "cities_tags": [],
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "brands": "Asda",
+        "states": "en:to-be-completed, en:nutrition-facts-to-be-completed, en:ingredients-to-be-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-to-be-completed, en:categories-to-be-completed, en:brands-completed, en:packaging-to-be-completed, en:quantity-to-be-completed, en:product-name-to-be-completed, en:photos-to-be-validated, en:photos-uploaded",
+        "nutrient_levels_tags": [],
+        "minerals_prev_tags": [],
+        "languages_tags": [
+            "en:finnish",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "allergens": "",
+        "ecoscore_data": {
+            "missing_agribalyse_match_warning": 1,
+            "status": "unknown",
+            "agribalyse": {
+                "warning": "missing_agribalyse_match"
+            },
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "transportation_score_lu": 0,
+                    "value_it": -5,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_value": -5,
+                    "transportation_score_ch": 0,
+                    "value_ie": -5,
+                    "transportation_value_de": 0,
+                    "value_fr": -5,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "value_lu": -5,
+                    "transportation_score_nl": 0
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:unknown",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "score": 0,
+                    "warning": "unscored_shape"
+                },
+                "threatened_species": {
+                    "warning": "ingredients_missing"
+                }
+            },
+            "missing": {
+                "packagings": 1,
+                "categories": 1,
+                "labels": 1,
+                "ingredients": 1,
+                "origins": 1
+            }
+        },
+        "selected_images": {
+            "front": {
+                "display": {
+                    "fi": "https://static.openfoodfacts.net/images/products/505/407/060/8074/front_fi.3.400.jpg"
+                },
+                "thumb": {
+                    "fi": "https://static.openfoodfacts.net/images/products/505/407/060/8074/front_fi.3.100.jpg"
+                },
+                "small": {
+                    "fi": "https://static.openfoodfacts.net/images/products/505/407/060/8074/front_fi.3.200.jpg"
+                }
+            }
+        },
+        "rev": 10,
+        "last_editor": "fix-missing-lang-bot",
+        "additives_prev_original_tags": [],
+        "ingredients_tags": [],
+        "labels_prev_tags": [],
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "unknown",
+        "labels_prev_hierarchy": [],
+        "languages": {
+            "en:finnish": 1
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-unknown",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-unknown",
+            "agribalyse-unknown"
+        ],
+        "id": "5054070608074",
+        "no_nutrition_data": "",
+        "pnns_groups_1": "unknown",
+        "allergens_from_user": "(fi) ",
+        "additives_debug_tags": [],
+        "data_quality_tags": [],
+        "additives_old_tags": [],
+        "ecoscore_tags": [
+            "unknown"
+        ],
+        "labels_hierarchy": [],
+        "complete": 0,
+        "pnns_groups_2": "unknown",
+        "nutrition_score_beverage": 0,
+        "categories_debug_tags": [],
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/505/407/060/8074/front_fi.3.100.jpg",
+        "ingredients_text_debug": null,
+        "_id": "5054070608074",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/505/407/060/8074/front_fi.3.400.jpg",
+        "countries_tags": [
+            "en:united-kingdom"
+        ],
+        "ingredients_hierarchy": [],
+        "additives_original_tags": [],
+        "stores_tags": [
+            "asda"
+        ],
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-to-be-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:categories-to-be-completed",
+            "en:brands-completed",
+            "en:packaging-to-be-completed",
+            "en:quantity-to-be-completed",
+            "en:product-name-to-be-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "pnns_groups_1_tags": [
+            "unknown",
+            "missing-category"
+        ],
+        "nutrition_score_debug": "no score when the product does not have a category",
+        "packagings": [
+            {
+                "shape": "en:unknown",
+                "material": "en:unknown"
+            }
+        ],
+        "brands_tags": [
+            "asda"
+        ],
+        "data_quality_info_tags": [],
+        "data_quality_errors_tags": [],
+        "ingredients_ids_debug": [],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "ingredients_original_tags": [],
+        "unknown_ingredients_n": 0,
+        "checkers_tags": [],
+        "max_imgid": "4",
+        "emb_codes": "",
+        "editors": [
+            "tacinte"
+        ],
+        "categories_prev_hierarchy": [],
+        "image_small_url": "https://static.openfoodfacts.net/images/products/505/407/060/8074/front_fi.3.200.jpg",
+        "brands_debug_tags": [],
+        "nutriments": {}
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/5201051001076.json
+++ b/testdata/product/5201051001076.json
@@ -1,0 +1,969 @@
+{
+    "status": 1,
+    "code": "5201051001076",
+    "product": {
+        "lc": "en",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "popularity_tags": [
+            "bottom-25-percent-scans-2020",
+            "top-80-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-50000-ch-scans-2020",
+            "top-100000-ch-scans-2020",
+            "top-country-ch-scans-2020",
+            "top-50000-be-scans-2020",
+            "top-100000-be-scans-2020"
+        ],
+        "categories_tags": [
+            "en:dolminades"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "origins_tags": [
+            "en:greece"
+        ],
+        "generic_name": "",
+        "languages_hierarchy": [
+            "en:english"
+        ],
+        "last_image_t": 1461318654,
+        "additives_n": 1,
+        "emb_codes_20141016": "",
+        "pnns_groups_2_tags": [
+            "unknown",
+            "missing-association"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "foodorigins"
+        ],
+        "ingredients_text_with_allergens_en": "Rice (Cooked) 60%, Water, Vine Leaves 15%, Onions, Sataoil 7.5%, Salt, Dill, Spearmint, Black Pepper, Acidifying Agent: Citric Acid.",
+        "sortkey": 1462924761,
+        "categories_old": "Dolminades",
+        "categories_properties": {},
+        "completeness": 0.9,
+        "traces_from_user": "(en) ",
+        "labels_tags": [
+            "en:no-preservatives"
+        ],
+        "nutrition_grades_tags": [
+            "c"
+        ],
+        "informers_tags": [
+            "foodorigins"
+        ],
+        "lang": "en",
+        "vitamins_tags": [],
+        "origins_lc": "en",
+        "interface_version_modified": "20120622",
+        "additives_tags": [
+            "en:e330"
+        ],
+        "unique_scans_n": 2,
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/520/105/100/1076/nutrition_en.9.400.jpg",
+        "generic_name_en": "",
+        "unknown_nutrients_tags": [],
+        "nova_group_debug": " -- ingredients/en:salt : 3",
+        "countries_hierarchy": [
+            "en:australia"
+        ],
+        "traces_tags": [],
+        "packaging_tags": [
+            "canned"
+        ],
+        "nova_groups": "3",
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/520/105/100/1076/front_en.7.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-content-unknown",
+            "en:vegan-status-unknown",
+            "en:vegetarian-status-unknown"
+        ],
+        "nutrient_levels": {
+            "salt": "moderate",
+            "sugars": "low",
+            "saturated-fat": "low",
+            "fat": "moderate"
+        },
+        "nutriscore_data": {
+            "proteins": 2.07,
+            "negative_points": 6,
+            "sugars_points": 0,
+            "score": 4,
+            "sodium_value": 486,
+            "positive_points": 2,
+            "saturated_fat_value": 0.8,
+            "is_water": 0,
+            "proteins_points": 1,
+            "saturated_fat_points": 0,
+            "saturated_fat_ratio": 10.48,
+            "proteins_value": 2.07,
+            "saturated_fat_ratio_points": 1,
+            "fiber_points": 1,
+            "grade": "c",
+            "is_cheese": 0,
+            "energy": 590,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 1.5,
+            "energy_points": 1,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 5,
+            "is_fat": 0,
+            "energy_value": 590,
+            "is_beverage": 0,
+            "fiber_value": 1.5,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 10.5,
+            "sugars_value": 1.21,
+            "saturated_fat": 0.786,
+            "sodium": 486,
+            "sugars": 1.21
+        },
+        "created_t": 1461318620,
+        "nova_group": 3,
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "c",
+        "nucleotides_tags": [],
+        "scans_n": 2,
+        "images": {
+            "front_en": {
+                "rev": "7",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 396,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 99,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1075,
+                        "w": 1085
+                    },
+                    "200": {
+                        "h": 198,
+                        "w": 200
+                    }
+                },
+                "normalize": "true",
+                "geometry": "1085x1075-16-419",
+                "imgid": "1"
+            },
+            "nutrition": {
+                "rev": "9",
+                "white_magic": "false",
+                "geometry": "1350x730-304-284",
+                "sizes": {
+                    "400": {
+                        "h": 216,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 54,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 730,
+                        "w": 1350
+                    },
+                    "200": {
+                        "h": 108,
+                        "w": 200
+                    }
+                },
+                "normalize": "true",
+                "imgid": "2"
+            },
+            "ingredients": {
+                "rev": "8",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 277,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 69,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 139,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 815,
+                        "w": 1175
+                    }
+                },
+                "normalize": "true",
+                "geometry": "1175x815-519-163",
+                "imgid": "3"
+            },
+            "3": {
+                "uploaded_t": "1461318653",
+                "uploader": "foodorigins",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1125,
+                        "w": 2000
+                    }
+                }
+            },
+            "nutrition_en": {
+                "rev": "9",
+                "white_magic": "false",
+                "geometry": "1350x730-304-284",
+                "sizes": {
+                    "400": {
+                        "h": 216,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 54,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 730,
+                        "w": 1350
+                    },
+                    "200": {
+                        "h": 108,
+                        "w": 200
+                    }
+                },
+                "normalize": "true",
+                "imgid": "2"
+            },
+            "ingredients_en": {
+                "rev": "8",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 277,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 69,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 139,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 815,
+                        "w": 1175
+                    }
+                },
+                "normalize": "true",
+                "geometry": "1175x815-519-163",
+                "imgid": "3"
+            },
+            "1": {
+                "uploaded_t": "1461318620",
+                "uploader": "foodorigins",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1125,
+                        "w": 2000
+                    }
+                }
+            },
+            "front": {
+                "rev": "7",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 396,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 99,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1075,
+                        "w": 1085
+                    },
+                    "200": {
+                        "h": 198,
+                        "w": 200
+                    }
+                },
+                "normalize": "true",
+                "geometry": "1085x1075-16-419",
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": "1461318644",
+                "uploader": "foodorigins",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1125,
+                        "w": 2000
+                    }
+                }
+            }
+        },
+        "ingredients_n": 11,
+        "editors_tags": [
+            "foodorigins"
+        ],
+        "countries_lc": "en",
+        "allergens_tags": [],
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "completed_t": 1462924761,
+        "nova_groups_tags": [
+            "en:3-processed-foods"
+        ],
+        "code": "5201051001076",
+        "manufacturing_places": "Greece",
+        "codes_tags": [
+            "code-13",
+            "5201051001076",
+            "520105100107x",
+            "52010510010xx",
+            "5201051001xxx",
+            "520105100xxxx",
+            "52010510xxxxx",
+            "5201051xxxxxx",
+            "520105xxxxxxx",
+            "52010xxxxxxxx",
+            "5201xxxxxxxxx",
+            "520xxxxxxxxxx",
+            "52xxxxxxxxxxx",
+            "5xxxxxxxxxxxx"
+        ],
+        "labels": "No preservatives",
+        "last_modified_by": "foodorigins",
+        "last_edit_dates_tags": [
+            "2016-05-11",
+            "2016-05",
+            "2016"
+        ],
+        "entry_dates_tags": [
+            "2016-04-22",
+            "2016-04",
+            "2016"
+        ],
+        "creator": "foodorigins",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "preservative",
+            "zanae",
+            "greece",
+            "no",
+            "dolminade"
+        ],
+        "amino_acids_tags": [],
+        "link": "",
+        "ingredients_debug": [
+            "Rice ",
+            "(",
+            "(",
+            null,
+            null,
+            "Cooked) 60%",
+            ",",
+            null,
+            null,
+            null,
+            " Water",
+            ",",
+            null,
+            null,
+            null,
+            " Vine Leaves 15%",
+            ",",
+            null,
+            null,
+            null,
+            " Onions",
+            ",",
+            null,
+            null,
+            null,
+            " Sataoil 7.5%",
+            ",",
+            null,
+            null,
+            null,
+            " Salt",
+            ",",
+            null,
+            null,
+            null,
+            " Dill",
+            ",",
+            null,
+            null,
+            null,
+            " Spearmint",
+            ",",
+            null,
+            null,
+            null,
+            " Black Pepper",
+            ",",
+            null,
+            null,
+            null,
+            " Acidifying Agent",
+            ":",
+            ":",
+            null,
+            null,
+            " Citric Acid."
+        ],
+        "languages_codes": {
+            "en": 5
+        },
+        "labels_lc": "en",
+        "packaging": "Canned",
+        "ingredients_text_en": "Rice (Cooked) 60%, Water, Vine Leaves 15%, Onions, Sataoil 7.5%, Salt, Dill, Spearmint, Black Pepper, Acidifying Agent: Citric Acid.",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/520/105/100/1076/front_en.7.400.jpg",
+        "last_image_dates_tags": [
+            "2016-04-22",
+            "2016-04",
+            "2016"
+        ],
+        "popularity_key": 2,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/520/105/100/1076/front_en.7.200.jpg",
+        "expiration_date": "04/April/2018",
+        "data_quality_warnings_tags": [
+            "en:ingredients-percent-analysis-not-ok"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-not-computed"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "serving",
+        "photographers_tags": [
+            "foodorigins"
+        ],
+        "last_modified_t": 1462924761,
+        "ingredients": [
+            {
+                "id": "en:rice",
+                "processing": "en:cooked",
+                "percent": "60",
+                "percent_estimate": "60",
+                "text": "Rice",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "id": "en:water",
+                "text": "Water",
+                "percent_estimate": 20,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "id": "en:vine-leaves",
+                "percent": "15",
+                "percent_estimate": "15",
+                "text": "Vine Leaves",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "id": "en:onion",
+                "percent_estimate": 2.5,
+                "text": "Onions",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "id": "en:Sataoil",
+                "text": "Sataoil",
+                "percent_estimate": 2.5,
+                "percent": "7.5"
+            },
+            {
+                "id": "en:salt",
+                "percent_estimate": 0,
+                "text": "Salt",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "id": "en:dill",
+                "text": "Dill",
+                "percent_estimate": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "id": "en:spearmint",
+                "text": "Spearmint",
+                "percent_estimate": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "id": "en:black-pepper",
+                "percent_estimate": 0,
+                "text": "Black Pepper",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "id": "en:Acidifying Agent",
+                "text": "Acidifying Agent",
+                "percent_estimate": 0
+            }
+        ],
+        "nutriscore_grade": "c",
+        "countries": "Australia",
+        "stores": "Aldi",
+        "cities_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "other_nutritional_substances_tags": [],
+        "brands": "Zanae",
+        "categories": "Dolminades",
+        "ingredients_text_with_allergens": "Rice (Cooked) 60%, Water, Vine Leaves 15%, Onions, Sataoil 7.5%, Salt, Dill, Spearmint, Black Pepper, Acidifying Agent: Citric Acid.",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "nutrition_grades": "c",
+        "nutrient_levels_tags": [
+            "en:fat-in-moderate-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-low-quantity",
+            "en:salt-in-moderate-quantity"
+        ],
+        "known_ingredients_n": 15,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Rice (Cooked) 60%, Water, Vine Leaves 15%, Onions, Sataoil 7.5%, Salt, Dill, Spearmint, Black Pepper, Acidifying Agent: Citric Acid.",
+        "product_name": "Dolminades",
+        "origins": "Greece",
+        "languages_tags": [
+            "en:english",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "serving_quantity": 140,
+        "allergens": "",
+        "categories_lc": "en",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/520/105/100/1076/ingredients_en.8.100.jpg",
+        "ecoscore_data": {
+            "missing_agribalyse_match_warning": 1,
+            "status": "unknown",
+            "agribalyse": {
+                "warning": "missing_agribalyse_match"
+            },
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_es": 11,
+                    "transportation_value_fr": 4,
+                    "transportation_value_be": 8,
+                    "transportation_value_ch": 9,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:greece",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_be": 53,
+                    "epi_score": 63,
+                    "transportation_score_ch": 63,
+                    "epi_value": 1,
+                    "transportation_score_ie": 41,
+                    "value_nl": 9,
+                    "value_ie": 7,
+                    "transportation_value_de": 8,
+                    "value_fr": 5,
+                    "value_be": 9,
+                    "value_es": 12,
+                    "transportation_score_it": 24,
+                    "transportation_value_ie": 6,
+                    "transportation_score_de": 53,
+                    "transportation_score_fr": 24,
+                    "origins_from_origins_field": [
+                        "en:greece"
+                    ],
+                    "transportation_value_lu": 7,
+                    "transportation_value_nl": 8,
+                    "value_ch": 10,
+                    "transportation_score_es": 76,
+                    "value_de": 9,
+                    "transportation_value_it": 4,
+                    "transportation_score_lu": 44,
+                    "value_it": 5,
+                    "value_lu": 8,
+                    "transportation_score_nl": 52
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:unknown",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "warning": "unscored_shape",
+                    "score": 0
+                },
+                "threatened_species": {}
+            },
+            "missing": {
+                "agb_category": 1,
+                "packagings": 1,
+                "labels": 1
+            }
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/520/105/100/1076/nutrition_en.9.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/520/105/100/1076/nutrition_en.9.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/520/105/100/1076/nutrition_en.9.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/520/105/100/1076/ingredients_en.8.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/520/105/100/1076/ingredients_en.8.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/520/105/100/1076/ingredients_en.8.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/520/105/100/1076/front_en.7.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/520/105/100/1076/front_en.7.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/520/105/100/1076/front_en.7.200.jpg"
+                }
+            }
+        },
+        "origins_old": "Greece",
+        "rev": 11,
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "foodorigins",
+        "additives_prev_original_tags": [
+            "en:e330"
+        ],
+        "ingredients_tags": [
+            "en:rice",
+            "en:water",
+            "en:vine-leaves",
+            "en:onion",
+            "en:vegetable",
+            "en:root-vegetable",
+            "en:sataoil",
+            "en:salt",
+            "en:dill",
+            "en:herb",
+            "en:spearmint",
+            "en:mint",
+            "en:black-pepper",
+            "en:seed",
+            "en:pepper",
+            "en:acidifying-agent",
+            "en:e330"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/520/105/100/1076/nutrition_en.9.100.jpg",
+        "labels_prev_tags": [
+            "en:no-preservatives"
+        ],
+        "product_name_en": "Dolminades",
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:Dolminades"
+        ],
+        "ecoscore_grade": "unknown",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "labels_prev_hierarchy": [
+            "en:no-preservatives"
+        ],
+        "languages": {
+            "en:english": 5
+        },
+        "ingredients_percent_analysis": -1,
+        "nutrition_data": "on",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-unknown",
+            "agribalyse-unknown"
+        ],
+        "purchase_places": "Sydney,NSW,Australia",
+        "id": "5201051001076",
+        "no_nutrition_data": null,
+        "pnns_groups_1": "unknown",
+        "allergens_from_user": "(en) ",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/520/105/100/1076/ingredients_en.8.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-not-ok"
+        ],
+        "additives_old_tags": [
+            "en:e330"
+        ],
+        "labels_hierarchy": [
+            "en:no-preservatives"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "ecoscore_tags": [
+            "unknown"
+        ],
+        "origins_hierarchy": [
+            "en:greece"
+        ],
+        "complete": 1,
+        "pnns_groups_2": "unknown",
+        "nutrition_score_beverage": 0,
+        "product_quantity": 280,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/520/105/100/1076/front_en.7.100.jpg",
+        "ingredients_text_debug": "Rice (Cooked) 60%, Water, Vine Leaves 15%, Onions, Sataoil 7.5%, Salt, Dill, Spearmint, Black Pepper, Acidifying Agent: Citric Acid.",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/520/105/100/1076/front_en.7.400.jpg",
+        "_id": "5201051001076",
+        "countries_tags": [
+            "en:australia"
+        ],
+        "ingredients_hierarchy": [
+            "en:rice",
+            "en:water",
+            "en:vine-leaves",
+            "en:onion",
+            "en:vegetable",
+            "en:root-vegetable",
+            "en:Sataoil",
+            "en:salt",
+            "en:dill",
+            "en:herb",
+            "en:spearmint",
+            "en:mint",
+            "en:black-pepper",
+            "en:seed",
+            "en:pepper",
+            "en:Acidifying Agent",
+            "en:e330"
+        ],
+        "serving_size": "140g",
+        "stores_tags": [
+            "aldi"
+        ],
+        "additives_original_tags": [
+            "en:e330"
+        ],
+        "nutriscore_score": 4,
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "11",
+            "11-20"
+        ],
+        "pnns_groups_1_tags": [
+            "unknown",
+            "missing-association"
+        ],
+        "additives_old_n": 1,
+        "packagings": [
+            {
+                "shape": "en:unknown",
+                "material": "en:unknown"
+            }
+        ],
+        "data_quality_errors_tags": [],
+        "brands_tags": [
+            "zanae"
+        ],
+        "data_quality_info_tags": [],
+        "quantity": "280g",
+        "ingredients_ids_debug": [
+            "rice",
+            "cooked-60",
+            "water",
+            "vine-leaves-15",
+            "onions",
+            "sataoil-7-5",
+            "salt",
+            "dill",
+            "spearmint",
+            "black-pepper",
+            "acidifying-agent",
+            "citric-acid"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "ingredients_original_tags": [
+            "en:rice",
+            "en:water",
+            "en:vine-leaves",
+            "en:onion",
+            "en:Sataoil",
+            "en:salt",
+            "en:dill",
+            "en:spearmint",
+            "en:black-pepper",
+            "en:Acidifying Agent",
+            "en:e330"
+        ],
+        "unknown_ingredients_n": 2,
+        "manufacturing_places_tags": [
+            "greece"
+        ],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "emb_codes": "",
+        "max_imgid": "3",
+        "nutriscore_score_opposite": -4,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/520/105/100/1076/front_en.7.200.jpg",
+        "nutriments": {
+            "proteins": 2.9,
+            "salt_serving": 1.7,
+            "energy_100g": 590,
+            "carbohydrates_unit": "g",
+            "saturated-fat_serving": 1.1,
+            "energy-kj_100g": 590,
+            "sodium_100g": 0.486,
+            "sugars_100g": 1.21,
+            "sodium_value": 0.68,
+            "proteins_serving": 2.9,
+            "salt_100g": 1.21,
+            "nova-group_serving": 3,
+            "nutrition-score-fr_100g": 4,
+            "energy_unit": "kJ",
+            "energy-kj_serving": 826,
+            "salt_unit": "g",
+            "proteins_unit": "g",
+            "carbohydrates_value": 21.7,
+            "sugars_unit": "g",
+            "sugars_serving": 1.7,
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt_value": 1.7,
+            "salt": 1.7,
+            "fiber_serving": 2.1,
+            "proteins_value": 2.9,
+            "saturated-fat_100g": 0.786,
+            "fiber_100g": 1.5,
+            "fat_serving": 10.5,
+            "saturated-fat": 1.1,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "fat_value": 10.5,
+            "energy": 826,
+            "nova-group": 3,
+            "fiber": 2.1,
+            "saturated-fat_value": 1.1,
+            "nova-group_100g": 3,
+            "fat_100g": 7.5,
+            "energy_serving": 826,
+            "saturated-fat_unit": "g",
+            "sodium_serving": 0.68,
+            "energy_value": 826,
+            "energy-kj_value": 826,
+            "fiber_value": 2.1,
+            "fiber_unit": "g",
+            "energy-kj": 826,
+            "proteins_100g": 2.07,
+            "sugars_value": 1.7,
+            "carbohydrates_serving": 21.7,
+            "sodium_unit": "g",
+            "nutrition-score-fr": 4,
+            "sodium": 0.68,
+            "carbohydrates_100g": 15.5,
+            "sugars": 1.7,
+            "carbohydrates": 21.7,
+            "fat": 10.5
+        },
+        "purchase_places_tags": [
+            "sydney",
+            "nsw",
+            "australia"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/520/105/100/1076/ingredients_en.8.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/520/105/100/1076/nutrition_en.9.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/5410228196693.json
+++ b/testdata/product/5410228196693.json
@@ -1,0 +1,678 @@
+{
+    "status": 1,
+    "code": "5410228196693",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "popularity_tags": [
+            "top-country-be-scans-2019",
+            "bottom-25-percent-scans-2020",
+            "bottom-20-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-50000-be-scans-2020",
+            "top-100000-be-scans-2020",
+            "top-country-be-scans-2020"
+        ],
+        "categories_tags": [
+            "en:beverages",
+            "en:alcoholic-beverages",
+            "en:beers",
+            "en:lagers"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "informers": [
+            "manu1400"
+        ],
+        "origins_tags": [
+            "en:belgium"
+        ],
+        "product_name_fr": "Bière Tauro",
+        "generic_name": "Bière",
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1332930009,
+        "additives_n": 0,
+        "emb_codes_20141016": "",
+        "pnns_groups_2_tags": [
+            "alcoholic-beverages",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "malikele",
+            "manu1400"
+        ],
+        "sortkey": 1346453678,
+        "categories_old": "Boissons, Boissons alcoolisées, Bières, Bières blondes",
+        "categories_properties": {
+            "ciqual_food_code:en": "5001",
+            "agribalyse_proxy_food_code:en": "5000",
+            "agribalyse_food_code:en": "5001"
+        },
+        "completeness": 0.783333333333333,
+        "traces_from_user": "(fr) ",
+        "labels_tags": [],
+        "nutrition_grades_tags": [
+            "not-applicable"
+        ],
+        "informers_tags": [
+            "malikele",
+            "manu1400"
+        ],
+        "lang": "fr",
+        "vitamins_tags": [],
+        "origins_lc": "fr",
+        "interface_version_modified": "20120622",
+        "additives_tags": [],
+        "unique_scans_n": 1,
+        "unknown_nutrients_tags": [],
+        "nova_group_debug": "no nova group if too many ingredients are unknown: 2 out of 1",
+        "countries_hierarchy": [
+            "en:belgium"
+        ],
+        "traces_tags": [],
+        "packaging_tags": [
+            "bouteille"
+        ],
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/541/022/819/6693/front_fr.13.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-content-unknown",
+            "en:vegan-status-unknown",
+            "en:vegetarian-status-unknown"
+        ],
+        "nutrient_levels": {},
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "created_t": 1332929839,
+        "amino_acids_prev_tags": [],
+        "nucleotides_tags": [],
+        "scans_n": 1,
+        "images": {
+            "1": {
+                "uploaded_t": 1332929840,
+                "uploader": "malikele",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "front": {
+                "rev": "13",
+                "white_magic": "checked",
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 104
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 26
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 52
+                    },
+                    "full": {
+                        "h": 1890,
+                        "w": 490
+                    }
+                },
+                "geometry": "490x1890-460-45",
+                "imgid": "2"
+            },
+            "ingredients": {
+                "rev": "7",
+                "white_magic": null,
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 157,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 39,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 545,
+                        "w": 1385
+                    },
+                    "200": {
+                        "h": 79,
+                        "w": 200
+                    }
+                },
+                "geometry": "1385x545-270-645",
+                "imgid": "3"
+            },
+            "front_fr": {
+                "rev": "13",
+                "white_magic": "checked",
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 104
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 26
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 52
+                    },
+                    "full": {
+                        "h": 1890,
+                        "w": 490
+                    }
+                },
+                "geometry": "490x1890-460-45",
+                "imgid": "2"
+            },
+            "2": {
+                "uploaded_t": 1332929858,
+                "uploader": "malikele",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": 1332930009,
+                "uploader": "malikele",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "rev": "7",
+                "white_magic": null,
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 157,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 39,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 545,
+                        "w": 1385
+                    },
+                    "200": {
+                        "h": 79,
+                        "w": 200
+                    }
+                },
+                "geometry": "1385x545-270-645",
+                "imgid": "3"
+            }
+        },
+        "ingredients_text_with_allergens_fr": "Contient du malt d'orge\r\nAlcool 8,3 % Vol.",
+        "ingredients_n": 1,
+        "editors_tags": [
+            "manu1400",
+            "malikele"
+        ],
+        "allergens_tags": [],
+        "countries_lc": "fr",
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "code": "5410228196693",
+        "codes_tags": [
+            "code-13",
+            "5410228196693",
+            "541022819669x",
+            "54102281966xx",
+            "5410228196xxx",
+            "541022819xxxx",
+            "54102281xxxxx",
+            "5410228xxxxxx",
+            "541022xxxxxxx",
+            "54102xxxxxxxx",
+            "5410xxxxxxxxx",
+            "541xxxxxxxxxx",
+            "54xxxxxxxxxxx",
+            "5xxxxxxxxxxxx"
+        ],
+        "labels": "",
+        "emb_code": "",
+        "last_modified_by": "manu1400",
+        "last_edit_dates_tags": [
+            "2012-09-01",
+            "2012-09",
+            "2012"
+        ],
+        "entry_dates_tags": [
+            "2012-03-28",
+            "2012-03",
+            "2012"
+        ],
+        "creator": "malikele",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "biere",
+            "blonde",
+            "belgique",
+            "tauro",
+            "jupiler"
+        ],
+        "amino_acids_tags": [],
+        "ingredients_debug": [
+            "Contient du malt d'orge\r\nAlcool 8",
+            ",",
+            null,
+            null,
+            null,
+            "3 % Vol."
+        ],
+        "languages_codes": {
+            "fr": 5
+        },
+        "labels_lc": "fr",
+        "packaging": "Bouteille",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/541/022/819/6693/front_fr.13.400.jpg",
+        "popularity_key": 1,
+        "last_image_dates_tags": [
+            "2012-03-28",
+            "2012-03",
+            "2012"
+        ],
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/541/022/819/6693/front_fr.13.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [
+            "en:ingredients-unknown-score-above-0",
+            "en:ingredients-100-percent-unknown",
+            "en:alcoholic-beverages-category-without-alcohol-value"
+        ],
+        "misc_tags": [
+            "en:nutriscore-not-computed",
+            "en:nutriscore-not-applicable",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "countries_debug_tags": [],
+        "nutrition_data_per": "100g",
+        "ecoscore_score": 47,
+        "photographers_tags": [
+            "malikele"
+        ],
+        "last_modified_t": 1346453678,
+        "ingredients": [
+            {
+                "percent_max": 100,
+                "id": "fr:Alcool 8,3 % Vol",
+                "text": "Alcool 8.3% Vol",
+                "percent_estimate": 100,
+                "percent_min": 100
+            }
+        ],
+        "stores": "",
+        "countries": "Belgique",
+        "cities_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "other_nutritional_substances_tags": [],
+        "brands": "Jupiler",
+        "categories": "Boissons, Boissons alcoolisées, Bières, Bières blondes",
+        "ingredients_text_with_allergens": "Contient du malt d'orge\r\nAlcool 8,3 % Vol.",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:photos-uploaded",
+        "nutrient_levels_tags": [],
+        "known_ingredients_n": 0,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Contient du malt d'orge\r\nAlcool 8,3 % Vol.",
+        "product_name": "Bière Tauro",
+        "origins": "Belgique",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Contient du malt d'orge\r\nAlcool 8,3 % Vol.",
+        "categories_lc": "fr",
+        "allergens": "",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/541/022/819/6693/ingredients_fr.7.100.jpg",
+        "photographers": [
+            "manu1400"
+        ],
+        "ecoscore_data": {
+            "grade_be": "b",
+            "status": "known",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 13,
+                    "transportation_value_es": 3,
+                    "transportation_value_be": 15,
+                    "transportation_value_ch": 11,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:belgium",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_be": 100,
+                    "epi_score": 74,
+                    "transportation_score_ch": 71,
+                    "epi_value": 2,
+                    "transportation_score_ie": 51,
+                    "value_nl": 16,
+                    "value_ie": 10,
+                    "value_fr": 15,
+                    "transportation_value_de": 11,
+                    "value_be": 17,
+                    "value_es": 5,
+                    "transportation_score_it": 45,
+                    "transportation_value_ie": 8,
+                    "transportation_score_de": 76,
+                    "transportation_score_fr": 85,
+                    "origins_from_origins_field": [
+                        "en:belgium"
+                    ],
+                    "transportation_value_lu": 13,
+                    "transportation_value_nl": 14,
+                    "value_ch": 13,
+                    "transportation_score_es": 21,
+                    "value_de": 13,
+                    "transportation_value_it": 7,
+                    "transportation_score_lu": 89,
+                    "value_it": 9,
+                    "value_lu": 15,
+                    "transportation_score_nl": 92
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:bottle",
+                            "material": "en:unknown",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "warning": "unspecified_material",
+                    "score": 0
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "b",
+            "score": 47,
+            "grade_de": "b",
+            "missing_data_warning": 1,
+            "grade_nl": "b",
+            "score_be": 64,
+            "agribalyse": {
+                "co2_transportation": "0.268586",
+                "ef_distribution": "0.0088128735",
+                "name_fr": "Bière \"coeur de marché\" (4-5° alcool)",
+                "score": 57,
+                "agribalyse_food_code": "5001",
+                "ef_agriculture": "0.0084453762",
+                "ef_consumption": "0.0024293397",
+                "name_en": "Beer, regular (4-5° alcohol)",
+                "co2_total": "1.0944464",
+                "ef_packaging": "0.051649676000000005",
+                "ef_processing": "0.031844848999999995",
+                "is_beverage": 1,
+                "dqr": "2.84",
+                "co2_processing": "0.25081748",
+                "code": "5001",
+                "co2_consumption": "0.0047993021",
+                "co2_distribution": "0.028932423",
+                "ef_total": "0.12383059000000002",
+                "co2_agriculture": "0.044404353",
+                "ef_transportation": "0.02064847",
+                "co2_packaging": "0.49690685"
+            },
+            "grade_it": "c",
+            "score_nl": 63,
+            "score_ch": 60,
+            "missing": {
+                "packagings": 1,
+                "labels": 1
+            },
+            "grade_ie": "c",
+            "score_fr": 62,
+            "score_de": 60,
+            "score_lu": 62,
+            "score_ie": 57,
+            "score_it": 56,
+            "score_es": 52,
+            "grade_lu": "b",
+            "grade": "c",
+            "grade_ch": "b",
+            "grade_es": "c"
+        },
+        "selected_images": {
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/541/022/819/6693/ingredients_fr.7.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/541/022/819/6693/ingredients_fr.7.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/541/022/819/6693/ingredients_fr.7.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/541/022/819/6693/front_fr.13.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/541/022/819/6693/front_fr.13.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/541/022/819/6693/front_fr.13.200.jpg"
+                }
+            }
+        },
+        "rev": 16,
+        "origins_old": "Belgique",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "manu1400",
+        "additives_prev_original_tags": [],
+        "ingredients_tags": [
+            "fr:alcool-8",
+            "fr:3-vol"
+        ],
+        "labels_prev_tags": [],
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:beverages",
+            "en:alcoholic-beverages",
+            "en:beers",
+            "en:lagers"
+        ],
+        "ecoscore_grade": "c",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "labels_prev_hierarchy": [],
+        "ingredients_percent_analysis": 1,
+        "languages": {
+            "en:french": 5
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-5001",
+            "agribalyse-food-code-known",
+            "agribalyse-proxy-food-code-5000",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-5001",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-5001"
+        ],
+        "purchase_places": "",
+        "no_nutrition_data": null,
+        "allergens_from_user": "(fr) ",
+        "checkers": [],
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/541/022/819/6693/ingredients_fr.7.400.jpg",
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:ingredients-unknown-score-above-0",
+            "en:ingredients-100-percent-unknown",
+            "en:alcoholic-beverages-category-without-alcohol-value"
+        ],
+        "additives_old_tags": [],
+        "ingredients_from_palm_oil_n": 0,
+        "ecoscore_tags": [
+            "c"
+        ],
+        "labels_hierarchy": [],
+        "origins_hierarchy": [
+            "en:belgium"
+        ],
+        "complete": 0,
+        "pnns_groups_2": "Alcoholic beverages",
+        "nutrition_score_beverage": 1,
+        "new_additives_n": 0,
+        "product_quantity": 330,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/541/022/819/6693/front_fr.13.100.jpg",
+        "ingredients_text_debug": "Contient du malt d'orge\r\nAlcool 8,3 % Vol.",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/541/022/819/6693/front_fr.13.400.jpg",
+        "_id": "5410228196693",
+        "countries_tags": [
+            "en:belgium"
+        ],
+        "ingredients_hierarchy": [
+            "fr:Alcool 8",
+            "fr:3 % Vol"
+        ],
+        "not_names_tags": [
+            "",
+            "stabilisant"
+        ],
+        "stores_tags": [],
+        "additives_original_tags": [],
+        "compared_to_category": "en:lagers",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "correctors": [],
+        "ingredients_n_tags": [
+            "1",
+            "1-10"
+        ],
+        "nutrition_score_debug": "no nutriscore for category en:alcoholic-beverages",
+        "additives_old_n": 0,
+        "packagings": [
+            {
+                "shape": "en:bottle"
+            }
+        ],
+        "brands_tags": [
+            "jupiler"
+        ],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "data_quality_errors_tags": [],
+        "quantity": "33 cl",
+        "ingredients_ids_debug": [
+            "contient-du-malt-d-orge-alcool-8",
+            "3-vol"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "ingredients_original_tags": [
+            "fr:Alcool 8,3 % Vol"
+        ],
+        "unknown_ingredients_n": "2",
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "emb_codes": "",
+        "max_imgid": "3",
+        "editors": [
+            "manu1400",
+            "malikele"
+        ],
+        "image_small_url": "https://static.openfoodfacts.net/images/products/541/022/819/6693/front_fr.13.200.jpg",
+        "generic_name_fr": "Bière",
+        "nutriments": {
+            "alcohol": 8.3,
+            "alcohol_100g": 8.3,
+            "alcohol_serving": 8.3,
+            "alcohol_unit": "% vol",
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0
+        },
+        "purchase_places_tags": [],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/541/022/819/6693/ingredients_fr.7.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/5449000179661.json
+++ b/testdata/product/5449000179661.json
@@ -1,0 +1,920 @@
+{
+    "status": 1,
+    "code": "5449000179661",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "popularity_tags": [
+            "top-country-mx-scans-2019"
+        ],
+        "categories_tags": [
+            "en:beverages",
+            "en:sweetened-beverages",
+            "fr:citronnades"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "informers": [],
+        "origins_tags": [],
+        "product_name_fr": "Limon & Nada - Citronnade",
+        "generic_name": "Citronnade",
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1340109717,
+        "additives_n": 2,
+        "emb_codes_20141016": "",
+        "carbon_footprint_from_known_ingredients_debug": "en:lemon-juice-from-concentrate 13% x 0.3 = 3.9 g - ",
+        "pnns_groups_2_tags": [
+            "sweetened-beverages",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "charlesnepote",
+            "manu1400",
+            "quechoisir"
+        ],
+        "sortkey": 1582769846,
+        "categories_old": "Boissons, Boissons avec sucre ajouté, Citronnades",
+        "completeness": 0.7875,
+        "categories_properties": {},
+        "traces_from_user": "(fr) ",
+        "labels_tags": [
+            "en:no-preservatives"
+        ],
+        "nutrition_grades_tags": [
+            "unknown"
+        ],
+        "informers_tags": [
+            "charlesnepote",
+            "manu1400",
+            "roboto-app",
+            "quechoisir"
+        ],
+        "vitamins_tags": [],
+        "lang": "fr",
+        "origins_lc": "fr",
+        "interface_version_modified": "20150316.jqm2",
+        "unique_scans_n": 2,
+        "additives_tags": [
+            "en:e160a",
+            "en:e160ai",
+            "en:e300"
+        ],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/544/900/017/9661/nutrition_fr.6.400.jpg",
+        "unknown_nutrients_tags": [],
+        "nova_group_debug": " -- ingredients/en:sugar : 3 -- additives/en:e160a : 4",
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "traces_tags": [],
+        "packaging_tags": [
+            "canette"
+        ],
+        "nova_groups": "4",
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/544/900/017/9661/front_fr.3.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:may-contain-palm-oil",
+            "en:maybe-vegan",
+            "en:maybe-vegetarian"
+        ],
+        "nutrient_levels": {
+            "sugars": "high",
+            "salt": "low",
+            "fat": "low",
+            "saturated-fat": "low"
+        },
+        "created_t": 1340109318,
+        "amino_acids_prev_tags": [],
+        "nova_group": 4,
+        "nucleotides_tags": [],
+        "scans_n": 6,
+        "images": {
+            "nutrition": {
+                "rev": "6",
+                "white_magic": null,
+                "geometry": "1210x830-450-475",
+                "sizes": {
+                    "400": {
+                        "h": 274,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 69,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 137,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 830,
+                        "w": 1210
+                    }
+                },
+                "normalize": null,
+                "imgid": "2"
+            },
+            "nutrition_fr": {
+                "rev": "6",
+                "white_magic": null,
+                "geometry": "1210x830-450-475",
+                "sizes": {
+                    "400": {
+                        "h": 274,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 69,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 137,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 830,
+                        "w": 1210
+                    }
+                },
+                "normalize": null,
+                "imgid": "2"
+            },
+            "front_fr": {
+                "rev": "3",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 234
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 58
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 117
+                    },
+                    "full": {
+                        "h": 1975,
+                        "w": 1155
+                    }
+                },
+                "normalize": null,
+                "geometry": "1155x1975-100-25",
+                "imgid": "1"
+            },
+            "ingredients": {
+                "rev": "5",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 335
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 84
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 167
+                    },
+                    "full": {
+                        "h": 1440,
+                        "w": 1205
+                    }
+                },
+                "normalize": null,
+                "geometry": "1205x1440-455-60",
+                "imgid": "2"
+            },
+            "1": {
+                "uploaded_t": 1340109629,
+                "uploader": "charlesnepote",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "front": {
+                "rev": "3",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 234
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 58
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 117
+                    },
+                    "full": {
+                        "h": 1975,
+                        "w": 1155
+                    }
+                },
+                "normalize": null,
+                "geometry": "1155x1975-100-25",
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": 1340109717,
+                "uploader": "charlesnepote",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "rev": "5",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 335
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 84
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 167
+                    },
+                    "full": {
+                        "h": 1440,
+                        "w": 1205
+                    }
+                },
+                "normalize": null,
+                "geometry": "1205x1440-455-60",
+                "imgid": "2"
+            }
+        },
+        "ingredients_text_with_allergens_fr": "Eau ; jus de citron à base de concentré (13%) ; sucre ; pulpe de citron ; arômes ; antioxydant ; acide ascorbique ; colorant : bêta-carotène",
+        "ingredients_n": 9,
+        "editors_tags": [
+            "roboto-app",
+            "manu1400",
+            "quechoisir",
+            "charlesnepote"
+        ],
+        "allergens_tags": [],
+        "countries_lc": "fr",
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "code": "5449000179661",
+        "codes_tags": [
+            "code-13",
+            "5449000179xxx",
+            "544900017xxxx",
+            "54490001xxxxx",
+            "5449000xxxxxx",
+            "544900xxxxxxx",
+            "54490xxxxxxxx",
+            "5449xxxxxxxxx",
+            "544xxxxxxxxxx",
+            "54xxxxxxxxxxx",
+            "5xxxxxxxxxxxx"
+        ],
+        "labels": "en:no-preservatives",
+        "last_modified_by": "quechoisir",
+        "last_edit_dates_tags": [
+            "2021-02-23",
+            "2021-02",
+            "2021"
+        ],
+        "entry_dates_tags": [
+            "2012-06-19",
+            "2012-06",
+            "2012"
+        ],
+        "creator": "charlesnepote",
+        "ingredients_that_may_be_from_palm_oil_n": 1,
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "citronnade",
+            "maid",
+            "boisson",
+            "no-preservative",
+            "avec",
+            "minute",
+            "sucre",
+            "limon",
+            "ajoute",
+            "nada"
+        ],
+        "ingredients_debug": [
+            "Eau ",
+            ";",
+            ";",
+            null,
+            null,
+            " jus de citron à base de concentré ",
+            "(",
+            "(",
+            null,
+            null,
+            "13%) ",
+            ";",
+            ";",
+            null,
+            null,
+            " sucre ",
+            ";",
+            ";",
+            null,
+            null,
+            " pulpe de citron ",
+            ";",
+            ";",
+            null,
+            null,
+            " arômes ",
+            ";",
+            ";",
+            null,
+            null,
+            " antioxydant ",
+            ":",
+            ":",
+            null,
+            null,
+            " ",
+            ";",
+            ";",
+            null,
+            null,
+            " acide ascorbique ",
+            ";",
+            ";",
+            null,
+            null,
+            " colorant ",
+            ":",
+            ":",
+            null,
+            null,
+            "  bêta-carotène"
+        ],
+        "languages_codes": {
+            "fr": 6
+        },
+        "labels_lc": "en",
+        "packaging": "Canette",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/544/900/017/9661/front_fr.3.400.jpg",
+        "last_image_dates_tags": [
+            "2012-06-19",
+            "2012-06",
+            "2012"
+        ],
+        "popularity_key": 2,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/544/900/017/9661/front_fr.3.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [
+            "en:nutrition-value-under-0-1-g-salt",
+            "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
+            "en:ecoscore-packaging-unspecified-material"
+        ],
+        "misc_tags": [
+            "en:nutriscore-not-computed",
+            "en:nutrition-not-enough-data-to-compute-nutrition-score",
+            "en:nutriscore-missing-nutrition-data",
+            "en:nutriscore-missing-nutrition-data-proteins",
+            "en:ecoscore-not-computed"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "countries_debug_tags": [],
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "charlesnepote"
+        ],
+        "last_modified_t": 1614040025,
+        "ingredients": [
+            {
+                "percent_max": 87,
+                "id": "en:water",
+                "percent_min": "13",
+                "percent_estimate": 50,
+                "text": "Eau",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent": "13",
+                "percent_min": "13",
+                "percent_estimate": "13",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "13",
+                "id": "en:lemon-juice-from-concentrate",
+                "text": "jus de citron à base de concentré"
+            },
+            {
+                "percent_max": "13",
+                "id": "en:sugar",
+                "text": "sucre",
+                "percent_min": 0,
+                "percent_estimate": 6.5,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": "13",
+                "id": "en:lemon-pulpe",
+                "text": "pulpe de citron",
+                "percent_min": 0,
+                "percent_estimate": 6.5,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": "13",
+                "id": "en:flavouring",
+                "text": "arômes",
+                "percent_min": 0,
+                "percent_estimate": 6.5,
+                "vegan": "maybe",
+                "vegetarian": "maybe"
+            },
+            {
+                "percent_max": "13",
+                "id": "en:antioxidant",
+                "percent_min": 0,
+                "percent_estimate": 6.5,
+                "text": "antioxydant"
+            },
+            {
+                "percent_max": "13",
+                "id": "en:e300",
+                "text": "acide ascorbique",
+                "percent_estimate": 5.5,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 12.4166666666667,
+                "id": "en:colour",
+                "percent_min": 0,
+                "percent_estimate": 5.5,
+                "text": "colorant"
+            }
+        ],
+        "stores": "",
+        "countries": "France",
+        "cities_tags": [],
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "brands": "Minute Maid",
+        "categories": "Boissons, Boissons avec sucre ajouté, Citronnades",
+        "ingredients_text_with_allergens": "Eau ; jus de citron à base de concentré (13%) ; sucre ; pulpe de citron ; arômes ; antioxydant ; acide ascorbique ; colorant : bêta-carotène",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-to-be-completed, en:origins-to-be-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:packaging-photo-to-be-selected, en:nutrition-photo-selected, en:ingredients-photo-selected, en:front-photo-selected, en:photos-uploaded",
+        "nutrient_levels_tags": [
+            "en:fat-in-low-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-high-quantity",
+            "en:salt-in-low-quantity"
+        ],
+        "known_ingredients_n": 13,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Eau ; jus de citron à base de concentré (13%) ; sucre ; pulpe de citron ; arômes ; antioxydant ; acide ascorbique ; colorant : bêta-carotène",
+        "product_name": "Limon & Nada - Citronnade",
+        "origins": "",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Eau ; jus de citron à base de concentré (13%) ; sucre ; pulpe de citron ; arômes ; antioxydant ; acide ascorbique ; colorant : bêta-carotène",
+        "categories_lc": "fr",
+        "allergens": "",
+        "serving_quantity": "330",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/544/900/017/9661/ingredients_fr.5.100.jpg",
+        "photographers": [],
+        "ecoscore_data": {
+            "missing_agribalyse_match_warning": 1,
+            "status": "unknown",
+            "agribalyse": {
+                "warning": "missing_agribalyse_match"
+            },
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:drink-can",
+                            "material": "en:unknown",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "warning": "unspecified_material",
+                    "score": 0
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "transportation_score_lu": 0,
+                    "value_it": -5,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_ch": 0,
+                    "epi_value": -5,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 0,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "threatened_species": {}
+            },
+            "missing": {
+                "agb_category": 1,
+                "packagings": 1,
+                "labels": 1,
+                "origins": 1
+            }
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/544/900/017/9661/nutrition_fr.6.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/544/900/017/9661/nutrition_fr.6.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/544/900/017/9661/nutrition_fr.6.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/544/900/017/9661/ingredients_fr.5.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/544/900/017/9661/ingredients_fr.5.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/544/900/017/9661/ingredients_fr.5.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/544/900/017/9661/front_fr.3.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/544/900/017/9661/front_fr.3.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/544/900/017/9661/front_fr.3.200.jpg"
+                }
+            }
+        },
+        "rev": 11,
+        "origins_old": "",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 1,
+        "last_editor": "quechoisir",
+        "additives_prev_original_tags": [
+            "en:e300",
+            "en:e160a"
+        ],
+        "ingredients_tags": [
+            "en:water",
+            "en:lemon-juice-concentrate",
+            "en:fruit",
+            "en:citrus-fruit",
+            "en:lemon",
+            "en:sugar",
+            "en:lemon-pulpe",
+            "en:flavouring",
+            "en:antioxidant",
+            "en:e300",
+            "en:colour",
+            "en:e160ai",
+            "en:e160a"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/544/900/017/9661/nutrition_fr.6.100.jpg",
+        "ingredients_from_palm_oil_tags": [],
+        "carbon_footprint_percent_of_known_ingredients": 13,
+        "categories_hierarchy": [
+            "en:beverages",
+            "en:sweetened-beverages",
+            "fr:citronnades"
+        ],
+        "ecoscore_grade": "unknown",
+        "ingredients_that_may_be_from_palm_oil_tags": [
+            "e160a-beta-carotene"
+        ],
+        "ingredients_percent_analysis": 1,
+        "nutrition_data": "on",
+        "languages": {
+            "en:french": 6
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-unknown",
+            "agribalyse-unknown"
+        ],
+        "purchase_places": "Marseille,France",
+        "id": "5449000179661",
+        "no_nutrition_data": null,
+        "pnns_groups_1": "Beverages",
+        "allergens_from_user": "(fr) ",
+        "checkers": [],
+        "additives_debug_tags": [
+            "en-e160ai-added"
+        ],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/544/900/017/9661/ingredients_fr.5.400.jpg",
+        "data_quality_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish",
+            "en:nutrition-value-under-0-1-g-salt",
+            "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
+            "en:ecoscore-packaging-unspecified-material"
+        ],
+        "additives_old_tags": [
+            "en:e300",
+            "en:e160a"
+        ],
+        "ecoscore_tags": [
+            "unknown"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "labels_hierarchy": [
+            "en:no-preservatives"
+        ],
+        "origins_hierarchy": [],
+        "complete": 0,
+        "nutrition_score_beverage": 1,
+        "pnns_groups_2": "Sweetened beverages",
+        "new_additives_n": 2,
+        "product_quantity": "330",
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/544/900/017/9661/front_fr.3.100.jpg",
+        "ingredients_text_debug": "Eau ; jus de citron à base de concentré (13%) ; sucre ; pulpe de citron ; arômes ; antioxydant : ; acide ascorbique ; colorant :  bêta-carotène",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/544/900/017/9661/front_fr.3.400.jpg",
+        "_id": "5449000179661",
+        "countries_tags": [
+            "en:france"
+        ],
+        "serving_size": "330 ml",
+        "ingredients_hierarchy": [
+            "en:water",
+            "en:lemon-juice-concentrate",
+            "en:fruit",
+            "en:citrus-fruit",
+            "en:lemon",
+            "en:sugar",
+            "en:lemon-pulpe",
+            "en:flavouring",
+            "en:antioxidant",
+            "en:e300",
+            "en:colour",
+            "en:e160ai",
+            "en:e160a"
+        ],
+        "stores_tags": [],
+        "additives_original_tags": [
+            "en:e300",
+            "en:e160ai"
+        ],
+        "compared_to_category": "fr:citronnades",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:origins-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "correctors": [],
+        "ingredients_n_tags": [
+            "9",
+            "1-10"
+        ],
+        "pnns_groups_1_tags": [
+            "beverages",
+            "known"
+        ],
+        "nutrition_score_debug": "missing proteins",
+        "additives_old_n": 2,
+        "packagings": [
+            {
+                "shape": "en:drink-can"
+            }
+        ],
+        "data_quality_info_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish"
+        ],
+        "brands_tags": [
+            "minute-maid"
+        ],
+        "data_quality_errors_tags": [],
+        "quantity": "330 ml",
+        "ingredients_ids_debug": [
+            "eau",
+            "jus-de-citron-a-base-de-concentre",
+            "13",
+            "sucre",
+            "pulpe-de-citron",
+            "aromes",
+            "antioxydant",
+            "acide-ascorbique",
+            "colorant",
+            "beta-carotene"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "ingredients_original_tags": [
+            "en:water",
+            "en:lemon-juice-from-concentrate",
+            "en:sugar",
+            "en:lemon-pulpe",
+            "en:flavouring",
+            "en:antioxidant",
+            "en:e300",
+            "en:colour",
+            "en:e160ai"
+        ],
+        "unknown_ingredients_n": 0,
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "emb_codes": "",
+        "max_imgid": "2",
+        "editors": [
+            "charlesnepote",
+            "manu1400"
+        ],
+        "image_small_url": "https://static.openfoodfacts.net/images/products/544/900/017/9661/front_fr.3.200.jpg",
+        "generic_name_fr": "Citronnade",
+        "nutriments": {
+            "salt_serving": 0.0838,
+            "energy_100g": 192,
+            "carbohydrates_unit": "g",
+            "saturated-fat_serving": 0,
+            "energy-kj_100g": 192,
+            "sodium_100g": 0.01016,
+            "energy-kcal": 45,
+            "sugars_100g": 10.8,
+            "sodium_value": 0.01016,
+            "salt_100g": 0.0254,
+            "nova-group_serving": 4,
+            "energy_unit": "kJ",
+            "energy-kj_serving": 634,
+            "salt_unit": "g",
+            "carbohydrates_value": 10.8,
+            "sugars_unit": "g",
+            "sugars_serving": 35.6,
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt": 0.0254,
+            "salt_value": 0.0254,
+            "fiber_serving": 0,
+            "saturated-fat_100g": 0,
+            "energy-kcal_100g": 45,
+            "fat_serving": 0,
+            "fiber_100g": 0,
+            "saturated-fat": 0,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 13,
+            "fat_value": 0,
+            "carbon-footprint-from-known-ingredients_100g": 3.9,
+            "nova-group": 4,
+            "energy": 192,
+            "fiber": 0,
+            "saturated-fat_value": 0,
+            "energy-kcal_value": 45,
+            "nova-group_100g": 4,
+            "fat_100g": 0,
+            "energy_serving": 634,
+            "saturated-fat_unit": "g",
+            "energy_value": 192,
+            "sodium_serving": 0.0335,
+            "carbon-footprint-from-known-ingredients_serving": 12.9,
+            "energy-kj_value": 192,
+            "fiber_value": 0,
+            "fiber_unit": "g",
+            "carbon-footprint-from-known-ingredients_product": 12.9,
+            "energy-kj": 192,
+            "sugars_value": 10.8,
+            "sodium_unit": "g",
+            "carbohydrates_serving": 35.6,
+            "carbohydrates_100g": 10.8,
+            "sodium": 0.01016,
+            "sugars": 10.8,
+            "carbohydrates": 10.8,
+            "energy-kcal_serving": 148,
+            "energy-kcal_unit": "kcal",
+            "fat": 0
+        },
+        "purchase_places_tags": [
+            "marseille",
+            "france"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/544/900/017/9661/ingredients_fr.5.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/544/900/017/9661/nutrition_fr.6.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/5601077161035.json
+++ b/testdata/product/5601077161035.json
@@ -1,0 +1,570 @@
+{
+    "status": 1,
+    "code": "5601077161035",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {
+            "ciqual_food_name:fr": "Vin doux",
+            "ciqual_food_name:en": "Wine, white, sweet"
+        },
+        "categories_tags": [
+            "en:beverages",
+            "en:alcoholic-beverages",
+            "en:wines",
+            "en:fortified-wines",
+            "en:sweet-wines",
+            "en:fortified-wines-such-as-natural-sweet-wines",
+            "en:wines-from-portugal",
+            "fr:porto"
+        ],
+        "traces_hierarchy": [
+            "en:sulphur-dioxide-and-sulphites"
+        ],
+        "informers": [
+            "manu1400"
+        ],
+        "allergens_hierarchy": [],
+        "generic_name": "Porto",
+        "product_name_fr": "Special reserve porto",
+        "origins_tags": [
+            "en:portugal"
+        ],
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1333919151,
+        "emb_codes_20141016": "",
+        "pnns_groups_2_tags": [
+            "alcoholic-beverages",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "malikele",
+            "manu1400"
+        ],
+        "sortkey": 1355588807,
+        "categories_old": "Boissons, Boissons alcoolisées, Vins, Vins mutés, Vins doux, Vins mutés de type vin doux naturel, Vins portugais, Porto",
+        "completeness": 0.666666666666667,
+        "categories_properties": {
+            "ciqual_food_code:en": "1006",
+            "agribalyse_food_code:en": "1006"
+        },
+        "labels_tags": [],
+        "traces_from_user": "(fr) en:sulphur-dioxide-and-sulphites",
+        "informers_tags": [
+            "malikele",
+            "manu1400"
+        ],
+        "nutrition_grades_tags": [
+            "not-applicable"
+        ],
+        "vitamins_tags": [],
+        "lang": "fr",
+        "origins_lc": "fr",
+        "interface_version_modified": "20120622",
+        "additives_tags": [],
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:portugal"
+        ],
+        "nova_group_debug": "no nova group when the product does not have ingredients",
+        "traces_tags": [
+            "en:sulphur-dioxide-and-sulphites"
+        ],
+        "packaging_tags": [
+            "bouteille"
+        ],
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/560/107/716/1035/front_fr.6.100.jpg",
+        "nutrient_levels": {},
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "created_t": 1333918502,
+        "amino_acids_prev_tags": [],
+        "nucleotides_tags": [],
+        "ingredients_text_with_allergens_fr": "",
+        "images": {
+            "1": {
+                "uploaded_t": 1333918502,
+                "uploader": "malikele",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "front_fr": {
+                "rev": "6",
+                "white_magic": "checked",
+                "geometry": "465x1710-570-95",
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 109
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 27
+                    },
+                    "full": {
+                        "h": 1710,
+                        "w": 465
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 54
+                    }
+                },
+                "imgid": "2"
+            },
+            "front": {
+                "rev": "6",
+                "white_magic": "checked",
+                "geometry": "465x1710-570-95",
+                "normalize": "checked",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 109
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 27
+                    },
+                    "full": {
+                        "h": 1710,
+                        "w": 465
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 54
+                    }
+                },
+                "imgid": "2"
+            },
+            "2": {
+                "uploaded_t": 1333918523,
+                "uploader": "malikele",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": 1333919151,
+                "uploader": "malikele",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1500,
+                        "w": 2000
+                    }
+                }
+            }
+        },
+        "editors_tags": [
+            "manu1400",
+            "malikele"
+        ],
+        "countries_lc": "fr",
+        "allergens_tags": [],
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "code": "5601077161035",
+        "codes_tags": [
+            "code-13",
+            "5601077161035",
+            "560107716103x",
+            "56010771610xx",
+            "5601077161xxx",
+            "560107716xxxx",
+            "56010771xxxxx",
+            "5601077xxxxxx",
+            "560107xxxxxxx",
+            "56010xxxxxxxx",
+            "5601xxxxxxxxx",
+            "560xxxxxxxxxx",
+            "56xxxxxxxxxxx",
+            "5xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "manu1400",
+        "emb_code": "",
+        "labels": "",
+        "entry_dates_tags": [
+            "2012-04-08",
+            "2012-04",
+            "2012"
+        ],
+        "last_edit_dates_tags": [
+            "2012-12-15",
+            "2012-12",
+            "2012"
+        ],
+        "creator": "malikele",
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "porto",
+            "special",
+            "reserve",
+            "portugal",
+            "calem",
+            "boisson",
+            "alcoolisee"
+        ],
+        "ingredients_debug": [],
+        "labels_lc": "fr",
+        "languages_codes": {
+            "fr": 3
+        },
+        "packaging": "Bouteille",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/560/107/716/1035/front_fr.6.400.jpg",
+        "last_image_dates_tags": [
+            "2012-04-08",
+            "2012-04",
+            "2012"
+        ],
+        "popularity_key": 0,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/560/107/716/1035/front_fr.6.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [
+            "en:alcoholic-beverages-category-without-alcohol-value"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutriscore-not-computed",
+            "en:nutriscore-not-applicable",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "countries_debug_tags": [],
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "malikele"
+        ],
+        "ecoscore_score": 35,
+        "last_modified_t": 1355588807,
+        "ingredients": [],
+        "countries": "Portugal",
+        "stores": "",
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "wine-white-sweet"
+        ],
+        "cities_tags": [],
+        "brands": "Calem",
+        "categories": "Boissons, Boissons alcoolisées, Vins, Vins mutés, Vins doux, Vins mutés de type vin doux naturel, Vins portugais, Porto",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-to-be-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:photos-uploaded",
+        "ingredients_text_with_allergens": "",
+        "nutrient_levels_tags": [],
+        "minerals_prev_tags": [],
+        "product_name": "Special reserve porto",
+        "ingredients_text": "",
+        "origins": "Portugal",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "",
+        "allergens": "",
+        "categories_lc": "fr",
+        "photographers": [
+            "manu1400"
+        ],
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "c",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:bottle",
+                            "material": "en:unknown",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "warning": "unspecified_material",
+                    "score": 0
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_es": 10,
+                    "transportation_value_fr": 7,
+                    "transportation_value_be": 11,
+                    "transportation_value_ch": 8,
+                    "transportation_score_be": 71,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:portugal",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_score": 57,
+                    "epi_value": 1,
+                    "transportation_score_ch": 53,
+                    "transportation_score_ie": 60,
+                    "value_nl": 12,
+                    "value_ie": 10,
+                    "transportation_value_de": 11,
+                    "value_fr": 8,
+                    "value_be": 12,
+                    "value_es": 11,
+                    "transportation_value_ie": 9,
+                    "transportation_score_it": 60,
+                    "transportation_score_de": 71,
+                    "origins_from_origins_field": [
+                        "en:portugal"
+                    ],
+                    "transportation_score_fr": 46,
+                    "transportation_value_nl": 11,
+                    "transportation_value_lu": 9,
+                    "value_ch": 9,
+                    "transportation_score_es": 69,
+                    "transportation_value_it": 9,
+                    "value_de": 12,
+                    "value_it": 10,
+                    "transportation_score_lu": 62,
+                    "value_lu": 10,
+                    "transportation_score_nl": 71
+                },
+                "threatened_species": {
+                    "warning": "ingredients_missing"
+                }
+            },
+            "grade_fr": "c",
+            "score": 35,
+            "grade_de": "c",
+            "missing_data_warning": 1,
+            "grade_nl": "c",
+            "score_be": 47,
+            "agribalyse": {
+                "co2_transportation": "0.19473145",
+                "ef_distribution": "0.004428340199999999",
+                "name_fr": "Vin doux",
+                "agribalyse_food_code": "1006",
+                "score": 45,
+                "ef_consumption": "0.0024293397",
+                "ef_agriculture": "0.087003491",
+                "name_en": "Wine, white, sweet",
+                "ef_packaging": "0.051649676000000005",
+                "co2_total": "1.0162479",
+                "ef_processing": "0.01220053",
+                "is_beverage": 1,
+                "code": "1006",
+                "co2_processing": "0.035796377",
+                "dqr": "3.01",
+                "co2_consumption": "0.0047993021",
+                "ef_total": "0.17296703",
+                "co2_distribution": "0.012389304",
+                "co2_agriculture": "0.27162412",
+                "ef_transportation": "0.015250933",
+                "co2_packaging": "0.49690685"
+            },
+            "grade_it": "c",
+            "score_nl": 47,
+            "grade_ie": "c",
+            "missing": {
+                "packagings": 1,
+                "ingredients": 1,
+                "labels": 1
+            },
+            "score_ch": 44,
+            "score_de": 47,
+            "score_fr": 43,
+            "score_ie": 45,
+            "score_lu": 45,
+            "score_it": 45,
+            "score_es": 46,
+            "grade_ch": "c",
+            "grade_es": "c",
+            "grade_lu": "c",
+            "grade": "d"
+        },
+        "selected_images": {
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/560/107/716/1035/front_fr.6.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/560/107/716/1035/front_fr.6.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/560/107/716/1035/front_fr.6.200.jpg"
+                }
+            }
+        },
+        "origins_old": "Portugal",
+        "rev": 10,
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "manu1400",
+        "additives_prev_original_tags": [],
+        "ingredients_tags": [],
+        "labels_prev_tags": [],
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:beverages",
+            "en:alcoholic-beverages",
+            "en:wines",
+            "en:fortified-wines",
+            "en:sweet-wines",
+            "en:fortified-wines-such-as-natural-sweet-wines",
+            "en:wines-from-portugal",
+            "fr:porto"
+        ],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "d",
+        "labels_prev_hierarchy": [],
+        "languages": {
+            "en:french": 3
+        },
+        "ingredients_percent_analysis": 1,
+        "purchase_places": "",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-1006",
+            "agribalyse-food-code-known",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-1006",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-1006"
+        ],
+        "no_nutrition_data": null,
+        "checkers": [],
+        "allergens_from_user": "(fr) ",
+        "additives_debug_tags": [],
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:alcoholic-beverages-category-without-alcohol-value"
+        ],
+        "additives_old_tags": [],
+        "origins_hierarchy": [
+            "en:portugal"
+        ],
+        "labels_hierarchy": [],
+        "ecoscore_tags": [
+            "d"
+        ],
+        "nutrition_score_beverage": 1,
+        "pnns_groups_2": "Alcoholic beverages",
+        "complete": 0,
+        "product_quantity": 750,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/560/107/716/1035/front_fr.6.100.jpg",
+        "ingredients_text_debug": "",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/560/107/716/1035/front_fr.6.400.jpg",
+        "_id": "5601077161035",
+        "countries_tags": [
+            "en:portugal"
+        ],
+        "ingredients_hierarchy": [],
+        "additives_original_tags": [],
+        "stores_tags": [],
+        "compared_to_category": "fr:porto",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "correctors": [
+            "manu1400"
+        ],
+        "nutrition_score_debug": "no nutriscore for category en:alcoholic-beverages",
+        "packagings": [
+            {
+                "shape": "en:bottle"
+            }
+        ],
+        "quantity": "750 ml",
+        "data_quality_errors_tags": [],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "brands_tags": [
+            "calem"
+        ],
+        "ingredients_ids_debug": [],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [],
+        "traces": "en:sulphur-dioxide-and-sulphites",
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "max_imgid": "3",
+        "emb_codes": "",
+        "editors": [
+            "manu1400",
+            "malikele"
+        ],
+        "image_small_url": "https://static.openfoodfacts.net/images/products/560/107/716/1035/front_fr.6.200.jpg",
+        "generic_name_fr": "Porto",
+        "nutriments": {
+            "alcohol": 20,
+            "alcohol_100g": 20,
+            "alcohol_serving": 20,
+            "alcohol_unit": "% vol"
+        },
+        "purchase_places_tags": []
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/6194002510064.json
+++ b/testdata/product/6194002510064.json
@@ -1,0 +1,1503 @@
+{
+    "status": 1,
+    "code": "6194002510064",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "popularity_tags": [
+            "top-100000-scans-2019",
+            "at-least-5-scans-2019",
+            "top-75-percent-scans-2019",
+            "top-80-percent-scans-2019",
+            "top-85-percent-scans-2019",
+            "top-90-percent-scans-2019",
+            "top-100000-fr-scans-2019",
+            "top-country-fr-scans-2019",
+            "at-least-5-fr-scans-2019",
+            "top-500-tn-scans-2019",
+            "top-1000-tn-scans-2019",
+            "top-5000-tn-scans-2019",
+            "top-10000-tn-scans-2019",
+            "top-50000-tn-scans-2019",
+            "top-100000-tn-scans-2019",
+            "top-50000-scans-2020",
+            "top-100000-scans-2020",
+            "at-least-5-scans-2020",
+            "at-least-10-scans-2020",
+            "top-75-percent-scans-2020",
+            "top-80-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-50-tn-scans-2020",
+            "top-100-tn-scans-2020",
+            "top-500-tn-scans-2020",
+            "top-1000-tn-scans-2020",
+            "top-5000-tn-scans-2020",
+            "top-10000-tn-scans-2020",
+            "top-50000-tn-scans-2020",
+            "top-100000-tn-scans-2020",
+            "top-country-tn-scans-2020",
+            "at-least-5-tn-scans-2020",
+            "at-least-10-tn-scans-2020",
+            "top-500-tg-scans-2020",
+            "top-1000-tg-scans-2020",
+            "top-5000-tg-scans-2020",
+            "top-10000-tg-scans-2020",
+            "top-50000-tg-scans-2020",
+            "top-100000-tg-scans-2020"
+        ],
+        "categories_tags": [
+            "en:snacks",
+            "en:sweet-snacks",
+            "en:biscuits-and-cakes",
+            "en:biscuits",
+            "en:chocolate-biscuits",
+            "en:filled-biscuits"
+        ],
+        "traces_hierarchy": [
+            "en:nuts"
+        ],
+        "allergens_hierarchy": [
+            "en:gluten"
+        ],
+        "product_name_fr": "Biscuit fourré goût chocolat",
+        "generic_name": "Biscuit fourré à la créme goût chocolat",
+        "origins_tags": [
+            "en:tunisia"
+        ],
+        "languages_hierarchy": [
+            "en:arabic",
+            "en:french"
+        ],
+        "last_image_t": 1601670615,
+        "emb_codes_20141016": "",
+        "additives_n": 4,
+        "allergens_lc": "fr",
+        "pnns_groups_2_tags": [
+            "biscuits-and-cakes",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "yuka.Uy9rYk01b0tuUFl4bk5zZ29pbnIvdGg4K2FXSVVUK3ZPYm9QSWc9PQ",
+            "desan",
+            "openfoodfacts-contributors",
+            "org-app-foodbowel",
+            "quechoisir"
+        ],
+        "sortkey": 1601670615,
+        "categories_old": "Snacks, Snacks sucrés, Biscuits et gâteaux, Biscuits, Biscuits au chocolat, Biscuits fourrés",
+        "completeness": 0.9875,
+        "categories_properties": {
+            "agribalyse_proxy_food_code:en": "24036"
+        },
+        "labels_tags": [],
+        "traces_from_user": "(fr) en:nuts",
+        "informers_tags": [
+            "amine",
+            "yuka.Uy9rYk01b0tuUFl4bk5zZ29pbnIvdGg4K2FXSVVUK3ZPYm9QSWc9PQ",
+            "desan",
+            "openfoodfacts-contributors"
+        ],
+        "nutrition_grades_tags": [
+            "d"
+        ],
+        "vitamins_tags": [],
+        "lang": "fr",
+        "origins_lc": "fr",
+        "interface_version_modified": "20150316.jqm2",
+        "unique_scans_n": 15,
+        "additives_tags": [
+            "en:e322",
+            "en:e322i",
+            "en:e330",
+            "en:e500",
+            "en:e500ii",
+            "en:e503",
+            "en:e503ii"
+        ],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/619/400/251/0064/nutrition_fr.7.400.jpg",
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:france",
+            "en:tunisia"
+        ],
+        "nova_group_debug": " -- ingredients/en:sugar : 3 -- ingredients/en:hydrogenated-fat : 4",
+        "traces_tags": [
+            "en:nuts"
+        ],
+        "nova_groups": "4",
+        "packaging_tags": [
+            "frais",
+            "sec"
+        ],
+        "allergens_from_ingredients": "blé",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/619/400/251/0064/front_fr.20.100.jpg",
+        "nutrient_levels": {
+            "sugars": "high",
+            "salt": "moderate",
+            "fat": "moderate",
+            "saturated-fat": "high"
+        },
+        "ingredients_analysis_tags": [
+            "en:palm-oil",
+            "en:non-vegan",
+            "en:vegetarian-status-unknown"
+        ],
+        "created_t": 1359814671,
+        "nutriscore_data": {
+            "proteins": 7,
+            "negative_points": 18,
+            "sugars_points": 4,
+            "sodium_value": 220,
+            "score": 18,
+            "positive_points": 0,
+            "saturated_fat_value": 12,
+            "is_water": 0,
+            "proteins_points": 4,
+            "saturated_fat_points": 10,
+            "saturated_fat_ratio": 63.1578947368421,
+            "proteins_value": 7,
+            "saturated_fat_ratio_points": 9,
+            "fiber_points": 0,
+            "grade": "d",
+            "is_cheese": 0,
+            "energy": 824,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 0,
+            "energy_points": 2,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 2,
+            "is_fat": 0,
+            "energy_value": 824,
+            "is_beverage": 0,
+            "fiber_value": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 63.2,
+            "sugars_value": 20,
+            "saturated_fat": 12,
+            "sodium": 220,
+            "sugars": 20
+        },
+        "amino_acids_prev_tags": [],
+        "nova_group": 4,
+        "nutrition_grade_fr": "d",
+        "data_sources_imported": "Apps, app-foodbowel",
+        "scans_n": 18,
+        "nucleotides_tags": [],
+        "ingredients_text_with_allergens_fr": "Farine de <span class=\"allergen\">blé</span>, sucre, graisses végétales hydrogénées (palme, palmiste), lactosérum en poudre, cacao en poudre, lait en poudre, émulsifiant (lécithine de soja E476), sel, poudres à lever (bicarbonate d'ammonium, bicarbonate de soude, acide citrique), arômes identiques nature (chocolat, vanilline)",
+        "images": {
+            "nutrition": {
+                "rev": "7",
+                "ocr": 1,
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 276,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 69,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 138,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 979,
+                        "w": 1420
+                    }
+                },
+                "orientation": "0",
+                "normalize": null,
+                "geometry": "1420x979-736-467",
+                "imgid": "3"
+            },
+            "nutrition_fr": {
+                "rev": "7",
+                "ocr": 1,
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 276,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 69,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 138,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 979,
+                        "w": 1420
+                    }
+                },
+                "orientation": "0",
+                "normalize": null,
+                "geometry": "1420x979-736-467",
+                "imgid": "3"
+            },
+            "3": {
+                "uploaded_t": 1359814863,
+                "uploader": "amine",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1920,
+                        "w": 2560
+                    }
+                }
+            },
+            "6": {
+                "uploaded_t": 1568825235,
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2560,
+                        "w": 1920
+                    }
+                }
+            },
+            "9": {
+                "uploaded_t": 1601670614,
+                "uploader": "org-app-foodbowel",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 4608,
+                        "w": 3456
+                    }
+                }
+            },
+            "ingredients_ar": {
+                "y1": null,
+                "y2": null,
+                "rev": "13",
+                "x2": null,
+                "white_magic": null,
+                "x1": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 150
+                    },
+                    "full": {
+                        "h": 2560,
+                        "w": 1920
+                    }
+                },
+                "angle": null,
+                "geometry": "0x0-0-0",
+                "normalize": null,
+                "imgid": "4"
+            },
+            "front_ar": {
+                "y1": null,
+                "y2": null,
+                "rev": "16",
+                "x2": null,
+                "white_magic": null,
+                "x1": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 359
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 90
+                    },
+                    "full": {
+                        "h": 1916,
+                        "w": 1720
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 180
+                    }
+                },
+                "angle": null,
+                "geometry": "0x0-0-0",
+                "normalize": null,
+                "imgid": "5"
+            },
+            "front": {
+                "rev": "5",
+                "white_magic": null,
+                "geometry": "2304x1050-192-396",
+                "normalize": null,
+                "sizes": {
+                    "400": {
+                        "h": 182,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 46,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 91,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 1050,
+                        "w": 2304
+                    }
+                },
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": 1359814824,
+                "uploader": "amine",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1920,
+                        "w": 2560
+                    }
+                }
+            },
+            "ingredients": {
+                "rev": "6",
+                "ocr": 1,
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 367,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 92,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 628,
+                        "w": 685
+                    },
+                    "200": {
+                        "h": 183,
+                        "w": 200
+                    }
+                },
+                "orientation": "0",
+                "normalize": null,
+                "geometry": "685x628-51-684",
+                "imgid": "2"
+            },
+            "front_fr": {
+                "y1": "84.8125",
+                "rev": "20",
+                "y2": "205.8125",
+                "x2": "339.828125",
+                "x1": "29.828125",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 156,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 39,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 78,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 1393,
+                        "w": 3571
+                    }
+                },
+                "angle": "90",
+                "normalize": "false",
+                "geometry": "3571x1393-343-977",
+                "imgid": "7"
+            },
+            "7": {
+                "uploaded_t": 1601670611,
+                "uploader": "org-app-foodbowel",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 4608,
+                        "w": 3456
+                    }
+                }
+            },
+            "10": {
+                "uploaded_t": 1601670615,
+                "uploader": "org-app-foodbowel",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 4608,
+                        "w": 3456
+                    }
+                }
+            },
+            "1": {
+                "uploaded_t": 1359814672,
+                "uploader": "amine",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2560,
+                        "w": 1920
+                    }
+                }
+            },
+            "4": {
+                "uploaded_t": 1568824832,
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2560,
+                        "w": 1920
+                    }
+                }
+            },
+            "5": {
+                "uploaded_t": 1568825031,
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 359
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 90
+                    },
+                    "full": {
+                        "h": 1916,
+                        "w": 1720
+                    }
+                }
+            },
+            "8": {
+                "uploaded_t": 1601670613,
+                "uploader": "org-app-foodbowel",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 4608,
+                        "w": 3456
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "rev": "6",
+                "ocr": 1,
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 367,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 92,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 628,
+                        "w": 685
+                    },
+                    "200": {
+                        "h": 183,
+                        "w": 200
+                    }
+                },
+                "orientation": "0",
+                "normalize": null,
+                "geometry": "685x628-51-684",
+                "imgid": "2"
+            }
+        },
+        "ingredients_n": 18,
+        "editors_tags": [
+            "yuka.Uy9rYk01b0tuUFl4bk5zZ29pbnIvdGg4K2FXSVVUK3ZPYm9QSWc9PQ",
+            "quechoisir",
+            "desan",
+            "openfoodfacts-contributors",
+            "org-app-foodbowel",
+            "amine"
+        ],
+        "allergens_tags": [
+            "en:gluten"
+        ],
+        "traces_lc": "fr",
+        "countries_lc": "fr",
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "manufacturing_places": "",
+        "code": "6194002510064",
+        "codes_tags": [
+            "code-13",
+            "6194002510xxx",
+            "619400251xxxx",
+            "61940025xxxxx",
+            "6194002xxxxxx",
+            "619400xxxxxxx",
+            "61940xxxxxxxx",
+            "6194xxxxxxxxx",
+            "619xxxxxxxxxx",
+            "61xxxxxxxxxxx",
+            "6xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "quechoisir",
+        "labels": "",
+        "entry_dates_tags": [
+            "2013-02-02",
+            "2013-02",
+            "2013"
+        ],
+        "last_edit_dates_tags": [
+            "2021-02-22",
+            "2021-02",
+            "2021"
+        ],
+        "creator": "amine",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "la",
+            "creme",
+            "fourre",
+            "snack",
+            "tunisie",
+            "gateaux",
+            "chocolat",
+            "sucre",
+            "kif",
+            "biscuit",
+            "et",
+            "gout",
+            "au"
+        ],
+        "link": "",
+        "countries_imported": "France",
+        "ingredients_debug": [
+            "Farine de blé",
+            ",",
+            null,
+            null,
+            null,
+            " sucre",
+            ",",
+            null,
+            null,
+            null,
+            " graisses végétales hydrogénées ",
+            "(",
+            "(",
+            null,
+            null,
+            "palme",
+            ",",
+            null,
+            null,
+            null,
+            " palmiste)",
+            ",",
+            null,
+            null,
+            null,
+            " lactosérum en poudre",
+            ",",
+            null,
+            null,
+            null,
+            " cacao en poudre",
+            ",",
+            null,
+            null,
+            null,
+            " lait en poudre",
+            ",",
+            null,
+            null,
+            null,
+            " émulsifiant ",
+            ":",
+            ":",
+            null,
+            null,
+            " ",
+            "(",
+            "(",
+            null,
+            null,
+            "lécithine de soja ",
+            " - ",
+            " - ",
+            " - ",
+            null,
+            "e476",
+            " - ",
+            " - ",
+            " - ",
+            null,
+            ")",
+            ",",
+            null,
+            null,
+            null,
+            " sel",
+            ",",
+            null,
+            null,
+            null,
+            " poudres à lever ",
+            ":",
+            ":",
+            null,
+            null,
+            " ",
+            "(",
+            "(",
+            null,
+            null,
+            "bicarbonate d'ammonium",
+            ",",
+            null,
+            null,
+            null,
+            " bicarbonate de soude",
+            ",",
+            null,
+            null,
+            null,
+            " acide citrique)",
+            ",",
+            null,
+            null,
+            null,
+            " arômes identiques nature ",
+            "(",
+            "(",
+            null,
+            null,
+            "chocolat",
+            ",",
+            null,
+            null,
+            null,
+            " vanilline)"
+        ],
+        "labels_lc": "fr",
+        "languages_codes": {
+            "ar": 2,
+            "fr": 6
+        },
+        "packaging": "frais,sec",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/619/400/251/0064/front_fr.20.400.jpg",
+        "last_image_dates_tags": [
+            "2020-10-02",
+            "2020-10",
+            "2020"
+        ],
+        "popularity_key": 19950000022,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/619/400/251/0064/front_fr.20.200.jpg",
+        "expiration_date": "Janvier 2014",
+        "data_quality_warnings_tags": [
+            "en:nutrition-value-very-low-for-category-energy",
+            "en:ecoscore-packaging-packaging-data-missing"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:origins-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutrition-no-fiber",
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-no-fiber-or-fruits-vegetables-nuts",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "amine",
+            "openfoodfacts-contributors",
+            "org-app-foodbowel"
+        ],
+        "debug_param_sorted_langs": [
+            "fr"
+        ],
+        "ecoscore_score": 26,
+        "last_modified_t": 1614027538,
+        "ingredients": [
+            {
+                "percent_max": 100,
+                "id": "en:wheat-flour",
+                "percent_estimate": 55,
+                "percent_min": 10,
+                "text": "Farine de blé",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 50,
+                "id": "en:sugar",
+                "percent_min": 0,
+                "percent_estimate": 22.5,
+                "text": "sucre",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": 0,
+                "percent_estimate": 11.25,
+                "vegan": "no",
+                "from_palm_oil": "no",
+                "vegetarian": "maybe",
+                "percent_max": 33.3333333333333,
+                "id": "en:hydrogenated-vegetable-fat",
+                "text": "graisses végétales hydrogénées"
+            },
+            {
+                "percent_max": 25,
+                "id": "en:whey-powder",
+                "percent_min": 0,
+                "percent_estimate": 5.625,
+                "text": "lactosérum en poudre",
+                "vegan": "no",
+                "vegetarian": "maybe"
+            },
+            {
+                "percent_max": 20,
+                "id": "en:cocoa-powder",
+                "text": "cacao en poudre",
+                "percent_min": 0,
+                "percent_estimate": 2.8125,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 16.6666666666667,
+                "id": "en:milk-powder",
+                "percent_estimate": 1.40625,
+                "percent_min": 0,
+                "text": "lait en poudre",
+                "vegan": "no",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 14.2857142857143,
+                "id": "en:emulsifier",
+                "percent_estimate": 0.703125,
+                "percent_min": 0,
+                "text": "émulsifiant"
+            },
+            {
+                "percent_max": 12.5,
+                "id": "en:salt",
+                "text": "sel",
+                "percent_estimate": 0.3515625,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 11.1111111111111,
+                "id": "en:raising-agent",
+                "text": "poudres à lever",
+                "percent_estimate": 0.17578125,
+                "percent_min": 0
+            },
+            {
+                "percent_estimate": 0.17578125,
+                "percent_min": 0,
+                "vegan": "maybe",
+                "vegetarian": "maybe",
+                "percent_max": 10,
+                "id": "fr:arome-identique-nature",
+                "text": "arômes identiques nature"
+            }
+        ],
+        "nutriscore_grade": "d",
+        "product_name_debug_tags": [],
+        "stores": "",
+        "countries": "France,Tunisie",
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "other_nutritional_substances_tags": [],
+        "cities_tags": [],
+        "brands": "Kif",
+        "categories": "Snacks, Snacks sucrés, Biscuits et gâteaux, Biscuits, Biscuits au chocolat, Biscuits fourrés",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:origins-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:packaging-photo-to-be-selected, en:nutrition-photo-selected, en:ingredients-photo-selected, en:front-photo-selected, en:photos-uploaded",
+        "ingredients_text_with_allergens": "Farine de <span class=\"allergen\">blé</span>, sucre, graisses végétales hydrogénées (palme, palmiste), lactosérum en poudre, cacao en poudre, lait en poudre, émulsifiant (lécithine de soja E476), sel, poudres à lever (bicarbonate d'ammonium, bicarbonate de soude, acide citrique), arômes identiques nature (chocolat, vanilline)",
+        "nutrition_grades": "d",
+        "nutrient_levels_tags": [
+            "en:fat-in-moderate-quantity",
+            "en:saturated-fat-in-high-quantity",
+            "en:sugars-in-high-quantity",
+            "en:salt-in-moderate-quantity"
+        ],
+        "known_ingredients_n": 35,
+        "minerals_prev_tags": [],
+        "other_nutritional_substances_prev_tags": [],
+        "product_name": "Biscuit fourré goût chocolat",
+        "ingredients_text": "Farine de blé, sucre, graisses végétales hydrogénées (palme, palmiste), lactosérum en poudre, cacao en poudre, lait en poudre, émulsifiant (lécithine de soja E476), sel, poudres à lever (bicarbonate d'ammonium, bicarbonate de soude, acide citrique), arômes identiques nature (chocolat, vanilline)",
+        "origins": "Tunisie",
+        "languages_tags": [
+            "en:arabic",
+            "en:french",
+            "en:2",
+            "en:multilingual"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Farine de blé, sucre, graisses végétales hydrogénées (palme, palmiste), lactosérum en poudre, cacao en poudre, lait en poudre, émulsifiant (lécithine de soja E476), sel, poudres à lever (bicarbonate d'ammonium, bicarbonate de soude, acide citrique), arômes identiques nature (chocolat, vanilline)",
+        "categories_lc": "fr",
+        "allergens": "en:gluten",
+        "serving_quantity": 21.67,
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/619/400/251/0064/ingredients_fr.6.100.jpg",
+        "ecoscore_data": {
+            "grade_be": "d",
+            "status": "known",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:unknown",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "score": 0,
+                    "warning": "unscored_shape"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_es": 13,
+                    "transportation_value_fr": 10,
+                    "transportation_value_be": 10,
+                    "transportation_value_ch": 11,
+                    "transportation_score_be": 64,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:tunisia",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_score": 0,
+                    "epi_value": -5,
+                    "transportation_score_ch": 71,
+                    "transportation_score_ie": 53,
+                    "value_nl": 5,
+                    "value_ie": 3,
+                    "transportation_value_de": 10,
+                    "value_fr": 5,
+                    "value_be": 5,
+                    "value_es": 8,
+                    "transportation_value_ie": 8,
+                    "transportation_score_it": 78,
+                    "transportation_score_de": 64,
+                    "origins_from_origins_field": [
+                        "en:tunisia"
+                    ],
+                    "transportation_score_fr": 65,
+                    "transportation_value_nl": 10,
+                    "transportation_value_lu": 8,
+                    "value_ch": 6,
+                    "transportation_score_es": 88,
+                    "transportation_value_it": 12,
+                    "value_de": 5,
+                    "value_it": 7,
+                    "transportation_score_lu": 55,
+                    "transportation_score_nl": 64,
+                    "value_lu": 3
+                },
+                "threatened_species": {
+                    "ingredient": "en:palm-oil",
+                    "value": -10
+                }
+            },
+            "grade_fr": "d",
+            "score": 26,
+            "grade_de": "d",
+            "missing_data_warning": 1,
+            "grade_nl": "d",
+            "score_be": 31,
+            "agribalyse": {
+                "co2_transportation": "0.16300729",
+                "ef_distribution": "0.0098990521",
+                "name_fr": "Biscuit sec chocolaté, préemballé",
+                "score": 46,
+                "ef_consumption": "0",
+                "ef_agriculture": "0.5198573599999999",
+                "name_en": "Biscuit (cookie), with chocolate, prepacked",
+                "ef_packaging": "0.016470162",
+                "co2_total": "7.5508182",
+                "ef_processing": "0.056234181",
+                "is_beverage": 0,
+                "code": "24036",
+                "dqr": "2.42",
+                "co2_processing": "0.36633542",
+                "agribalyse_proxy_food_code": "24036",
+                "co2_consumption": "0",
+                "ef_total": "0.61611724",
+                "co2_distribution": "0.029120657",
+                "co2_agriculture": "6.8826501",
+                "ef_transportation": "0.01359472",
+                "co2_packaging": "0.10868541"
+            },
+            "grade_it": "d",
+            "score_nl": 31,
+            "score_ch": 32,
+            "missing": {
+                "packagings": 1,
+                "labels": 1
+            },
+            "grade_ie": "d",
+            "score_fr": 31,
+            "score_de": 31,
+            "score_lu": 29,
+            "score_ie": 29,
+            "score_it": 33,
+            "score_es": 34,
+            "grade": "d",
+            "grade_lu": "d",
+            "grade_ch": "d",
+            "grade_es": "d"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/619/400/251/0064/nutrition_fr.7.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/619/400/251/0064/nutrition_fr.7.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/619/400/251/0064/nutrition_fr.7.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "ar": "https://static.openfoodfacts.net/images/products/619/400/251/0064/ingredients_ar.13.400.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/619/400/251/0064/ingredients_fr.6.400.jpg"
+                },
+                "thumb": {
+                    "ar": "https://static.openfoodfacts.net/images/products/619/400/251/0064/ingredients_ar.13.100.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/619/400/251/0064/ingredients_fr.6.100.jpg"
+                },
+                "small": {
+                    "ar": "https://static.openfoodfacts.net/images/products/619/400/251/0064/ingredients_ar.13.200.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/619/400/251/0064/ingredients_fr.6.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "ar": "https://static.openfoodfacts.net/images/products/619/400/251/0064/front_ar.16.400.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/619/400/251/0064/front_fr.20.400.jpg"
+                },
+                "thumb": {
+                    "ar": "https://static.openfoodfacts.net/images/products/619/400/251/0064/front_ar.16.100.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/619/400/251/0064/front_fr.20.100.jpg"
+                },
+                "small": {
+                    "ar": "https://static.openfoodfacts.net/images/products/619/400/251/0064/front_ar.16.200.jpg",
+                    "fr": "https://static.openfoodfacts.net/images/products/619/400/251/0064/front_fr.20.200.jpg"
+                }
+            }
+        },
+        "rev": 24,
+        "origins_old": "Tunisie",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 1,
+        "last_editor": "quechoisir",
+        "additives_prev_original_tags": [
+            "en:e322",
+            "en:e476",
+            "en:e503",
+            "en:e500",
+            "en:e330"
+        ],
+        "ingredients_tags": [
+            "en:wheat-flour",
+            "en:cereal",
+            "en:flour",
+            "en:wheat",
+            "en:cereal-flour",
+            "en:sugar",
+            "en:hydrogenated-vegetable-fat",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:fat",
+            "en:hydrogenated-fat",
+            "en:vegetable-fat",
+            "en:whey-powder",
+            "en:dairy",
+            "en:whey",
+            "en:cocoa-powder",
+            "en:cocoa",
+            "en:milk-powder",
+            "en:emulsifier",
+            "en:salt",
+            "en:raising-agent",
+            "fr:arome-identique-nature",
+            "en:flavouring",
+            "en:palm",
+            "en:palm-oil-and-fat",
+            "en:palm-oil",
+            "en:palm-kernel-oil",
+            "en:palm-kernel-oil-and-fat",
+            "fr:lecithine-de-soja-e476",
+            "en:e503ii",
+            "en:e503",
+            "en:e500ii",
+            "en:e500",
+            "en:e330",
+            "en:chocolate",
+            "en:vanillin"
+        ],
+        "data_sources_tags": [
+            "app-yuka",
+            "apps",
+            "app-foodbowel"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/619/400/251/0064/nutrition_fr.7.100.jpg",
+        "ingredients_from_palm_oil_tags": [
+            "huile-de-palme"
+        ],
+        "categories_hierarchy": [
+            "en:snacks",
+            "en:sweet-snacks",
+            "en:biscuits-and-cakes",
+            "en:biscuits",
+            "en:chocolate-biscuits",
+            "en:filled-biscuits"
+        ],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "d",
+        "nutrition_data": "on",
+        "ingredients_percent_analysis": 1,
+        "languages": {
+            "en:arabic": 2,
+            "en:french": 6
+        },
+        "purchase_places": "Tunisie",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-24036",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-unknown",
+            "agribalyse-known",
+            "agribalyse-24036"
+        ],
+        "id": "6194002510064",
+        "sources": [
+            {
+                "import_t": 1601670606,
+                "fields": [
+                    "data_sources"
+                ],
+                "id": "org-app-foodbowel",
+                "manufacturer": 0,
+                "url": null,
+                "name": "app-foodbowel",
+                "images": []
+            }
+        ],
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Sugary snacks",
+        "allergens_from_user": "(fr) en:gluten",
+        "nutrition_data_prepared": "",
+        "additives_debug_tags": [
+            "en-e322i-added",
+            "en-e500ii-added"
+        ],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/619/400/251/0064/ingredients_fr.6.400.jpg",
+        "nutrition_score_warning_no_fiber": 1,
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok",
+            "en:nutrition-value-very-low-for-category-energy",
+            "en:ecoscore-packaging-packaging-data-missing"
+        ],
+        "additives_old_tags": [
+            "en:e1403",
+            "en:e322",
+            "en:e503",
+            "en:e500",
+            "en:e330"
+        ],
+        "origins_hierarchy": [
+            "en:tunisia"
+        ],
+        "ecoscore_tags": [
+            "d"
+        ],
+        "ingredients_from_palm_oil_n": 1,
+        "labels_hierarchy": [],
+        "lc_imported": "fr",
+        "nutrition_score_beverage": 0,
+        "pnns_groups_2": "Biscuits and cakes",
+        "complete": 0,
+        "product_quantity": "130",
+        "new_additives_n": 4,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/619/400/251/0064/front_fr.20.100.jpg",
+        "ingredients_text_debug": "Farine de blé, sucre, graisses végétales hydrogénées (palme, palmiste), lactosérum en poudre, cacao en poudre, lait en poudre, émulsifiant : (lécithine de soja  - e476 - ), sel, poudres à lever : (bicarbonate d'ammonium, bicarbonate de soude, acide citrique), arômes identiques nature (chocolat, vanilline)",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/619/400/251/0064/front_fr.20.400.jpg",
+        "_id": "6194002510064",
+        "countries_tags": [
+            "en:france",
+            "en:tunisia"
+        ],
+        "serving_size": "21,67 g",
+        "ingredients_hierarchy": [
+            "en:wheat-flour",
+            "en:cereal",
+            "en:flour",
+            "en:wheat",
+            "en:cereal-flour",
+            "en:sugar",
+            "en:hydrogenated-vegetable-fat",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:fat",
+            "en:hydrogenated-fat",
+            "en:vegetable-fat",
+            "en:whey-powder",
+            "en:dairy",
+            "en:whey",
+            "en:cocoa-powder",
+            "en:cocoa",
+            "en:milk-powder",
+            "en:emulsifier",
+            "en:salt",
+            "en:raising-agent",
+            "fr:arome-identique-nature",
+            "en:flavouring",
+            "en:palm",
+            "en:palm-oil-and-fat",
+            "en:palm-oil",
+            "en:palm-kernel-oil",
+            "en:palm-kernel-oil-and-fat",
+            "fr:lécithine de soja e476",
+            "en:e503ii",
+            "en:e503",
+            "en:e500ii",
+            "en:e500",
+            "en:e330",
+            "en:chocolate",
+            "en:vanillin"
+        ],
+        "additives_original_tags": [
+            "en:e322i",
+            "en:e503ii",
+            "en:e500ii",
+            "en:e330"
+        ],
+        "stores_tags": [],
+        "nutriscore_score": 18,
+        "compared_to_category": "en:filled-biscuits",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:origins-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "18",
+            "11-20"
+        ],
+        "pnns_groups_1_tags": [
+            "sugary-snacks",
+            "known"
+        ],
+        "additives_old_n": 5,
+        "packagings": [
+            {
+                "shape": "en:unknown",
+                "material": "en:unknown"
+            }
+        ],
+        "quantity": "130 g",
+        "data_quality_info_tags": [
+            "en:packaging-data-incomplete",
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "brands_tags": [
+            "kif"
+        ],
+        "data_quality_errors_tags": [],
+        "ingredients_ids_debug": [
+            "farine-de-ble",
+            "sucre",
+            "graisses-vegetales-hydrogenees",
+            "palme",
+            "palmiste",
+            "lactoserum-en-poudre",
+            "cacao-en-poudre",
+            "lait-en-poudre",
+            "emulsifiant",
+            "lecithine-de-soja",
+            "e476",
+            "sel",
+            "poudres-a-lever",
+            "bicarbonate-d-ammonium",
+            "bicarbonate-de-soude",
+            "acide-citrique",
+            "aromes-identiques-nature",
+            "chocolat",
+            "vanilline"
+        ],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [
+            "en:wheat-flour",
+            "en:sugar",
+            "en:hydrogenated-vegetable-fat",
+            "en:whey-powder",
+            "en:cocoa-powder",
+            "en:milk-powder",
+            "en:emulsifier",
+            "en:salt",
+            "en:raising-agent",
+            "fr:arome-identique-nature",
+            "en:palm",
+            "en:palm-kernel-oil",
+            "fr:lécithine de soja e476",
+            "en:e503ii",
+            "en:e500ii",
+            "en:e330",
+            "en:chocolate",
+            "en:vanillin"
+        ],
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "traces": "en:nuts",
+        "data_sources": "App - yuka, Apps, app-foodbowel",
+        "unknown_ingredients_n": 1,
+        "manufacturing_places_tags": [],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "max_imgid": "10",
+        "emb_codes": "",
+        "editors": [
+            "amine"
+        ],
+        "nutriscore_score_opposite": -18,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/619/400/251/0064/front_fr.20.200.jpg",
+        "generic_name_fr": "Biscuit fourré à la créme goût chocolat",
+        "nutriments": {
+            "iron_serving": 5.07e-05,
+            "cholesterol": 0.0005,
+            "carbohydrates_unit": "g",
+            "iron": 0.000234,
+            "saturated-fat_serving": 2.6,
+            "potassium_serving": 0.0433,
+            "sugars_100g": 20,
+            "energy-kcal": 197,
+            "vitamin-c_100g": 0.00018,
+            "sodium_value": 0.22,
+            "proteins_serving": 1.52,
+            "nova-group_serving": 4,
+            "salt_100g": 0.55,
+            "energy_unit": "kcal",
+            "iron_100g": 0.000234,
+            "calcium_unit": "% DV",
+            "sugars_unit": "g",
+            "salt": 0.55,
+            "vitamin-c_label": "0",
+            "iron_label": "0",
+            "vitamin-a_100g": 3e-06,
+            "energy-kcal_100g": 197,
+            "iron_value": 1.3,
+            "potassium_100g": 0.2,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "saturated-fat": 12,
+            "potassium_value": 200,
+            "fat_value": 19,
+            "nova-group_100g": 4,
+            "cholesterol_value": 0.5,
+            "vitamin-a_serving": 6.5e-07,
+            "energy_value": 197,
+            "vitamin-a_unit": "% DV",
+            "calcium_100g": 0.002,
+            "sodium_unit": "g",
+            "carbohydrates_serving": 14.5,
+            "carbohydrates_100g": 67,
+            "cholesterol_label": "0",
+            "cholesterol_unit": "mg",
+            "potassium_label": "0",
+            "energy-kcal_unit": "kcal",
+            "fat": 19,
+            "proteins": 7,
+            "salt_serving": 0.119,
+            "energy_100g": 824,
+            "vitamin-c_value": 0.3,
+            "cholesterol_100g": 0.0005,
+            "sodium_100g": 0.22,
+            "nutrition-score-fr_100g": 18,
+            "salt_unit": "g",
+            "carbohydrates_value": 67,
+            "proteins_unit": "g",
+            "vitamin-c": 0.00018,
+            "sugars_serving": 4.33,
+            "calcium_label": "0",
+            "fat_unit": "g",
+            "salt_value": 0.55,
+            "proteins_value": 7,
+            "saturated-fat_100g": 12,
+            "fat_serving": 4.12,
+            "potassium_unit": "mg",
+            "energy": 824,
+            "calcium_value": 0.2,
+            "nova-group": 4,
+            "vitamin-a_label": "0",
+            "saturated-fat_value": 12,
+            "energy-kcal_value": 197,
+            "energy_serving": 179,
+            "fat_100g": 19,
+            "saturated-fat_unit": "g",
+            "sodium_serving": 0.0477,
+            "calcium": 0.002,
+            "vitamin-c_serving": 3.9e-05,
+            "vitamin-a_value": 0.2,
+            "vitamin-a": 3e-06,
+            "sugars_value": 20,
+            "proteins_100g": 7,
+            "vitamin-c_unit": "% DV",
+            "nutrition-score-fr": 18,
+            "sodium": 0.22,
+            "calcium_serving": 0.000433,
+            "potassium": 0.2,
+            "iron_unit": "% DV",
+            "sugars": 20,
+            "carbohydrates": 67,
+            "energy-kcal_serving": 42.7,
+            "cholesterol_serving": 0.000108
+        },
+        "purchase_places_tags": [
+            "tunisie"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/619/400/251/0064/ingredients_fr.6.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/619/400/251/0064/nutrition_fr.7.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/7640101710236.json
+++ b/testdata/product/7640101710236.json
@@ -1,0 +1,413 @@
+{
+    "status": 1,
+    "code": "7640101710236",
+    "product": {
+        "nutrient_levels_tags": [],
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "minerals_prev_tags": [],
+        "category_properties": {},
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "categories_tags": [],
+        "data_quality_bugs_tags": [],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "allergens": "",
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "ecoscore_data": {
+            "agribalyse": {
+                "warning": "missing_agribalyse_match"
+            },
+            "status": "unknown",
+            "missing_agribalyse_match_warning": 1,
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "transportation_score_lu": 0,
+                    "value_it": -5,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_ch": 0,
+                    "epi_value": -5,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 0,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:unknown",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "warning": "unscored_shape",
+                    "score": 0
+                },
+                "threatened_species": {
+                    "warning": "ingredients_missing"
+                }
+            },
+            "missing": {
+                "packagings": 1,
+                "categories": 1,
+                "ingredients": 1,
+                "labels": 1,
+                "origins": 1
+            }
+        },
+        "selected_images": {
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/764/010/171/0236/front_fr.3.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/764/010/171/0236/front_fr.3.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/764/010/171/0236/front_fr.3.200.jpg"
+                }
+            }
+        },
+        "rev": 5,
+        "last_editor": "fix-missing-lang-bot",
+        "last_image_t": 1450200035,
+        "additives_prev_original_tags": [],
+        "emb_codes_20141016": "",
+        "pnns_groups_2_tags": [
+            "unknown",
+            "missing-category"
+        ],
+        "ingredients_tags": [],
+        "emb_codes_tags": [],
+        "labels_prev_tags": [],
+        "correctors_tags": [
+            "openfoodfacts-contributors"
+        ],
+        "sortkey": 1572643474,
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "unknown",
+        "categories_properties": {},
+        "completeness": 0.0666666666666667,
+        "labels_tags": [],
+        "traces_from_user": "(fr) ",
+        "labels_prev_hierarchy": [],
+        "nutrition_grades_tags": [
+            "unknown"
+        ],
+        "informers_tags": [
+            "openfoodfacts-contributors",
+            "fix-missing-lang-bot"
+        ],
+        "languages": {
+            "en:french": 1
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-unknown",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-unknown",
+            "agribalyse-unknown"
+        ],
+        "lang": "fr",
+        "id": "7640101710236",
+        "vitamins_tags": [],
+        "additives_tags": [],
+        "categories_prev_tags": [],
+        "pnns_groups_1": "unknown",
+        "allergens_from_user": "(fr) ",
+        "countries_hierarchy": [
+            "en:switzerland"
+        ],
+        "nova_group_debug": "no nova group when the product does not have ingredients",
+        "additives_debug_tags": [],
+        "traces_tags": [],
+        "data_quality_tags": [],
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/764/010/171/0236/front_fr.3.100.jpg",
+        "nutrient_levels": {},
+        "additives_old_tags": [],
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "labels_hierarchy": [],
+        "ecoscore_tags": [
+            "unknown"
+        ],
+        "pnns_groups_2": "unknown",
+        "nutrition_score_beverage": 0,
+        "complete": 0,
+        "created_t": 1450199978,
+        "categories_debug_tags": [],
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/764/010/171/0236/front_fr.3.100.jpg",
+        "ingredients_text_debug": null,
+        "amino_acids_prev_tags": [],
+        "image_front_url": "https://static.openfoodfacts.net/images/products/764/010/171/0236/front_fr.3.400.jpg",
+        "_id": "7640101710236",
+        "nucleotides_tags": [],
+        "countries_tags": [
+            "en:switzerland"
+        ],
+        "ingredients_hierarchy": [],
+        "images": {
+            "1": {
+                "uploaded_t": "1450199978",
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 4032,
+                        "w": 3024
+                    }
+                }
+            },
+            "front_fr": {
+                "rev": "3",
+                "white_magic": null,
+                "geometry": "0x0--10--10",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 150
+                    },
+                    "full": {
+                        "h": 4032,
+                        "w": 3024
+                    }
+                },
+                "normalize": null,
+                "imgid": "1"
+            },
+            "front": {
+                "rev": "3",
+                "white_magic": null,
+                "geometry": "0x0--10--10",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 150
+                    },
+                    "full": {
+                        "h": 4032,
+                        "w": 3024
+                    }
+                },
+                "normalize": null,
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": "1450200034",
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 4032,
+                        "w": 3024
+                    }
+                }
+            }
+        },
+        "additives_original_tags": [],
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-to-be-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:categories-to-be-completed",
+            "en:brands-to-be-completed",
+            "en:packaging-to-be-completed",
+            "en:quantity-to-be-completed",
+            "en:product-name-to-be-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "editors_tags": [
+            "openfoodfacts-contributors",
+            "fix-missing-lang-bot"
+        ],
+        "countries_lc": "fr",
+        "allergens_tags": [],
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "pnns_groups_1_tags": [
+            "unknown",
+            "missing-category"
+        ],
+        "code": "7640101710236",
+        "nutrition_score_debug": "no score when the product does not have a category",
+        "packagings": [
+            {
+                "shape": "en:unknown",
+                "material": "en:unknown"
+            }
+        ],
+        "codes_tags": [
+            "code-13",
+            "7640101710xxx",
+            "764010171xxxx",
+            "76401017xxxxx",
+            "7640101xxxxxx",
+            "764010xxxxxxx",
+            "76401xxxxxxxx",
+            "7640xxxxxxxxx",
+            "764xxxxxxxxxx",
+            "76xxxxxxxxxxx",
+            "7xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "fix-missing-lang-bot",
+        "data_quality_errors_tags": [],
+        "data_quality_info_tags": [],
+        "entry_dates_tags": [
+            "2015-12-15",
+            "2015-12",
+            "2015"
+        ],
+        "last_edit_dates_tags": [
+            "2019-11-01",
+            "2019-11",
+            "2019"
+        ],
+        "creator": "openfoodfacts-contributors",
+        "ingredients_ids_debug": [],
+        "vitamins_prev_tags": [],
+        "nutrition_data_prepared_per": "100g",
+        "ingredients_original_tags": [],
+        "traces": "",
+        "_keywords": [],
+        "amino_acids_tags": [],
+        "unknown_ingredients_n": 0,
+        "ingredients_debug": [],
+        "languages_codes": {
+            "fr": 1
+        },
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/764/010/171/0236/front_fr.3.400.jpg",
+        "popularity_key": 0,
+        "last_image_dates_tags": [
+            "2015-12-15",
+            "2015-12",
+            "2015"
+        ],
+        "checkers_tags": [],
+        "max_imgid": "2",
+        "emb_codes": "",
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/764/010/171/0236/front_fr.3.200.jpg",
+        "labels_debug_tags": [],
+        "data_quality_warnings_tags": [],
+        "misc_tags": [
+            "en:nutriscore-not-computed",
+            "en:nutriscore-missing-category",
+            "en:ecoscore-not-computed"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-to-be-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:categories-to-be-completed",
+            "en:brands-to-be-completed",
+            "en:packaging-to-be-completed",
+            "en:quantity-to-be-completed",
+            "en:product-name-to-be-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "categories_prev_hierarchy": [],
+        "photographers_tags": [
+            "openfoodfacts-contributors"
+        ],
+        "image_small_url": "https://static.openfoodfacts.net/images/products/764/010/171/0236/front_fr.3.200.jpg",
+        "nutriments": {},
+        "last_modified_t": 1572643474,
+        "ingredients": [],
+        "countries": "Suisse",
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "other_nutritional_substances_tags": [],
+        "cities_tags": [],
+        "states": "en:to-be-completed, en:nutrition-facts-to-be-completed, en:ingredients-to-be-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-to-be-completed, en:categories-to-be-completed, en:brands-to-be-completed, en:packaging-to-be-completed, en:quantity-to-be-completed, en:product-name-to-be-completed, en:photos-to-be-validated, en:photos-uploaded"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/8424259826051.json
+++ b/testdata/product/8424259826051.json
@@ -1,0 +1,1020 @@
+{
+    "status": 1,
+    "code": "8424259826051",
+    "product": {
+        "lc": "es",
+        "traces_from_ingredients": "",
+        "category_properties": {
+            "ciqual_food_name:fr": "Boisson au soja, nature",
+            "ciqual_food_name:en": "Soy drink, plain"
+        },
+        "popularity_tags": [
+            "top-50000-scans-2019",
+            "top-100000-scans-2019",
+            "at-least-5-scans-2019",
+            "at-least-10-scans-2019",
+            "top-75-percent-scans-2019",
+            "top-80-percent-scans-2019",
+            "top-85-percent-scans-2019",
+            "top-90-percent-scans-2019",
+            "top-5000-es-scans-2019",
+            "top-10000-es-scans-2019",
+            "top-50000-es-scans-2019",
+            "top-100000-es-scans-2019",
+            "top-country-es-scans-2019",
+            "at-least-5-es-scans-2019",
+            "at-least-10-es-scans-2019",
+            "top-50000-scans-2020",
+            "top-100000-scans-2020",
+            "at-least-5-scans-2020",
+            "at-least-10-scans-2020",
+            "top-75-percent-scans-2020",
+            "top-80-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-5000-es-scans-2020",
+            "top-10000-es-scans-2020",
+            "top-50000-es-scans-2020",
+            "top-100000-es-scans-2020",
+            "top-country-es-scans-2020",
+            "at-least-5-es-scans-2020",
+            "at-least-10-es-scans-2020"
+        ],
+        "categories_tags": [
+            "en:plant-based-foods-and-beverages",
+            "en:beverages",
+            "en:plant-based-foods",
+            "en:legumes-and-their-products",
+            "en:plant-based-beverages",
+            "en:milk-substitute",
+            "en:plant-milks",
+            "en:legume-milks",
+            "en:soy-milks",
+            "en:unsweetened-natural-soy-milks"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "informers": [
+            "javichu"
+        ],
+        "origins_tags": [
+            "es:agricultura-ue"
+        ],
+        "generic_name": "Bebida de soja ecológica",
+        "teams_tags": [
+            "we-are-the-robots"
+        ],
+        "languages_hierarchy": [
+            "en:spanish"
+        ],
+        "last_image_t": 1343778528,
+        "additives_n": 0,
+        "emb_codes_20141016": "//FABRICANTE Y ENVASADOR://, //CODE EMB: 45273//, LSDH - LAITERIE DE SAINT DENIS DE L’HÔTEL S.A.S., //DISTRIBUIDOR EN ESPAÑA://, NUTRITION & SANTÉ IBERIA S.L., //PERTENECIENTE A://, NUTRITION & SANTÉ S.A.S., OTSUKA PHARMACEUTICAL CO. LTD., OTSUKA HOLDINGS CO. LTD.",
+        "pnns_groups_2_tags": [
+            "plant-based-milk-substitutes",
+            "known"
+        ],
+        "allergens_lc": "es",
+        "emb_codes_tags": [
+            "emb-45273",
+            "fabricante-y-envasador",
+            "lsdh-laiterie-de-saint-denis-de-l-hotel-s-a-s",
+            "distribuidor-en-espana",
+            "nutrition-sante-iberia-s-l",
+            "perteneciente-a",
+            "nutrition-sante-s-a-s",
+            "otsuka-pharmaceutical-co-ltd",
+            "otsuka-holdings-co-ltd"
+        ],
+        "correctors_tags": [
+            "javichu",
+            "moon-rabbit",
+            "musarana",
+            "fix-ingredientes-bot"
+        ],
+        "sortkey": 1586797500,
+        "product_name_es": "Bebida de soja ecológica",
+        "categories_old": "Alimentos y bebidas de origen vegetal, Bebidas, Alimentos de origen vegetal, Leguminosas y derivados, Bebidas de origen vegetal, Sustitutos de la leche, Bebidas vegetales, Leches de leguminosas, Bebidas de soja, Bebidas de soja natural sin azúcar",
+        "categories_properties": {
+            "ciqual_food_code:en": "18900",
+            "agribalyse_food_code:en": "18900"
+        },
+        "completeness": 1,
+        "generic_name_es": "Bebida de soja ecológica",
+        "traces_from_user": "(es) ",
+        "labels_tags": [
+            "en:organic",
+            "en:eu-organic",
+            "en:vegetarian",
+            "en:vegan",
+            "en:fr-bio-01"
+        ],
+        "nutrition_grades_tags": [
+            "a"
+        ],
+        "informers_tags": [
+            "javichu",
+            "moon-rabbit"
+        ],
+        "lang": "es",
+        "vitamins_tags": [],
+        "downgraded": "non_recyclable_and_non_biodegradable_materials",
+        "origins_lc": "es",
+        "interface_version_modified": "20190830",
+        "additives_tags": [],
+        "unique_scans_n": 14,
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/842/425/982/6051/nutrition_es.7.400.jpg",
+        "unknown_nutrients_tags": [],
+        "obsolete_since_date": "",
+        "countries_hierarchy": [
+            "en:spain"
+        ],
+        "nova_group_debug": "",
+        "traces_tags": [],
+        "packaging_tags": [
+            "tetra-brik"
+        ],
+        "nova_groups": "1",
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/842/425/982/6051/front_es.5.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-free",
+            "en:vegan",
+            "en:vegetarian"
+        ],
+        "nutrient_levels": {
+            "sugars": "low",
+            "salt": "low",
+            "fat": "moderate",
+            "saturated-fat": "low"
+        },
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "ingredients_text_with_allergens_es": "Agua, habas de soja descascarilladas* 13,2%. (* Ingredientes procedentes de la agricultura ecológica).",
+        "nutriscore_data": {
+            "proteins": 3.8,
+            "negative_points": 0,
+            "sugars_points": 0,
+            "sodium_value": 10.2,
+            "score": -2,
+            "positive_points": 2,
+            "saturated_fat_value": 0.3,
+            "is_water": 0,
+            "proteins_points": 2,
+            "saturated_fat_points": 0,
+            "saturated_fat_ratio": 13.6363636363636,
+            "proteins_value": 3.8,
+            "saturated_fat_ratio_points": 1,
+            "fiber_points": 0,
+            "grade": "a",
+            "is_cheese": 0,
+            "energy": 177,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 0.5,
+            "energy_points": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 0,
+            "is_fat": 0,
+            "energy_value": 177,
+            "is_beverage": 0,
+            "fiber_value": 0.5,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 13.6,
+            "sugars_value": 0.7,
+            "saturated_fat": 0.3,
+            "sodium": 10.16,
+            "sugars": 0.7
+        },
+        "created_t": 1343778505,
+        "nova_group": 1,
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "a",
+        "nucleotides_tags": [],
+        "scans_n": 24,
+        "images": {
+            "nutrition": {
+                "rev": "7",
+                "white_magic": "checked",
+                "geometry": "0x0--1--1",
+                "sizes": {
+                    "400": {
+                        "h": 396,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 99,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 550,
+                        "w": 556
+                    },
+                    "200": {
+                        "h": 198,
+                        "w": 200
+                    }
+                },
+                "normalize": null,
+                "imgid": "2"
+            },
+            "ingredients": {
+                "rev": "6",
+                "white_magic": "checked",
+                "geometry": "0x0--1--1",
+                "normalize": null,
+                "sizes": {
+                    "400": {
+                        "h": 124,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 31,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 165,
+                        "w": 532
+                    },
+                    "200": {
+                        "h": 62,
+                        "w": 200
+                    }
+                },
+                "imgid": "1"
+            },
+            "3": {
+                "uploaded_t": 1343778528,
+                "uploader": "javichu",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 177
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 44
+                    },
+                    "full": {
+                        "h": 1999,
+                        "w": 884
+                    }
+                }
+            },
+            "1": {
+                "uploaded_t": 1343778518,
+                "uploader": "javichu",
+                "sizes": {
+                    "400": {
+                        "h": 124,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 31,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 165,
+                        "w": 532
+                    }
+                }
+            },
+            "front_es": {
+                "rev": "5",
+                "white_magic": null,
+                "geometry": "0x0--4--4",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 177
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 44
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 88
+                    },
+                    "full": {
+                        "h": 1999,
+                        "w": 884
+                    }
+                },
+                "normalize": null,
+                "imgid": "3"
+            },
+            "front": {
+                "rev": "5",
+                "white_magic": null,
+                "geometry": "0x0--4--4",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 177
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 44
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 88
+                    },
+                    "full": {
+                        "h": 1999,
+                        "w": 884
+                    }
+                },
+                "normalize": null,
+                "imgid": "3"
+            },
+            "nutrition_es": {
+                "rev": "7",
+                "white_magic": "checked",
+                "geometry": "0x0--1--1",
+                "sizes": {
+                    "400": {
+                        "h": 396,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 99,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 550,
+                        "w": 556
+                    },
+                    "200": {
+                        "h": 198,
+                        "w": 200
+                    }
+                },
+                "normalize": null,
+                "imgid": "2"
+            },
+            "2": {
+                "uploaded_t": 1343778519,
+                "uploader": "javichu",
+                "sizes": {
+                    "400": {
+                        "h": 396,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 99,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 550,
+                        "w": 556
+                    }
+                }
+            },
+            "ingredients_es": {
+                "rev": "6",
+                "white_magic": "checked",
+                "geometry": "0x0--1--1",
+                "normalize": null,
+                "sizes": {
+                    "400": {
+                        "h": 124,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 31,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 165,
+                        "w": 532
+                    },
+                    "200": {
+                        "h": 62,
+                        "w": 200
+                    }
+                },
+                "imgid": "1"
+            }
+        },
+        "ingredients_n": 2,
+        "editors_tags": [
+            "moon-rabbit",
+            "fix-ingredientes-bot",
+            "musarana",
+            "javichu"
+        ],
+        "allergens_tags": [],
+        "traces_lc": "es",
+        "countries_lc": "es",
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "environment_impact_level_tags": [],
+        "completed_t": 1343780791,
+        "ingredients_text_es": "Agua, habas de soja descascarilladas* 13,2%. (* Ingredientes procedentes de la agricultura ecológica).",
+        "nova_groups_tags": [
+            "en:1-unprocessed-or-minimally-processed-foods"
+        ],
+        "code": "8424259826051",
+        "manufacturing_places": "[FABRICANTE],Saint-Denis-de-l'Hôtel,Orleans (distrito),Loiret,Centro (región),Francia,[DISTRIBUIDOR],España",
+        "codes_tags": [
+            "code-13",
+            "8424259826xxx",
+            "842425982xxxx",
+            "84242598xxxxx",
+            "8424259xxxxxx",
+            "842425xxxxxxx",
+            "84242xxxxxxxx",
+            "8424xxxxxxxxx",
+            "842xxxxxxxxxx",
+            "84xxxxxxxxxxx",
+            "8xxxxxxxxxxxx"
+        ],
+        "labels": "Ecológico,Vegetariano,Ecológico UE,Vegano,FR-BIO-01",
+        "last_modified_by": "fix-ingredientes-bot",
+        "last_edit_dates_tags": [
+            "2020-04-13",
+            "2020-04",
+            "2020"
+        ],
+        "entry_dates_tags": [
+            "2012-08-01",
+            "2012-08",
+            "2012"
+        ],
+        "creator": "javichu",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "soja",
+            "ecologico",
+            "la",
+            "fr-bio-01",
+            "vegetale",
+            "vegano",
+            "sin",
+            "ue",
+            "ecologica",
+            "derivado",
+            "vegetariano",
+            "leche",
+            "vegetal",
+            "agricultura",
+            "bebida",
+            "azucar",
+            "origen",
+            "alimento",
+            "leguminosa",
+            "de",
+            "natural",
+            "gerble",
+            "sustituto"
+        ],
+        "amino_acids_tags": [],
+        "link": "http://www.gerble.es/productos/bebida-de-soja-natural/",
+        "ingredients_debug": [
+            "Agua",
+            ",",
+            null,
+            null,
+            null,
+            " habas de soja descascarilladas* 13",
+            ",",
+            null,
+            null,
+            null,
+            "2%",
+            ". ",
+            null,
+            null,
+            null,
+            "",
+            "(",
+            "(",
+            null,
+            null,
+            "* Ingredientes procedentes de la agricultura ecológica)."
+        ],
+        "languages_codes": {
+            "es": 6
+        },
+        "labels_lc": "es",
+        "packaging": "Tetra Brik",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/842/425/982/6051/front_es.5.400.jpg",
+        "last_image_dates_tags": [
+            "2012-08-01",
+            "2012-08",
+            "2012"
+        ],
+        "popularity_key": 19950000014,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/842/425/982/6051/front_es.5.200.jpg",
+        "expiration_date": "24-05-2013",
+        "data_quality_warnings_tags": [
+            "en:ingredients-unknown-score-above-0",
+            "en:ingredients-100-percent-unknown",
+            "en:nutrition-value-under-0-1-g-salt"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "debug_param_sorted_langs": [
+            "es"
+        ],
+        "ecoscore_score": 87,
+        "photographers_tags": [
+            "javichu"
+        ],
+        "last_modified_t": 1586797500,
+        "ingredients": [
+            {
+                "percent_max": 86.8,
+                "id": "en:water",
+                "text": "Agua",
+                "percent_estimate": 86.8,
+                "percent_min": 86.8,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_estimate": 13.2,
+                "percent_min": "13.2",
+                "percent": "13.2",
+                "labels": "en:organic",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "13.2",
+                "id": "en:hulled-soya-bean",
+                "text": "habas de soja descascarilladas"
+            }
+        ],
+        "nutriscore_grade": "a",
+        "stores": "Carrefour",
+        "countries": "España",
+        "cities_tags": [
+            "saint-denis-de-l-hotel-loiret-france"
+        ],
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "soy-drink-plain"
+        ],
+        "brands": "Gerblé",
+        "obsolete": "",
+        "categories": "Alimentos y bebidas de origen vegetal, Bebidas, Alimentos de origen vegetal, Leguminosas y derivados, Bebidas de origen vegetal, Sustitutos de la leche, Bebidas vegetales, Leches de leguminosas, Bebidas de soja, Bebidas de soja natural sin azúcar",
+        "ingredients_text_with_allergens": "Agua, habas de soja descascarilladas* 13,2%. (* Ingredientes procedentes de la agricultura ecológica).",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "environment_impact_level": "",
+        "nutrition_grades": "a",
+        "nutrient_levels_tags": [
+            "en:fat-in-moderate-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-low-quantity",
+            "en:salt-in-low-quantity"
+        ],
+        "known_ingredients_n": 5,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Agua, habas de soja descascarilladas* 13,2%. (* Ingredientes procedentes de la agricultura ecológica).",
+        "product_name": "Bebida de soja ecológica",
+        "origins": "Agricultura UE",
+        "languages_tags": [
+            "en:spanish",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "categories_lc": "es",
+        "serving_quantity": 250,
+        "allergens": "",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/842/425/982/6051/ingredients_es.6.100.jpg",
+        "photographers": [
+            "javichu"
+        ],
+        "ecoscore_data": {
+            "grade_be": "b",
+            "status": "known",
+            "adjustments": {
+                "production_system": {
+                    "value": 15,
+                    "label": "en:eu-organic"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_ch": 0,
+                    "epi_value": -5,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 0,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "value_lu": -5,
+                    "transportation_score_nl": 0
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:unknown",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "score": 0,
+                    "warning": "unscored_shape"
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "b",
+            "score": 87,
+            "grade_de": "b",
+            "missing_data_warning": 1,
+            "grade_nl": "b",
+            "score_be": 82,
+            "agribalyse": {
+                "co2_transportation": "0.19403306",
+                "ef_distribution": "0.0088128735",
+                "name_fr": "Boisson au soja, nature",
+                "score": 82,
+                "agribalyse_food_code": "18900",
+                "ef_agriculture": "0.014107424",
+                "ef_consumption": "0.0024293397",
+                "name_en": "Soy drink, plain",
+                "co2_total": "0.41691542",
+                "ef_packaging": "0.014974093",
+                "ef_processing": "0.00034049978",
+                "is_beverage": 1,
+                "dqr": "2.95",
+                "co2_processing": "0.00033979179",
+                "code": "18900",
+                "co2_consumption": "0.0047993021",
+                "co2_distribution": "0.028932423",
+                "ef_total": "0.055473705",
+                "co2_agriculture": "0.090024208",
+                "ef_transportation": "0.014809476",
+                "co2_packaging": "0.098786634"
+            },
+            "grade_it": "b",
+            "score_nl": 82,
+            "score_ch": 82,
+            "missing": {
+                "packagings": 1,
+                "origins": 1
+            },
+            "grade_ie": "b",
+            "score_fr": 82,
+            "score_de": 82,
+            "score_lu": 82,
+            "score_ie": 82,
+            "score_it": 82,
+            "score_es": 82,
+            "grade_lu": "b",
+            "grade": "b",
+            "grade_ch": "b",
+            "grade_es": "b"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "es": "https://static.openfoodfacts.net/images/products/842/425/982/6051/nutrition_es.7.400.jpg"
+                },
+                "thumb": {
+                    "es": "https://static.openfoodfacts.net/images/products/842/425/982/6051/nutrition_es.7.100.jpg"
+                },
+                "small": {
+                    "es": "https://static.openfoodfacts.net/images/products/842/425/982/6051/nutrition_es.7.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "es": "https://static.openfoodfacts.net/images/products/842/425/982/6051/ingredients_es.6.400.jpg"
+                },
+                "thumb": {
+                    "es": "https://static.openfoodfacts.net/images/products/842/425/982/6051/ingredients_es.6.100.jpg"
+                },
+                "small": {
+                    "es": "https://static.openfoodfacts.net/images/products/842/425/982/6051/ingredients_es.6.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "es": "https://static.openfoodfacts.net/images/products/842/425/982/6051/front_es.5.400.jpg"
+                },
+                "thumb": {
+                    "es": "https://static.openfoodfacts.net/images/products/842/425/982/6051/front_es.5.100.jpg"
+                },
+                "small": {
+                    "es": "https://static.openfoodfacts.net/images/products/842/425/982/6051/front_es.5.200.jpg"
+                }
+            }
+        },
+        "rev": 19,
+        "origins_old": "Agricultura UE",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "fix-ingredientes-bot",
+        "additives_prev_original_tags": [],
+        "ingredients_tags": [
+            "en:water",
+            "en:hulled-soya-bean",
+            "en:legume",
+            "en:soya",
+            "en:soya-bean"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/842/425/982/6051/nutrition_es.7.100.jpg",
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:plant-based-foods-and-beverages",
+            "en:beverages",
+            "en:plant-based-foods",
+            "en:legumes-and-their-products",
+            "en:plant-based-beverages",
+            "en:milk-substitute",
+            "en:plant-milks",
+            "en:legume-milks",
+            "en:soy-milks",
+            "en:unsweetened-natural-soy-milks"
+        ],
+        "ecoscore_grade": "b",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "nutrition_data": "on",
+        "ingredients_percent_analysis": 1,
+        "languages": {
+            "en:spanish": 6
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-18900",
+            "agribalyse-food-code-known",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-18900",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-18900"
+        ],
+        "purchase_places": "Madrid,España",
+        "id": "8424259826051",
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Beverages",
+        "allergens_from_user": "(es) ",
+        "nutrition_data_prepared": "",
+        "checkers": [],
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/842/425/982/6051/ingredients_es.6.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:ingredients-unknown-score-above-0",
+            "en:ingredients-100-percent-unknown",
+            "en:nutrition-value-under-0-1-g-salt"
+        ],
+        "additives_old_tags": [],
+        "ingredients_from_palm_oil_n": 0,
+        "ecoscore_tags": [
+            "b"
+        ],
+        "labels_hierarchy": [
+            "en:organic",
+            "en:eu-organic",
+            "en:vegetarian",
+            "en:vegan",
+            "en:fr-bio-01"
+        ],
+        "origins_hierarchy": [
+            "es:Agricultura UE"
+        ],
+        "complete": 1,
+        "pnns_groups_2": "Plant-based milk substitutes",
+        "nutrition_score_beverage": 0,
+        "teams": "we-are-the-robots",
+        "new_additives_n": 0,
+        "product_quantity": 1000,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/842/425/982/6051/front_es.5.100.jpg",
+        "ingredients_text_debug": "Agua, habas de soja descascarilladas* 13,2%. (* Ingredientes procedentes de la agricultura ecológica).",
+        "ingredients_text_es_ocr_1579088422_result": "procedentes de la agricultura ecológica).",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/842/425/982/6051/front_es.5.400.jpg",
+        "_id": "8424259826051",
+        "countries_tags": [
+            "en:spain"
+        ],
+        "ingredients_hierarchy": [
+            "en:water",
+            "en:hulled-soya-bean",
+            "en:legume",
+            "en:soya",
+            "en:soya-bean"
+        ],
+        "serving_size": "250 ml",
+        "stores_tags": [
+            "carrefour"
+        ],
+        "additives_original_tags": [],
+        "nutriscore_score": -2,
+        "compared_to_category": "en:unsweetened-natural-soy-milks",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "correctors": [
+            "javichu"
+        ],
+        "ingredients_n_tags": [
+            "2",
+            "1-10"
+        ],
+        "pnns_groups_1_tags": [
+            "beverages",
+            "known"
+        ],
+        "additives_old_n": 0,
+        "packagings": [
+            {
+                "shape": "en:unknown",
+                "material": "en:unknown"
+            }
+        ],
+        "brands_tags": [
+            "gerble"
+        ],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "data_quality_errors_tags": [],
+        "quantity": "1 l",
+        "ingredients_ids_debug": [
+            "agua",
+            "habas-de-soja-descascarilladas-13",
+            "2",
+            "ingredientes-procedentes-de-la-agricultura-ecologica"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 0,
+        "ingredients_original_tags": [
+            "en:water",
+            "en:hulled-soya-bean"
+        ],
+        "unknown_ingredients_n": 0,
+        "manufacturing_places_tags": [
+            "fabricante",
+            "saint-denis-de-l-hotel",
+            "orleans-distrito",
+            "loiret",
+            "centro-region",
+            "francia",
+            "distribuidor",
+            "espana"
+        ],
+        "emb_codes_orig": "EMB 45273,FABRICANTE Y ENVASADOR:,LSDH - LAITERIE DE SAINT DENIS DE L’HÔTEL S.A.S.,DISTRIBUIDOR EN ESPAÑA:,NUTRITION & SANTÉ IBERIA S.L.,PERTENECIENTE A:,NUTRITION & SANTÉ S.A.S.,OTSUKA PHARMACEUTICAL CO. LTD.,OTSUKA HOLDINGS CO. LTD.",
+        "checkers_tags": [],
+        "emb_codes": "EMB 45273,FABRICANTE Y ENVASADOR:,LSDH - LAITERIE DE SAINT DENIS DE L’HÔTEL S.A.S.,DISTRIBUIDOR EN ESPAÑA:,NUTRITION & SANTÉ IBERIA S.L.,PERTENECIENTE A:,NUTRITION & SANTÉ S.A.S.,OTSUKA PHARMACEUTICAL CO. LTD.,OTSUKA HOLDINGS CO. LTD.",
+        "max_imgid": "3",
+        "editors": [
+            "javichu"
+        ],
+        "ingredients_text_es_ocr_1579088422": "Agua, habas de soja descascarilladas* 13,2%. (* Ingredientes procedentes de la agricultura ecológica).",
+        "nutriscore_score_opposite": 2,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/842/425/982/6051/front_es.5.200.jpg",
+        "nutriments": {
+            "carbohydrates_unit": "g",
+            "energy-kj_100g": 177,
+            "saturated-fat_serving": 0.75,
+            "sugars_100g": 0.7,
+            "sodium_value": 0.01016,
+            "proteins_serving": 9.5,
+            "nova-group_serving": 1,
+            "salt_100g": 0.0254,
+            "energy_unit": "kJ",
+            "energy-kj_serving": 442,
+            "sugars_unit": "g",
+            "energy-kj_unit": "kJ",
+            "salt": 0.0254,
+            "monounsaturated-fat_value": 0.4,
+            "fiber_100g": 0.5,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0,
+            "saturated-fat": 0.3,
+            "monounsaturated-fat_serving": 1,
+            "fat_value": 2.2,
+            "fiber": 0.5,
+            "nova-group_100g": 1,
+            "polyunsaturated-fat": 1.2,
+            "energy_value": 177,
+            "fiber_value": 0.5,
+            "polyunsaturated-fat_value": 1.2,
+            "fiber_unit": "g",
+            "monounsaturated-fat": 0.4,
+            "sodium_unit": "g",
+            "carbohydrates_serving": 4,
+            "carbohydrates_100g": 1.6,
+            "fat": 2.2,
+            "salt_serving": 0.0635,
+            "proteins": 3.8,
+            "energy_100g": 177,
+            "sodium_100g": 0.01016,
+            "polyunsaturated-fat_unit": "g",
+            "nutrition-score-fr_100g": -2,
+            "salt_unit": "g",
+            "carbohydrates_value": 1.6,
+            "proteins_unit": "g",
+            "polyunsaturated-fat_serving": 3,
+            "sugars_serving": 1.75,
+            "fat_unit": "g",
+            "salt_value": 0.0254,
+            "fiber_serving": 1.25,
+            "monounsaturated-fat_100g": 0.4,
+            "proteins_value": 3.8,
+            "saturated-fat_100g": 0.3,
+            "fat_serving": 5.5,
+            "monounsaturated-fat_unit": "g",
+            "nova-group": 1,
+            "energy": 177,
+            "saturated-fat_value": 0.3,
+            "energy_serving": 442,
+            "fat_100g": 2.2,
+            "saturated-fat_unit": "g",
+            "sodium_serving": 0.0254,
+            "energy-kj_value": 177,
+            "energy-kj": 177,
+            "sugars_value": 0.7,
+            "proteins_100g": 3.8,
+            "nutrition-score-fr": -2,
+            "polyunsaturated-fat_100g": 1.2,
+            "sodium": 0.01016,
+            "sugars": 0.7,
+            "carbohydrates": 1.6
+        },
+        "purchase_places_tags": [
+            "madrid",
+            "espana"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/842/425/982/6051/ingredients_es.6.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/842/425/982/6051/nutrition_es.7.200.jpg",
+        "additives_tags_n": null
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/8585002476821.json
+++ b/testdata/product/8585002476821.json
@@ -1,0 +1,1157 @@
+{
+    "status": 1,
+    "code": "8585002476821",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "categories_tags": [
+            "en:groceries"
+        ],
+        "traces_hierarchy": [
+            "en:celery",
+            "en:eggs",
+            "en:fish",
+            "en:milk",
+            "en:soybeans"
+        ],
+        "allergens_hierarchy": [
+            "en:gluten"
+        ],
+        "product_name_fr": "Papillottes Spécial Poêle Saumon à l'aneth et au jus de citron",
+        "generic_name": "Assaisonnement déshydraté aneth et jus de citron sur papier de cuisson",
+        "origins_tags": [],
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1450811060,
+        "emb_codes_20141016": "",
+        "additives_n": 2,
+        "carbon_footprint_from_known_ingredients_debug": "en:concentrated-lemon-juice 0.7% x 0.3 = 0.21 g - ",
+        "pnns_groups_2_tags": [
+            "unknown",
+            "missing-association"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "tacite"
+        ],
+        "sortkey": 1451218465,
+        "categories_old": "Epicerie",
+        "categories_properties": {},
+        "completeness": 0.8,
+        "labels_tags": [
+            "en:no-colorings",
+            "en:no-preservatives"
+        ],
+        "traces_from_user": "(fr) en:celery,en:eggs,en:fish,en:milk,en:soybeans",
+        "informers_tags": [
+            "tacite"
+        ],
+        "nutrition_grades_tags": [
+            "e"
+        ],
+        "lang": "fr",
+        "vitamins_tags": [],
+        "origins_lc": "fr",
+        "interface_version_modified": "20120622",
+        "additives_tags": [
+            "en:e330",
+            "en:e392"
+        ],
+        "unique_scans_n": 1,
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/858/500/247/6821/nutrition_fr.7.400.jpg",
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:france"
+        ],
+        "nova_group_debug": " -- ingredients/en:sugar : 3 -- ingredients/en:flavouring : 4",
+        "traces_tags": [
+            "en:celery",
+            "en:eggs",
+            "en:fish",
+            "en:milk",
+            "en:soybeans"
+        ],
+        "nova_groups": "4",
+        "packaging_tags": [
+            "sachet",
+            "papier"
+        ],
+        "allergens_from_ingredients": "blé",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/858/500/247/6821/front_fr.5.100.jpg",
+        "nutrient_levels": {
+            "salt": "high",
+            "sugars": "moderate",
+            "saturated-fat": "high",
+            "fat": "high"
+        },
+        "ingredients_analysis_tags": [
+            "en:palm-oil",
+            "en:maybe-vegan",
+            "en:maybe-vegetarian"
+        ],
+        "created_t": 1450811035,
+        "nutriscore_data": {
+            "proteins": 6.9,
+            "negative_points": 26,
+            "sugars_points": 1,
+            "score": 21,
+            "sodium_value": 8280,
+            "positive_points": 5,
+            "is_water": 0,
+            "saturated_fat_value": 13.7,
+            "proteins_points": 4,
+            "saturated_fat_points": 10,
+            "saturated_fat_ratio": 40.6528189910979,
+            "proteins_value": 6.9,
+            "saturated_fat_ratio_points": 6,
+            "fiber_points": 5,
+            "grade": "e",
+            "is_cheese": 0,
+            "energy": 1860,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 6.5,
+            "fiber": 6.2,
+            "energy_points": 5,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 10,
+            "is_fat": 0,
+            "energy_value": 1860,
+            "is_beverage": 0,
+            "fiber_value": 6.2,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 6.5,
+            "saturated_fat_ratio_value": 40.7,
+            "sugars_value": 7.5,
+            "saturated_fat": 13.7,
+            "sodium": 8280,
+            "sugars": 7.5
+        },
+        "nova_group": 4,
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "e",
+        "scans_n": 2,
+        "nucleotides_tags": [],
+        "ingredients_text_with_allergens_fr": "Sel, huile de palme, plantes aromatiques : ail, aneth 4,4%, persil; huile de tournesol, légumes : oignon, tomate; arômes (<span class=\"allergen\">blé</span>), acidifiant : acide citrique; sucre, fibres de pois, jus de citron concentré 0,7%, poivre, curcuma, antioxydant : extraits de romarin",
+        "images": {
+            "nutrition_fr": {
+                "rev": "7",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 334
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 84
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 167
+                    },
+                    "full": {
+                        "h": 1031,
+                        "w": 861
+                    }
+                },
+                "normalize": "false",
+                "geometry": "861x1031-342-198",
+                "imgid": "1"
+            },
+            "nutrition": {
+                "rev": "7",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 334
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 84
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 167
+                    },
+                    "full": {
+                        "h": 1031,
+                        "w": 861
+                    }
+                },
+                "normalize": "false",
+                "geometry": "861x1031-342-198",
+                "imgid": "1"
+            },
+            "front_fr": {
+                "rev": "5",
+                "white_magic": "false",
+                "geometry": "0x0-0-0",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 268
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 67
+                    },
+                    "full": {
+                        "h": 3702,
+                        "w": 2477
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 134
+                    }
+                },
+                "normalize": "false",
+                "imgid": "2"
+            },
+            "ingredients": {
+                "rev": "6",
+                "white_magic": "false",
+                "normalize": "false",
+                "sizes": {
+                    "400": {
+                        "h": 42,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 10,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 311,
+                        "w": 2994
+                    },
+                    "200": {
+                        "h": 21,
+                        "w": 200
+                    }
+                },
+                "geometry": "2994x311-262-1460",
+                "imgid": "1"
+            },
+            "1": {
+                "uploaded_t": "1450811035",
+                "uploader": "tacite",
+                "sizes": {
+                    "400": {
+                        "h": 327,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 82,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 2906,
+                        "w": 3554
+                    }
+                }
+            },
+            "front": {
+                "rev": "5",
+                "white_magic": "false",
+                "geometry": "0x0-0-0",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 268
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 67
+                    },
+                    "full": {
+                        "h": 3702,
+                        "w": 2477
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 134
+                    }
+                },
+                "normalize": "false",
+                "imgid": "2"
+            },
+            "2": {
+                "uploaded_t": "1450811059",
+                "uploader": "tacite",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 268
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 67
+                    },
+                    "full": {
+                        "h": 3702,
+                        "w": 2477
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "rev": "6",
+                "white_magic": "false",
+                "normalize": "false",
+                "sizes": {
+                    "400": {
+                        "h": 42,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 10,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 311,
+                        "w": 2994
+                    },
+                    "200": {
+                        "h": 21,
+                        "w": 200
+                    }
+                },
+                "geometry": "2994x311-262-1460",
+                "imgid": "1"
+            }
+        },
+        "ingredients_n": 21,
+        "editors_tags": [
+            "tacite"
+        ],
+        "allergens_tags": [
+            "en:gluten"
+        ],
+        "countries_lc": "fr",
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "completed_t": 1451218465,
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "code": "8585002476821",
+        "manufacturing_places": "",
+        "codes_tags": [
+            "code-13",
+            "8585002476821",
+            "858500247682x",
+            "85850024768xx",
+            "8585002476xxx",
+            "858500247xxxx",
+            "85850024xxxxx",
+            "8585002xxxxxx",
+            "858500xxxxxxx",
+            "85850xxxxxxxx",
+            "8585xxxxxxxxx",
+            "858xxxxxxxxxx",
+            "85xxxxxxxxxxx",
+            "8xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "tacite",
+        "labels": "Sans colorants, Sans conservateurs",
+        "entry_dates_tags": [
+            "2015-12-22",
+            "2015-12",
+            "2015"
+        ],
+        "last_edit_dates_tags": [
+            "2015-12-27",
+            "2015-12",
+            "2015"
+        ],
+        "creator": "tacite",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "citron",
+            "san",
+            "deshydrate",
+            "ju",
+            "cuisson",
+            "poele",
+            "aneth",
+            "au",
+            "special",
+            "colorant",
+            "epicerie",
+            "et",
+            "sur",
+            "saumon",
+            "papier",
+            "assaisonnement",
+            "papillotte",
+            "de",
+            "conservateur",
+            "maggi"
+        ],
+        "amino_acids_tags": [],
+        "link": "",
+        "ingredients_debug": [
+            "Sel",
+            ",",
+            null,
+            null,
+            null,
+            " huile de palme",
+            ",",
+            null,
+            null,
+            null,
+            " plantes aromatiques ",
+            ":",
+            ":",
+            null,
+            null,
+            " ail",
+            ",",
+            null,
+            null,
+            null,
+            " aneth 4",
+            ",",
+            null,
+            null,
+            null,
+            "4%",
+            ",",
+            null,
+            null,
+            null,
+            " persil",
+            ";",
+            ";",
+            null,
+            null,
+            " huile de tournesol",
+            ",",
+            null,
+            null,
+            null,
+            " légumes ",
+            ":",
+            ":",
+            null,
+            null,
+            " oignon",
+            ",",
+            null,
+            null,
+            null,
+            " tomate",
+            ";",
+            ";",
+            null,
+            null,
+            " arômes ",
+            "(",
+            "(",
+            null,
+            null,
+            "_blé_)",
+            ",",
+            null,
+            null,
+            null,
+            " acidifiant ",
+            ":",
+            ":",
+            null,
+            null,
+            "  acide citrique",
+            ";",
+            ";",
+            null,
+            null,
+            " sucre",
+            ",",
+            null,
+            null,
+            null,
+            " fibres de pois",
+            ",",
+            null,
+            null,
+            null,
+            " jus de citron concentré 0",
+            ",",
+            null,
+            null,
+            null,
+            "7%",
+            ",",
+            null,
+            null,
+            null,
+            " poivre",
+            ",",
+            null,
+            null,
+            null,
+            " curcuma",
+            ",",
+            null,
+            null,
+            null,
+            " antioxydant ",
+            ":",
+            ":",
+            null,
+            null,
+            "  extraits de romarin"
+        ],
+        "labels_lc": "fr",
+        "languages_codes": {
+            "fr": 6
+        },
+        "packaging": "sachet,papier",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/858/500/247/6821/front_fr.5.400.jpg",
+        "last_image_dates_tags": [
+            "2015-12-22",
+            "2015-12",
+            "2015"
+        ],
+        "popularity_key": 1,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/858/500/247/6821/front_fr.5.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [
+            "en:nutrition-value-very-high-for-category-saturated-fat",
+            "en:nutrition-value-very-high-for-category-salt"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-not-computed"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "tacite"
+        ],
+        "last_modified_t": 1451218465,
+        "ingredients": [
+            {
+                "percent_max": 80.5,
+                "id": "en:salt",
+                "percent_min": 6.25,
+                "percent_estimate": 43.375,
+                "text": "Sel",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_estimate": 23.425,
+                "percent_min": "4.4",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "from_palm_oil": "yes",
+                "percent_max": 42.45,
+                "id": "en:palm-oil",
+                "text": "huile de palme"
+            },
+            {
+                "percent_estimate": 17.0833333333333,
+                "percent_min": "4.4",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": 29.7666666666667,
+                "id": "en:herb",
+                "text": "plantes aromatiques"
+            },
+            {
+                "percent_estimate": "4.4",
+                "percent_min": "4.4",
+                "percent": "4.4",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "4.4",
+                "id": "en:dill",
+                "text": "aneth"
+            },
+            {
+                "percent_max": "4.4",
+                "id": "en:parsley",
+                "percent_min": "0.7",
+                "percent_estimate": 2.55,
+                "text": "persil",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_estimate": 2.55,
+                "percent_min": "0.7",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "from_palm_oil": "no",
+                "percent_max": "4.4",
+                "id": "en:sunflower-oil",
+                "text": "huile de tournesol"
+            },
+            {
+                "percent_estimate": 2.55,
+                "percent_min": "0.7",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "4.4",
+                "id": "en:vegetable",
+                "text": "légumes"
+            },
+            {
+                "percent_max": "4.4",
+                "id": "en:tomato",
+                "percent_min": "0.7",
+                "percent_estimate": 2.38333333333334,
+                "text": "tomate",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_estimate": 1.19166666666667,
+                "percent_min": "0.7",
+                "vegan": "maybe",
+                "vegetarian": "maybe",
+                "percent_max": "4.4",
+                "id": "en:flavouring",
+                "text": "arômes"
+            },
+            {
+                "percent_max": "4.4",
+                "id": "en:acid",
+                "percent_estimate": 0.595833333333337,
+                "percent_min": "0.7",
+                "text": "acidifiant"
+            },
+            {
+                "percent_max": "4.4",
+                "id": "en:sugar",
+                "text": "sucre",
+                "percent_estimate": 0.297916666666671,
+                "percent_min": "0.7",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": "4.4",
+                "id": "en:pea-fiber",
+                "percent_estimate": 0.148958333333339,
+                "percent_min": "0.7",
+                "text": "fibres de pois",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent": "0.7",
+                "percent_estimate": -0.551041666666663,
+                "percent_min": "0.7",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "0.7",
+                "id": "en:concentrated-lemon-juice",
+                "text": "jus de citron concentré"
+            },
+            {
+                "percent_max": "0.7",
+                "id": "en:pepper",
+                "text": "poivre",
+                "percent_estimate": 0,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": "0.7",
+                "id": "en:turmeric",
+                "text": "curcuma",
+                "percent_estimate": 0,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": "0.7",
+                "id": "en:antioxidant",
+                "text": "antioxydant",
+                "percent_estimate": 0,
+                "percent_min": 0
+            }
+        ],
+        "nutriscore_grade": "e",
+        "stores": "",
+        "countries": "France",
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "other_nutritional_substances_tags": [],
+        "cities_tags": [],
+        "brands": "Maggi",
+        "categories": "Epicerie",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "ingredients_text_with_allergens": "Sel, huile de palme, plantes aromatiques : ail, aneth 4,4%, persil; huile de tournesol, légumes : oignon, tomate; arômes (<span class=\"allergen\">blé</span>), acidifiant : acide citrique; sucre, fibres de pois, jus de citron concentré 0,7%, poivre, curcuma, antioxydant : extraits de romarin",
+        "nutrition_grades": "e",
+        "nutrient_levels_tags": [
+            "en:fat-in-high-quantity",
+            "en:saturated-fat-in-high-quantity",
+            "en:sugars-in-moderate-quantity",
+            "en:salt-in-high-quantity"
+        ],
+        "known_ingredients_n": 34,
+        "minerals_prev_tags": [],
+        "product_name": "Papillottes Spécial Poêle Saumon à l'aneth et au jus de citron",
+        "ingredients_text": "Sel, huile de palme, plantes aromatiques : ail, aneth 4,4%, persil; huile de tournesol, légumes : oignon, tomate; arômes (_blé_), acidifiant : acide citrique; sucre, fibres de pois, jus de citron concentré 0,7%, poivre, curcuma, antioxydant : extraits de romarin",
+        "origins": "",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Sel, huile de palme, plantes aromatiques : ail, aneth 4,4%, persil; huile de tournesol, légumes : oignon, tomate; arômes (_blé_), acidifiant : acide citrique; sucre, fibres de pois, jus de citron concentré 0,7%, poivre, curcuma, antioxydant : extraits de romarin",
+        "categories_lc": "fr",
+        "allergens": "en:gluten",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/858/500/247/6821/ingredients_fr.6.100.jpg",
+        "ecoscore_data": {
+            "missing_agribalyse_match_warning": 1,
+            "status": "unknown",
+            "agribalyse": {
+                "warning": "missing_agribalyse_match"
+            },
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -1,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:bag",
+                            "material": "en:paper",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": "92"
+                        }
+                    ],
+                    "score": 92
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_value": -5,
+                    "transportation_score_ch": 0,
+                    "value_ie": -5,
+                    "transportation_value_de": 0,
+                    "value_fr": -5,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "value_lu": -5,
+                    "transportation_score_nl": 0
+                },
+                "threatened_species": {
+                    "ingredient": "en:palm-oil",
+                    "value": -10
+                }
+            },
+            "missing": {
+                "agb_category": 1,
+                "labels": 1,
+                "origins": 1
+            }
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/858/500/247/6821/nutrition_fr.7.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/858/500/247/6821/nutrition_fr.7.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/858/500/247/6821/nutrition_fr.7.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/858/500/247/6821/ingredients_fr.6.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/858/500/247/6821/ingredients_fr.6.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/858/500/247/6821/ingredients_fr.6.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/858/500/247/6821/front_fr.5.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/858/500/247/6821/front_fr.5.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/858/500/247/6821/front_fr.5.200.jpg"
+                }
+            }
+        },
+        "rev": 11,
+        "origins_old": "",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 1,
+        "last_editor": "tacite",
+        "additives_prev_original_tags": [
+            "en:e330",
+            "en:e100",
+            "en:e392"
+        ],
+        "ingredients_tags": [
+            "en:salt",
+            "en:palm-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:palm-oil-and-fat",
+            "en:herb",
+            "en:dill",
+            "en:parsley",
+            "en:sunflower-oil",
+            "en:vegetable-oil",
+            "en:vegetable",
+            "en:tomato",
+            "en:flavouring",
+            "en:acid",
+            "en:sugar",
+            "en:pea-fiber",
+            "en:fiber",
+            "en:vegetable-fiber",
+            "en:concentrated-lemon-juice",
+            "en:fruit",
+            "en:citrus-fruit",
+            "en:lemon",
+            "en:pepper",
+            "en:seed",
+            "en:turmeric",
+            "en:spice",
+            "en:antioxidant",
+            "en:garlic",
+            "en:root-vegetable",
+            "en:onion",
+            "en:wheat",
+            "en:cereal",
+            "en:e330",
+            "en:e392"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/858/500/247/6821/nutrition_fr.7.100.jpg",
+        "labels_prev_tags": [
+            "en:no-colorings",
+            "en:no-preservatives"
+        ],
+        "ingredients_from_palm_oil_tags": [
+            "huile-de-palme"
+        ],
+        "carbon_footprint_percent_of_known_ingredients": 0.7,
+        "categories_hierarchy": [
+            "en:groceries"
+        ],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "unknown",
+        "labels_prev_hierarchy": [
+            "en:no-colorings",
+            "en:no-preservatives"
+        ],
+        "ingredients_percent_analysis": 1,
+        "languages": {
+            "en:french": 6
+        },
+        "purchase_places": "",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-unknown",
+            "agribalyse-unknown"
+        ],
+        "id": "8585002476821",
+        "no_nutrition_data": null,
+        "pnns_groups_1": "unknown",
+        "allergens_from_user": "(fr) en:gluten",
+        "additives_debug_tags": [
+            "en-e100-removed"
+        ],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/858/500/247/6821/ingredients_fr.6.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish",
+            "en:nutrition-value-very-high-for-category-saturated-fat",
+            "en:nutrition-value-very-high-for-category-salt"
+        ],
+        "additives_old_tags": [
+            "en:e330"
+        ],
+        "origins_hierarchy": [],
+        "ingredients_from_palm_oil_n": 1,
+        "ecoscore_tags": [
+            "unknown"
+        ],
+        "labels_hierarchy": [
+            "en:no-colorings",
+            "en:no-preservatives"
+        ],
+        "pnns_groups_2": "unknown",
+        "nutrition_score_beverage": 0,
+        "complete": 1,
+        "product_quantity": 23.2,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/858/500/247/6821/front_fr.5.100.jpg",
+        "ingredients_text_debug": "Sel, huile de palme, plantes aromatiques : ail, aneth 4,4%, persil; huile de tournesol, légumes : oignon, tomate; arômes (_blé_), acidifiant :  acide citrique; sucre, fibres de pois, jus de citron concentré 0,7%, poivre, curcuma, antioxydant :  extraits de romarin",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/858/500/247/6821/front_fr.5.400.jpg",
+        "_id": "8585002476821",
+        "countries_tags": [
+            "en:france"
+        ],
+        "ingredients_hierarchy": [
+            "en:salt",
+            "en:palm-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:palm-oil-and-fat",
+            "en:herb",
+            "en:dill",
+            "en:parsley",
+            "en:sunflower-oil",
+            "en:vegetable-oil",
+            "en:vegetable",
+            "en:tomato",
+            "en:flavouring",
+            "en:acid",
+            "en:sugar",
+            "en:pea-fiber",
+            "en:fiber",
+            "en:vegetable-fiber",
+            "en:concentrated-lemon-juice",
+            "en:fruit",
+            "en:citrus-fruit",
+            "en:lemon",
+            "en:pepper",
+            "en:seed",
+            "en:turmeric",
+            "en:spice",
+            "en:antioxidant",
+            "en:garlic",
+            "en:root-vegetable",
+            "en:onion",
+            "en:wheat",
+            "en:cereal",
+            "en:e330",
+            "en:e392"
+        ],
+        "additives_original_tags": [
+            "en:e330",
+            "en:e392"
+        ],
+        "stores_tags": [],
+        "nutriscore_score": 21,
+        "compared_to_category": "en:groceries",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "21",
+            "21-30"
+        ],
+        "pnns_groups_1_tags": [
+            "unknown",
+            "missing-association"
+        ],
+        "additives_old_n": 1,
+        "packagings": [
+            {
+                "shape": "en:bag",
+                "material": "en:paper"
+            }
+        ],
+        "quantity": "23,2 g",
+        "brands_tags": [
+            "maggi"
+        ],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:carbon-footprint-from-known-ingredients-but-not-from-meat-or-fish"
+        ],
+        "data_quality_errors_tags": [],
+        "ingredients_ids_debug": [
+            "sel",
+            "huile-de-palme",
+            "plantes-aromatiques",
+            "ail",
+            "aneth-4",
+            "4",
+            "persil",
+            "huile-de-tournesol",
+            "legumes",
+            "oignon",
+            "tomate",
+            "aromes",
+            "ble",
+            "acidifiant",
+            "acide-citrique",
+            "sucre",
+            "fibres-de-pois",
+            "jus-de-citron-concentre-0",
+            "7",
+            "poivre",
+            "curcuma",
+            "antioxydant",
+            "extraits-de-romarin"
+        ],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [
+            "en:salt",
+            "en:palm-oil",
+            "en:herb",
+            "en:dill",
+            "en:parsley",
+            "en:sunflower-oil",
+            "en:vegetable",
+            "en:tomato",
+            "en:flavouring",
+            "en:acid",
+            "en:sugar",
+            "en:pea-fiber",
+            "en:concentrated-lemon-juice",
+            "en:pepper",
+            "en:turmeric",
+            "en:antioxidant",
+            "en:garlic",
+            "en:onion",
+            "en:wheat",
+            "en:e330",
+            "en:e392"
+        ],
+        "traces": "en:celery,en:eggs,en:fish,en:milk,en:soybeans",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 6.5,
+        "unknown_ingredients_n": 0,
+        "manufacturing_places_tags": [],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "max_imgid": "2",
+        "emb_codes": "",
+        "nutriscore_score_opposite": -21,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/858/500/247/6821/front_fr.5.200.jpg",
+        "generic_name_fr": "Assaisonnement déshydraté aneth et jus de citron sur papier de cuisson",
+        "nutriments": {
+            "proteins": 6.9,
+            "energy_100g": 1860,
+            "carbohydrates_unit": "g",
+            "energy-kj_100g": 1860,
+            "sodium_100g": 8.28,
+            "sugars_100g": 7.5,
+            "sodium_value": 8.28,
+            "salt_100g": 20.7,
+            "nova-group_serving": 4,
+            "nutrition-score-fr_100g": 21,
+            "energy_unit": "kJ",
+            "salt_unit": "g",
+            "proteins_unit": "g",
+            "carbohydrates_value": 21.8,
+            "sugars_unit": "g",
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt_value": 20.7,
+            "salt": 20.7,
+            "proteins_value": 6.9,
+            "saturated-fat_100g": 13.7,
+            "fiber_100g": 6.2,
+            "saturated-fat": 13.7,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 6.5,
+            "fat_value": 33.7,
+            "carbon-footprint-from-known-ingredients_100g": 0.21,
+            "energy": 1860,
+            "nova-group": 4,
+            "fiber": 6.2,
+            "saturated-fat_value": 13.7,
+            "nova-group_100g": 4,
+            "fat_100g": 33.7,
+            "saturated-fat_unit": "g",
+            "energy_value": 1860,
+            "energy-kj_value": 1860,
+            "fiber_value": 6.2,
+            "fiber_unit": "g",
+            "energy-kj": 1860,
+            "carbon-footprint-from-known-ingredients_product": 0.0487,
+            "proteins_100g": 6.9,
+            "sugars_value": 7.5,
+            "sodium_unit": "g",
+            "nutrition-score-fr": 21,
+            "sodium": 8.28,
+            "carbohydrates_100g": 21.8,
+            "sugars": 7.5,
+            "carbohydrates": 21.8,
+            "fat": 33.7
+        },
+        "purchase_places_tags": [],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/858/500/247/6821/ingredients_fr.6.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/858/500/247/6821/nutrition_fr.7.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/8712000031312.json
+++ b/testdata/product/8712000031312.json
@@ -1,0 +1,639 @@
+{
+    "status": 1,
+    "code": "8712000031312",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "popularity_tags": [
+            "bottom-25-percent-scans-2019",
+            "top-80-percent-scans-2019",
+            "top-85-percent-scans-2019",
+            "top-90-percent-scans-2019",
+            "top-50000-de-scans-2019",
+            "top-100000-de-scans-2019",
+            "top-country-de-scans-2019",
+            "top-50000-be-scans-2019",
+            "top-100000-be-scans-2019",
+            "top-75-percent-scans-2020",
+            "top-80-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-5000-nl-scans-2020",
+            "top-10000-nl-scans-2020",
+            "top-50000-nl-scans-2020",
+            "top-100000-nl-scans-2020",
+            "top-country-nl-scans-2020",
+            "top-50000-de-scans-2020",
+            "top-100000-de-scans-2020"
+        ],
+        "categories_tags": [
+            "en:beverages",
+            "en:alcoholic-beverages",
+            "en:beers"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [
+            "en:gluten"
+        ],
+        "informers": [],
+        "origins_tags": [],
+        "product_name_fr": "heineken pilsener",
+        "generic_name": "Bière pils",
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1339845658,
+        "additives_n": 0,
+        "emb_codes_20141016": "",
+        "pnns_groups_2_tags": [
+            "alcoholic-beverages",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "malikele"
+        ],
+        "sortkey": 1358510855,
+        "categories_old": "Boissons, Boissons alcoolisées, Bières",
+        "completeness": 0.766666666666667,
+        "categories_properties": {
+            "agribalyse_proxy_food_code:en": "5000"
+        },
+        "traces_from_user": "(fr) ",
+        "labels_tags": [],
+        "nutrition_grades_tags": [
+            "not-applicable"
+        ],
+        "informers_tags": [
+            "malikele",
+            "manu1400"
+        ],
+        "vitamins_tags": [],
+        "lang": "fr",
+        "origins_lc": "fr",
+        "interface_version_modified": "20120622",
+        "unique_scans_n": 4,
+        "additives_tags": [],
+        "unknown_nutrients_tags": [],
+        "nova_group_debug": " -- categories/en:alcoholic-beverages : 3",
+        "countries_hierarchy": [
+            "en:belgium"
+        ],
+        "traces_tags": [],
+        "packaging_tags": [
+            "canette"
+        ],
+        "nova_groups": "3",
+        "allergens_from_ingredients": "orge",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/871/200/003/1312/front_fr.5.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-free",
+            "en:vegan",
+            "en:vegetarian"
+        ],
+        "nutrient_levels": {},
+        "created_t": 1339845643,
+        "amino_acids_prev_tags": [],
+        "nova_group": 3,
+        "nucleotides_tags": [],
+        "scans_n": 8,
+        "images": {
+            "1": {
+                "uploaded_t": 1339845644,
+                "uploader": "malikele",
+                "sizes": {
+                    "400": {
+                        "h": 266,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 66,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1329,
+                        "w": 2000
+                    }
+                }
+            },
+            "front_fr": {
+                "rev": "5",
+                "white_magic": "checked",
+                "geometry": "845x1395-214-430",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 242
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 61
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 121
+                    },
+                    "full": {
+                        "h": 1395,
+                        "w": 845
+                    }
+                },
+                "normalize": null,
+                "imgid": "2"
+            },
+            "front": {
+                "rev": "5",
+                "white_magic": "checked",
+                "geometry": "845x1395-214-430",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 242
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 61
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 121
+                    },
+                    "full": {
+                        "h": 1395,
+                        "w": 845
+                    }
+                },
+                "normalize": null,
+                "imgid": "2"
+            },
+            "2": {
+                "uploaded_t": 1339845658,
+                "uploader": "malikele",
+                "sizes": {
+                    "400": {
+                        "h": 266,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 66,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1329,
+                        "w": 2000
+                    }
+                }
+            }
+        },
+        "ingredients_text_with_allergens_fr": "Eau, <span class=\"allergen\">orge</span>, houblon",
+        "ingredients_n": 3,
+        "editors_tags": [
+            "manu1400",
+            "malikele"
+        ],
+        "allergens_tags": [
+            "en:gluten"
+        ],
+        "countries_lc": "fr",
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "nova_groups_tags": [
+            "en:3-processed-foods"
+        ],
+        "code": "8712000031312",
+        "codes_tags": [
+            "code-13",
+            "8712000031312",
+            "871200003131x",
+            "87120000313xx",
+            "8712000031xxx",
+            "871200003xxxx",
+            "87120000xxxxx",
+            "8712000xxxxxx",
+            "871200xxxxxxx",
+            "87120xxxxxxxx",
+            "8712xxxxxxxxx",
+            "871xxxxxxxxxx",
+            "87xxxxxxxxxxx",
+            "8xxxxxxxxxxxx"
+        ],
+        "labels": "",
+        "last_modified_by": "manu1400",
+        "last_edit_dates_tags": [
+            "2013-01-18",
+            "2013-01",
+            "2013"
+        ],
+        "entry_dates_tags": [
+            "2012-06-16",
+            "2012-06",
+            "2012"
+        ],
+        "creator": "malikele",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "biere",
+            "pilsener",
+            "pil",
+            "heineken"
+        ],
+        "ingredients_debug": [
+            "Eau",
+            ",",
+            null,
+            null,
+            null,
+            " orge",
+            ",",
+            null,
+            null,
+            null,
+            " houblon"
+        ],
+        "languages_codes": {
+            "fr": 4
+        },
+        "labels_lc": "fr",
+        "packaging": "canette",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/871/200/003/1312/front_fr.5.400.jpg",
+        "last_image_dates_tags": [
+            "2012-06-16",
+            "2012-06",
+            "2012"
+        ],
+        "popularity_key": 4,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/871/200/003/1312/front_fr.5.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [
+            "en:alcoholic-beverages-category-without-alcohol-value"
+        ],
+        "misc_tags": [
+            "en:nutriscore-not-computed",
+            "en:nutriscore-not-applicable",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "countries_debug_tags": [],
+        "nutrition_data_per": "100g",
+        "ecoscore_score": 47,
+        "photographers_tags": [
+            "malikele"
+        ],
+        "last_modified_t": 1358510855,
+        "ingredients": [
+            {
+                "percent_max": 100,
+                "id": "en:water",
+                "percent_min": 33.3333333333333,
+                "percent_estimate": 66.6666666666667,
+                "text": "Eau",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 50,
+                "id": "en:barley",
+                "text": "orge",
+                "percent_estimate": 16.6666666666667,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 33.3333333333333,
+                "id": "en:hops",
+                "text": "houblon",
+                "percent_estimate": 16.6666666666667,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            }
+        ],
+        "stores": "",
+        "countries": "Belgique",
+        "cities_tags": [],
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "brands": "heineken",
+        "categories": "Boissons, Boissons alcoolisées, Bières",
+        "ingredients_text_with_allergens": "Eau, <span class=\"allergen\">orge</span>, houblon",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:photos-uploaded",
+        "nutrient_levels_tags": [],
+        "known_ingredients_n": 5,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Eau, orge, houblon",
+        "product_name": "heineken pilsener",
+        "origins": "",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "Eau, orge, houblon",
+        "categories_lc": "fr",
+        "allergens": "",
+        "photographers": [],
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "c",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_ch": 0,
+                    "epi_value": -5,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 0,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:drink-can",
+                            "material": "en:unknown",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "score": 0,
+                    "warning": "unspecified_material"
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "c",
+            "score": 47,
+            "grade_de": "c",
+            "missing_data_warning": 1,
+            "grade_nl": "c",
+            "score_be": 42,
+            "agribalyse": {
+                "co2_transportation": "0.268586",
+                "ef_distribution": "0.0088128735",
+                "name_fr": "Bière brune",
+                "agribalyse_food_code": "5000",
+                "score": 57,
+                "ef_consumption": "0.0024293397",
+                "ef_agriculture": "0.0084453762",
+                "name_en": "Beer, dark",
+                "ef_packaging": "0.051649676000000005",
+                "co2_total": "1.0944464",
+                "ef_processing": "0.031844848999999995",
+                "is_beverage": 1,
+                "code": "5000",
+                "co2_processing": "0.25081748",
+                "dqr": "3.07",
+                "agribalyse_proxy_food_code": "5000",
+                "co2_consumption": "0.0047993021",
+                "ef_total": "0.12383059000000002",
+                "co2_distribution": "0.028932423",
+                "co2_agriculture": "0.044404353",
+                "ef_transportation": "0.02064847",
+                "co2_packaging": "0.49690685"
+            },
+            "grade_it": "c",
+            "score_nl": 42,
+            "missing": {
+                "packagings": 1,
+                "labels": 1,
+                "origins": 1
+            },
+            "grade_ie": "c",
+            "score_ch": 42,
+            "score_de": 42,
+            "score_fr": 42,
+            "score_ie": 42,
+            "score_lu": 42,
+            "score_it": 42,
+            "score_es": 42,
+            "grade_es": "c",
+            "grade_ch": "c",
+            "grade": "c",
+            "grade_lu": "c"
+        },
+        "selected_images": {
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/871/200/003/1312/front_fr.5.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/871/200/003/1312/front_fr.5.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/871/200/003/1312/front_fr.5.200.jpg"
+                }
+            }
+        },
+        "rev": 7,
+        "origins_old": "",
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "manu1400",
+        "additives_prev_original_tags": [],
+        "ingredients_tags": [
+            "en:water",
+            "en:barley",
+            "en:cereal",
+            "en:hops",
+            "en:plant"
+        ],
+        "labels_prev_tags": [],
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:beverages",
+            "en:alcoholic-beverages",
+            "en:beers"
+        ],
+        "ecoscore_grade": "c",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "labels_prev_hierarchy": [],
+        "ingredients_percent_analysis": 1,
+        "languages": {
+            "en:french": 4
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-5000",
+            "agribalyse-proxy-food-code-known",
+            "ciqual-food-code-unknown",
+            "agribalyse-known",
+            "agribalyse-5000"
+        ],
+        "purchase_places": "",
+        "id": "8712000031312",
+        "no_nutrition_data": null,
+        "allergens_from_user": "(fr) ",
+        "checkers": [],
+        "additives_debug_tags": [],
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok",
+            "en:alcoholic-beverages-category-without-alcohol-value"
+        ],
+        "additives_old_tags": [],
+        "ecoscore_tags": [
+            "c"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "labels_hierarchy": [],
+        "origins_hierarchy": [],
+        "complete": 0,
+        "nutrition_score_beverage": 1,
+        "pnns_groups_2": "Alcoholic beverages",
+        "new_additives_n": 0,
+        "product_quantity": 330,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/871/200/003/1312/front_fr.5.100.jpg",
+        "ingredients_text_debug": "Eau, orge, houblon",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/871/200/003/1312/front_fr.5.400.jpg",
+        "_id": "8712000031312",
+        "countries_tags": [
+            "en:belgium"
+        ],
+        "ingredients_hierarchy": [
+            "en:water",
+            "en:barley",
+            "en:cereal",
+            "en:hops",
+            "en:plant"
+        ],
+        "stores_tags": [],
+        "additives_original_tags": [],
+        "compared_to_category": "en:beers",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "correctors": [],
+        "ingredients_n_tags": [
+            "3",
+            "1-10"
+        ],
+        "nutrition_score_debug": "no nutriscore for category en:alcoholic-beverages",
+        "additives_old_n": 0,
+        "packagings": [
+            {
+                "shape": "en:drink-can"
+            }
+        ],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "brands_tags": [
+            "heineken"
+        ],
+        "data_quality_errors_tags": [],
+        "quantity": "330ml",
+        "ingredients_ids_debug": [
+            "eau",
+            "orge",
+            "houblon"
+        ],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "ingredients_original_tags": [
+            "en:water",
+            "en:barley",
+            "en:hops"
+        ],
+        "unknown_ingredients_n": 0,
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "emb_codes": "",
+        "max_imgid": "2",
+        "editors": [
+            "manu1400",
+            "malikele"
+        ],
+        "image_small_url": "https://static.openfoodfacts.net/images/products/871/200/003/1312/front_fr.5.200.jpg",
+        "generic_name_fr": "Bière pils",
+        "nutriments": {
+            "energy_100g": 170,
+            "nova-group": 3,
+            "energy": 170,
+            "energy-kj_100g": 170,
+            "alcohol_serving": 5,
+            "nova-group_serving": 3,
+            "alcohol_100g": 5,
+            "energy_unit": "kJ",
+            "nova-group_100g": 3,
+            "energy_value": 170,
+            "energy-kj_value": 170,
+            "energy-kj_unit": "kJ",
+            "energy-kj": 170,
+            "alcohol_value": 5,
+            "alcohol_unit": "% vol",
+            "alcohol": 5,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 0
+        },
+        "purchase_places_tags": []
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/8992696419766.json
+++ b/testdata/product/8992696419766.json
@@ -1,0 +1,478 @@
+{
+    "status": 1,
+    "code": "8992696419766",
+    "product": {
+        "lc": "fr",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "popularity_tags": [
+            "bottom-25-percent-scans-2020",
+            "bottom-20-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-10000-gb-scans-2020",
+            "top-50000-gb-scans-2020",
+            "top-100000-gb-scans-2020",
+            "top-country-gb-scans-2020"
+        ],
+        "categories_tags": [],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "product_name_fr": "Sweetened Condensed Milk",
+        "languages_hierarchy": [
+            "en:french"
+        ],
+        "last_image_t": 1366045401,
+        "emb_codes_20141016": "",
+        "pnns_groups_2_tags": [
+            "unknown",
+            "missing-category"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [],
+        "sortkey": 1572644333,
+        "completeness": 0.366666666666667,
+        "categories_properties": {},
+        "traces_from_user": "(fr) ",
+        "labels_tags": [],
+        "nutrition_grades_tags": [
+            "unknown"
+        ],
+        "informers_tags": [
+            "openfoodfacts-contributors",
+            "fix-missing-lang-bot"
+        ],
+        "vitamins_tags": [],
+        "lang": "fr",
+        "interface_version_modified": "20130323.jqm",
+        "unique_scans_n": 1,
+        "additives_tags": [],
+        "categories_prev_tags": [],
+        "unknown_nutrients_tags": [],
+        "countries_hierarchy": [
+            "en:taiwan"
+        ],
+        "nova_group_debug": "no nova group when the product does not have ingredients",
+        "traces_tags": [],
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/899/269/641/9766/front_fr.3.100.jpg",
+        "nutrient_levels": {},
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "created_t": 1366045297,
+        "amino_acids_prev_tags": [],
+        "nucleotides_tags": [],
+        "scans_n": 1,
+        "images": {
+            "1": {
+                "uploaded_t": 1366045298,
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 3264,
+                        "w": 2448
+                    }
+                }
+            },
+            "4": {
+                "uploaded_t": 1366045401,
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 3264,
+                        "w": 2448
+                    }
+                }
+            },
+            "front": {
+                "rev": "3",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 3264,
+                        "w": 2448
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 150
+                    }
+                },
+                "normalize": null,
+                "geometry": "0x0--8--8",
+                "imgid": "1"
+            },
+            "front_fr": {
+                "rev": "3",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 3264,
+                        "w": 2448
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 150
+                    }
+                },
+                "normalize": null,
+                "geometry": "0x0--8--8",
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": 1366045351,
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 3264,
+                        "w": 2448
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": 1366045375,
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 3264,
+                        "w": 2448
+                    }
+                }
+            }
+        },
+        "editors_tags": [
+            "openfoodfacts-contributors",
+            "fix-missing-lang-bot"
+        ],
+        "countries_lc": "fr",
+        "allergens_tags": [],
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "code": "8992696419766",
+        "codes_tags": [
+            "code-13",
+            "8992696419xxx",
+            "899269641xxxx",
+            "89926964xxxxx",
+            "8992696xxxxxx",
+            "899269xxxxxxx",
+            "89926xxxxxxxx",
+            "8992xxxxxxxxx",
+            "899xxxxxxxxxx",
+            "89xxxxxxxxxxx",
+            "8xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "fix-missing-lang-bot",
+        "last_edit_dates_tags": [
+            "2019-11-01",
+            "2019-11",
+            "2019"
+        ],
+        "entry_dates_tags": [
+            "2013-04-15",
+            "2013-04",
+            "2013"
+        ],
+        "creator": "openfoodfacts-contributors",
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "nestle",
+            "condensed",
+            "milk",
+            "sweetened"
+        ],
+        "ingredients_debug": [],
+        "languages_codes": {
+            "fr": 2
+        },
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/899/269/641/9766/front_fr.3.400.jpg",
+        "popularity_key": 1,
+        "last_image_dates_tags": [
+            "2013-04-15",
+            "2013-04",
+            "2013"
+        ],
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/899/269/641/9766/front_fr.3.200.jpg",
+        "data_quality_warnings_tags": [],
+        "labels_debug_tags": [],
+        "misc_tags": [
+            "en:nutriscore-not-computed",
+            "en:nutriscore-missing-category",
+            "en:ecoscore-not-computed"
+        ],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-to-be-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:categories-to-be-completed",
+            "en:brands-completed",
+            "en:packaging-to-be-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "openfoodfacts-contributors"
+        ],
+        "last_modified_t": 1572644333,
+        "ingredients": [],
+        "countries": "Taiwan",
+        "cities_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "other_nutritional_substances_tags": [],
+        "brands": "Nestlé",
+        "states": "en:to-be-completed, en:nutrition-facts-to-be-completed, en:ingredients-to-be-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-to-be-completed, en:categories-to-be-completed, en:brands-completed, en:packaging-to-be-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:photos-uploaded",
+        "nutrient_levels_tags": [],
+        "minerals_prev_tags": [],
+        "product_name": "Sweetened Condensed Milk",
+        "languages_tags": [
+            "en:french",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "allergens": "",
+        "ecoscore_data": {
+            "agribalyse": {
+                "warning": "missing_agribalyse_match"
+            },
+            "status": "unknown",
+            "missing_agribalyse_match_warning": 1,
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:unknown",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "warning": "unscored_shape",
+                    "score": 0
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_value": -5,
+                    "transportation_score_ch": 0,
+                    "value_ie": -5,
+                    "transportation_value_de": 0,
+                    "value_fr": -5,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "threatened_species": {
+                    "warning": "ingredients_missing"
+                }
+            },
+            "missing": {
+                "packagings": 1,
+                "categories": 1,
+                "ingredients": 1,
+                "labels": 1,
+                "origins": 1
+            }
+        },
+        "selected_images": {
+            "front": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/899/269/641/9766/front_fr.3.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/899/269/641/9766/front_fr.3.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/899/269/641/9766/front_fr.3.200.jpg"
+                }
+            }
+        },
+        "rev": 8,
+        "last_editor": "fix-missing-lang-bot",
+        "additives_prev_original_tags": [],
+        "ingredients_tags": [],
+        "labels_prev_tags": [],
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [],
+        "ecoscore_grade": "unknown",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "labels_prev_hierarchy": [],
+        "languages": {
+            "en:french": 2
+        },
+        "categories_properties_tags": [
+            "all-products",
+            "categories-unknown",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-unknown",
+            "agribalyse-unknown"
+        ],
+        "id": "8992696419766",
+        "pnns_groups_1": "unknown",
+        "allergens_from_user": "(fr) ",
+        "additives_debug_tags": [],
+        "data_quality_tags": [],
+        "additives_old_tags": [],
+        "labels_hierarchy": [],
+        "ecoscore_tags": [
+            "unknown"
+        ],
+        "complete": 0,
+        "nutrition_score_beverage": 0,
+        "pnns_groups_2": "unknown",
+        "categories_debug_tags": [],
+        "product_quantity": 397,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/899/269/641/9766/front_fr.3.100.jpg",
+        "ingredients_text_debug": null,
+        "image_front_url": "https://static.openfoodfacts.net/images/products/899/269/641/9766/front_fr.3.400.jpg",
+        "_id": "8992696419766",
+        "countries_tags": [
+            "en:taiwan"
+        ],
+        "ingredients_hierarchy": [],
+        "additives_original_tags": [],
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-to-be-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:categories-to-be-completed",
+            "en:brands-completed",
+            "en:packaging-to-be-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "pnns_groups_1_tags": [
+            "unknown",
+            "missing-category"
+        ],
+        "nutrition_score_debug": "no score when the product does not have a category",
+        "packagings": [
+            {
+                "shape": "en:unknown",
+                "material": "en:unknown"
+            }
+        ],
+        "data_quality_errors_tags": [],
+        "data_quality_info_tags": [],
+        "brands_tags": [
+            "nestle"
+        ],
+        "quantity": "397g",
+        "ingredients_ids_debug": [],
+        "vitamins_prev_tags": [],
+        "traces": "",
+        "ingredients_original_tags": [],
+        "unknown_ingredients_n": 0,
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "emb_codes": "",
+        "max_imgid": "4",
+        "editors": [
+            ""
+        ],
+        "categories_prev_hierarchy": [],
+        "image_small_url": "https://static.openfoodfacts.net/images/products/899/269/641/9766/front_fr.3.200.jpg",
+        "nutriments": {}
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/9300601768226.json
+++ b/testdata/product/9300601768226.json
@@ -1,0 +1,1141 @@
+{
+    "status": 1,
+    "code": "9300601768226",
+    "product": {
+        "lc": "en",
+        "traces_from_ingredients": "",
+        "category_properties": {
+            "ciqual_food_name:fr": "Houmous",
+            "ciqual_food_name:en": "Hummus"
+        },
+        "categories_tags": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:spreads",
+            "en:salted-spreads",
+            "en:plant-based-spreads",
+            "en:hummus"
+        ],
+        "traces_hierarchy": [
+            "en:nuts"
+        ],
+        "allergens_hierarchy": [
+            "en:sesame-seeds"
+        ],
+        "origins_tags": [
+            "en:australia"
+        ],
+        "generic_name": "",
+        "languages_hierarchy": [
+            "en:english"
+        ],
+        "last_image_t": 1462775940,
+        "additives_n": 2,
+        "emb_codes_20141016": "",
+        "allergens_lc": "en",
+        "pnns_groups_2_tags": [
+            "salty-and-fatty-products",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "foodorigins",
+            "moon-rabbit"
+        ],
+        "ingredients_text_with_allergens_en": "Cooked Chickpeas (72%), Canola Oil, Tahini (8%), (<span class=\"allergen\">Sesame Seeds</span>), Garlic, Salt, Extra Virgin Olive Oil, Lemon Juice Concentrate, Vinegar, Acidity Regulator (330), Thickener (415). CONTAINS <span class=\"allergen\">SESAME</span>",
+        "sortkey": 1574619108,
+        "categories_old": "Plant-based foods and beverages, Plant-based foods, Spreads, Salted spreads, Plant-based spreads, Hummus",
+        "completeness": 0.9,
+        "categories_properties": {
+            "ciqual_food_code:en": "25621",
+            "agribalyse_food_code:en": "25621"
+        },
+        "traces_from_user": "(en) en:nuts",
+        "labels_tags": [
+            "en:gluten-free",
+            "en:australian-made",
+            "en:gf"
+        ],
+        "nutrition_grades_tags": [
+            "a"
+        ],
+        "informers_tags": [
+            "foodorigins"
+        ],
+        "vitamins_tags": [],
+        "lang": "en",
+        "downgraded": "non_recyclable_and_non_biodegradable_materials",
+        "origins_lc": "en",
+        "interface_version_modified": "20190830",
+        "additives_tags": [
+            "en:e330",
+            "en:e415"
+        ],
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/930/060/176/8226/nutrition_en.11.400.jpg",
+        "unknown_nutrients_tags": [],
+        "generic_name_en": "",
+        "countries_hierarchy": [
+            "en:australia"
+        ],
+        "nova_group_debug": " -- ingredients/en:salt : 3 -- ingredients/en:thickener : 4",
+        "obsolete_since_date": "",
+        "traces_tags": [
+            "en:nuts"
+        ],
+        "packaging_tags": [
+            "plastic",
+            "cardboard"
+        ],
+        "nova_groups": "4",
+        "allergens_from_ingredients": "Sesame Seeds, SESAME",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/930/060/176/8226/front_en.8.100.jpg",
+        "ingredients_analysis_tags": [
+            "en:palm-oil-content-unknown",
+            "en:vegan-status-unknown",
+            "en:vegetarian-status-unknown"
+        ],
+        "nutrient_levels": {
+            "salt": "moderate",
+            "sugars": "low",
+            "saturated-fat": "moderate",
+            "fat": "moderate"
+        },
+        "nutriscore_data": {
+            "proteins": 6.8,
+            "negative_points": 5,
+            "sugars_points": 0,
+            "score": -4,
+            "sodium_value": 375.9,
+            "positive_points": 9,
+            "is_water": 0,
+            "saturated_fat_value": 1.6,
+            "proteins_points": 4,
+            "saturated_fat_points": 1,
+            "saturated_fat_ratio": 8.55614973262032,
+            "proteins_value": 6.8,
+            "saturated_fat_ratio_points": 0,
+            "fiber_points": 5,
+            "grade": "a",
+            "is_cheese": 0,
+            "energy": 266,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 8,
+            "fiber": 5.5,
+            "energy_points": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 4,
+            "is_fat": 0,
+            "energy_value": 266,
+            "is_beverage": 0,
+            "fiber_value": 5.5,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 8,
+            "saturated_fat_ratio_value": 8.6,
+            "sugars_value": 0.4,
+            "saturated_fat": 1.6,
+            "sodium": 375.92,
+            "sugars": 0.4
+        },
+        "created_t": 1462775905,
+        "amino_acids_prev_tags": [],
+        "nova_group": 4,
+        "nutrition_grade_fr": "a",
+        "nucleotides_tags": [],
+        "images": {
+            "front_en": {
+                "rev": "8",
+                "white_magic": "false",
+                "geometry": "1125x1085-394-27",
+                "normalize": "true",
+                "sizes": {
+                    "400": {
+                        "h": 386,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 96,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1085,
+                        "w": 1125
+                    },
+                    "200": {
+                        "h": 193,
+                        "w": 200
+                    }
+                },
+                "imgid": "2"
+            },
+            "nutrition": {
+                "rev": "11",
+                "white_magic": "false",
+                "normalize": "true",
+                "sizes": {
+                    "400": {
+                        "h": 396,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 99,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 198,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 915,
+                        "w": 925
+                    }
+                },
+                "geometry": "925x915-146-401",
+                "imgid": "3"
+            },
+            "ingredients": {
+                "rev": "10",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 141,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 35,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 71,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 380,
+                        "w": 1075
+                    }
+                },
+                "normalize": "true",
+                "geometry": "1075x380-46-621",
+                "imgid": "4"
+            },
+            "3": {
+                "uploaded_t": "1462775923",
+                "uploader": "foodorigins",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1125,
+                        "w": 2000
+                    }
+                }
+            },
+            "nutrition_en": {
+                "rev": "11",
+                "white_magic": "false",
+                "normalize": "true",
+                "sizes": {
+                    "400": {
+                        "h": 396,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 99,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 198,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 915,
+                        "w": 925
+                    }
+                },
+                "geometry": "925x915-146-401",
+                "imgid": "3"
+            },
+            "ingredients_en": {
+                "rev": "10",
+                "white_magic": "false",
+                "sizes": {
+                    "400": {
+                        "h": 141,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 35,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 71,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 380,
+                        "w": 1075
+                    }
+                },
+                "normalize": "true",
+                "geometry": "1075x380-46-621",
+                "imgid": "4"
+            },
+            "1": {
+                "uploaded_t": "1462775905",
+                "uploader": "foodorigins",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1125,
+                        "w": 2000
+                    }
+                }
+            },
+            "4": {
+                "uploaded_t": "1462775939",
+                "uploader": "foodorigins",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 225
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 56
+                    },
+                    "full": {
+                        "h": 2000,
+                        "w": 1125
+                    }
+                }
+            },
+            "front": {
+                "rev": "8",
+                "white_magic": "false",
+                "geometry": "1125x1085-394-27",
+                "normalize": "true",
+                "sizes": {
+                    "400": {
+                        "h": 386,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 96,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1085,
+                        "w": 1125
+                    },
+                    "200": {
+                        "h": 193,
+                        "w": 200
+                    }
+                },
+                "imgid": "2"
+            },
+            "2": {
+                "uploaded_t": "1462775914",
+                "uploader": "foodorigins",
+                "sizes": {
+                    "400": {
+                        "h": 225,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 56,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1125,
+                        "w": 2000
+                    }
+                }
+            }
+        },
+        "ingredients_n": 13,
+        "editors_tags": [
+            "foodorigins",
+            "moon-rabbit"
+        ],
+        "countries_lc": "en",
+        "allergens_tags": [
+            "en:sesame-seeds"
+        ],
+        "traces_lc": "en",
+        "update_key": "key_1618065313",
+        "nucleotides_prev_tags": [],
+        "completed_t": 1462848468,
+        "environment_impact_level_tags": [],
+        "nova_groups_tags": [
+            "en:4-ultra-processed-food-and-drink-products"
+        ],
+        "manufacturing_places": "Australia",
+        "code": "9300601768226",
+        "codes_tags": [
+            "code-13",
+            "9300601768xxx",
+            "930060176xxxx",
+            "93006017xxxxx",
+            "9300601xxxxxx",
+            "930060xxxxxxx",
+            "93006xxxxxxxx",
+            "9300xxxxxxxxx",
+            "930xxxxxxxxxx",
+            "93xxxxxxxxxxx",
+            "9xxxxxxxxxxxx"
+        ],
+        "labels": "Gluten-free,Australian made,GF",
+        "last_modified_by": "moon-rabbit",
+        "last_edit_dates_tags": [
+            "2019-11-24",
+            "2019-11",
+            "2019"
+        ],
+        "entry_dates_tags": [
+            "2016-05-09",
+            "2016-05",
+            "2016"
+        ],
+        "creator": "foodorigins",
+        "ingredients_that_may_be_from_palm_oil_n": 0,
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "australian",
+            "made",
+            "gf",
+            "dip",
+            "cole",
+            "houmou",
+            "hommu",
+            "australia",
+            "mini",
+            "gluten-free"
+        ],
+        "link": "http://shop.coles.com.au/online/national/coles-mini-dips-hommus",
+        "ingredients_debug": [
+            "Cooked Chickpeas ",
+            "(",
+            "(",
+            null,
+            null,
+            "72%)",
+            ",",
+            null,
+            null,
+            null,
+            " Canola Oil",
+            ",",
+            null,
+            null,
+            null,
+            " Tahini ",
+            "(",
+            "(",
+            null,
+            null,
+            "8%)",
+            ",",
+            null,
+            null,
+            null,
+            " ",
+            "(",
+            "(",
+            null,
+            null,
+            "Sesame Seeds)",
+            ",",
+            null,
+            null,
+            null,
+            " Garlic",
+            ",",
+            null,
+            null,
+            null,
+            " Salt",
+            ",",
+            null,
+            null,
+            null,
+            " Extra Virgin Olive Oil",
+            ",",
+            null,
+            null,
+            null,
+            " Lemon Juice Concentrate",
+            ",",
+            null,
+            null,
+            null,
+            " Vinegar",
+            ",",
+            null,
+            null,
+            null,
+            " Acidity Regulator ",
+            "(",
+            "(",
+            null,
+            null,
+            "330)",
+            ",",
+            null,
+            null,
+            null,
+            " Thickener ",
+            "(",
+            "(",
+            null,
+            null,
+            "415)",
+            ". ",
+            null,
+            null,
+            null,
+            "CONTAINS SESAME "
+        ],
+        "languages_codes": {
+            "en": 5
+        },
+        "labels_lc": "en",
+        "packaging": "Plastic,Cardboard",
+        "ingredients_text_en": "Cooked Chickpeas (72%), Canola Oil, Tahini (8%), (Sesame Seeds), Garlic, Salt, Extra Virgin Olive Oil, Lemon Juice Concentrate, Vinegar, Acidity Regulator (330), Thickener (415). CONTAINS SESAME",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/930/060/176/8226/front_en.8.400.jpg",
+        "last_image_dates_tags": [
+            "2016-05-09",
+            "2016-05",
+            "2016"
+        ],
+        "popularity_key": 0,
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/930/060/176/8226/front_en.8.200.jpg",
+        "expiration_date": "09/May/16",
+        "data_quality_warnings_tags": [],
+        "misc_tags": [
+            "en:nutrition-fruits-vegetables-nuts-estimate-from-ingredients",
+            "en:nutrition-all-nutriscore-values-known",
+            "en:nutriscore-computed",
+            "en:ecoscore-missing-data-warning",
+            "en:ecoscore-computed"
+        ],
+        "states_tags": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "fruits-vegetables-nuts_100g_estimate": 0,
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "ecoscore_score": 81,
+        "debug_param_sorted_langs": [
+            "en"
+        ],
+        "photographers_tags": [
+            "foodorigins"
+        ],
+        "last_modified_t": 1574619108,
+        "ingredients": [
+            {
+                "percent_estimate": "72",
+                "percent_min": "72",
+                "percent": "72",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "72",
+                "id": "en:cooked-chickpeas",
+                "text": "Cooked Chickpeas"
+            },
+            {
+                "percent_estimate": 18,
+                "percent_min": "8",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "from_palm_oil": "no",
+                "percent_max": 28,
+                "id": "en:canola-oil",
+                "text": "Canola Oil"
+            },
+            {
+                "percent_estimate": "8",
+                "percent_min": "8",
+                "percent": "8",
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "percent_max": "8",
+                "id": "en:tahini",
+                "text": "Tahini"
+            },
+            {
+                "percent_max": "8",
+                "id": "en:garlic",
+                "percent_estimate": 1,
+                "percent_min": 0,
+                "text": "Garlic",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 6.66666666666667,
+                "id": "en:salt",
+                "percent_estimate": 0.5,
+                "percent_min": 0,
+                "text": "Salt",
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_min": 0,
+                "percent_estimate": 0.25,
+                "vegan": "yes",
+                "vegetarian": "yes",
+                "from_palm_oil": "no",
+                "percent_max": 5,
+                "id": "en:extra-virgin-olive-oil",
+                "text": "Extra Virgin Olive Oil"
+            },
+            {
+                "percent_max": 4,
+                "id": "en:lemon-juice-concentrate",
+                "text": "Lemon Juice Concentrate",
+                "percent_estimate": 0.125,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 3.33333333333333,
+                "id": "en:vinegar",
+                "text": "Vinegar",
+                "percent_estimate": 0.0625,
+                "percent_min": 0,
+                "vegan": "yes",
+                "vegetarian": "yes"
+            },
+            {
+                "percent_max": 2.85714285714286,
+                "id": "en:acidity-regulator",
+                "text": "Acidity Regulator",
+                "percent_estimate": 0.03125,
+                "percent_min": 0
+            },
+            {
+                "percent_max": 2.5,
+                "id": "en:thickener",
+                "percent_min": 0,
+                "percent_estimate": 0.03125,
+                "text": "Thickener"
+            }
+        ],
+        "nutriscore_grade": "a",
+        "countries": "Australia",
+        "stores": "Coles",
+        "cities_tags": [],
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "hummus"
+        ],
+        "brands": "Coles",
+        "obsolete": "",
+        "categories": "Plant-based foods and beverages, Plant-based foods, Spreads, Salted spreads, Plant-based spreads, Hummus",
+        "ingredients_text_with_allergens": "Cooked Chickpeas (72%), Canola Oil, Tahini (8%), (<span class=\"allergen\">Sesame Seeds</span>), Garlic, Salt, Extra Virgin Olive Oil, Lemon Juice Concentrate, Vinegar, Acidity Regulator (330), Thickener (415). CONTAINS <span class=\"allergen\">SESAME</span>",
+        "environment_impact_level": "",
+        "states": "en:to-be-checked, en:complete, en:nutrition-facts-completed, en:ingredients-completed, en:expiration-date-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-validated, en:photos-uploaded",
+        "nutrition_grades": "a",
+        "nutrient_levels_tags": [
+            "en:fat-in-moderate-quantity",
+            "en:saturated-fat-in-moderate-quantity",
+            "en:sugars-in-low-quantity",
+            "en:salt-in-moderate-quantity"
+        ],
+        "known_ingredients_n": 27,
+        "minerals_prev_tags": [],
+        "ingredients_text": "Cooked Chickpeas (72%), Canola Oil, Tahini (8%), (Sesame Seeds), Garlic, Salt, Extra Virgin Olive Oil, Lemon Juice Concentrate, Vinegar, Acidity Regulator (330), Thickener (415). CONTAINS SESAME",
+        "product_name": "Hommus Mini Dips",
+        "origins": "Australia",
+        "languages_tags": [
+            "en:english",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "allergens": "en:sesame-seeds",
+        "serving_quantity": 60,
+        "categories_lc": "en",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/930/060/176/8226/ingredients_en.10.100.jpg",
+        "ecoscore_data": {
+            "status": "known",
+            "grade_be": "b",
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:card",
+                            "material": "en:cardboard",
+                            "ecoscore_shape_ratio": "1",
+                            "ecoscore_material_score": "92"
+                        },
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:plastic",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": "0"
+                        }
+                    ],
+                    "score": -8,
+                    "warning": "unspecified_shape"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_es": 0,
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:australia",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_be": 0,
+                    "epi_score": 79,
+                    "transportation_score_ch": 0,
+                    "epi_value": 3,
+                    "transportation_score_ie": 0,
+                    "value_nl": 3,
+                    "value_ie": 3,
+                    "transportation_value_de": 0,
+                    "value_fr": 3,
+                    "value_be": 3,
+                    "value_es": 3,
+                    "transportation_score_it": 0,
+                    "transportation_value_ie": 0,
+                    "transportation_score_de": 0,
+                    "transportation_score_fr": 0,
+                    "origins_from_origins_field": [
+                        "en:australia"
+                    ],
+                    "transportation_value_lu": 0,
+                    "transportation_value_nl": 0,
+                    "value_ch": 3,
+                    "transportation_score_es": 0,
+                    "value_de": 3,
+                    "transportation_value_it": 0,
+                    "transportation_score_lu": 0,
+                    "value_it": 3,
+                    "value_lu": 3,
+                    "transportation_score_nl": 0
+                },
+                "threatened_species": {}
+            },
+            "grade_fr": "b",
+            "score": 81,
+            "grade_de": "b",
+            "missing_data_warning": 1,
+            "grade_nl": "b",
+            "score_be": 84,
+            "agribalyse": {
+                "co2_transportation": "0.28181731",
+                "ef_distribution": "0.0089786658",
+                "name_fr": "Houmous",
+                "score": 91,
+                "agribalyse_food_code": "25621",
+                "ef_agriculture": "0.093986069",
+                "ef_consumption": "0.0024293397",
+                "name_en": "Hummus",
+                "co2_total": "0.9679808",
+                "ef_packaging": "0.020453713999999998",
+                "ef_processing": "0.034307027000000004",
+                "is_beverage": 0,
+                "dqr": "2.95",
+                "co2_processing": "0.15726908",
+                "code": "25621",
+                "co2_consumption": "0.0047993021",
+                "co2_distribution": "0.030685111",
+                "ef_total": "0.18435258999999998",
+                "co2_agriculture": "0.30474851",
+                "ef_transportation": "0.024196791999999998",
+                "co2_packaging": "0.18864842"
+            },
+            "grade_it": "b",
+            "score_nl": 84,
+            "missing": {
+                "packagings": 1,
+                "labels": 1
+            },
+            "grade_ie": "b",
+            "score_ch": 84,
+            "score_de": 84,
+            "score_fr": 84,
+            "score_ie": 84,
+            "score_lu": 84,
+            "score_it": 84,
+            "score_es": 84,
+            "grade_es": "b",
+            "grade_ch": "b",
+            "grade_lu": "b",
+            "grade": "b"
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/930/060/176/8226/nutrition_en.11.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/930/060/176/8226/nutrition_en.11.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/930/060/176/8226/nutrition_en.11.200.jpg"
+                }
+            },
+            "ingredients": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/930/060/176/8226/ingredients_en.10.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/930/060/176/8226/ingredients_en.10.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/930/060/176/8226/ingredients_en.10.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/930/060/176/8226/front_en.8.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/930/060/176/8226/front_en.8.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/930/060/176/8226/front_en.8.200.jpg"
+                }
+            }
+        },
+        "origins_old": "Australia",
+        "rev": 13,
+        "ingredients_from_or_that_may_be_from_palm_oil_n": 0,
+        "last_editor": "moon-rabbit",
+        "additives_prev_original_tags": [
+            "en:e330",
+            "en:e415"
+        ],
+        "ingredients_tags": [
+            "en:cooked-chickpeas",
+            "en:legume",
+            "en:chickpea",
+            "en:canola-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:rapeseed-oil",
+            "en:tahini",
+            "en:seed",
+            "en:sesame",
+            "en:sesame-paste",
+            "en:garlic",
+            "en:vegetable",
+            "en:root-vegetable",
+            "en:salt",
+            "en:extra-virgin-olive-oil",
+            "en:vegetable-oil",
+            "en:olive-oil",
+            "en:virgin-olive-oil",
+            "en:lemon-juice-concentrate",
+            "en:fruit",
+            "en:citrus-fruit",
+            "en:lemon",
+            "en:vinegar",
+            "en:acidity-regulator",
+            "en:thickener",
+            "en:sesame-seeds",
+            "en:330",
+            "en:415"
+        ],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/930/060/176/8226/nutrition_en.11.100.jpg",
+        "product_name_en": "Hommus Mini Dips",
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:spreads",
+            "en:salted-spreads",
+            "en:plant-based-spreads",
+            "en:hummus"
+        ],
+        "ecoscore_grade": "b",
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "languages": {
+            "en:english": 5
+        },
+        "nutrition_data": "on",
+        "ingredients_percent_analysis": 1,
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-25621",
+            "agribalyse-food-code-known",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-25621",
+            "ciqual-food-code-known",
+            "agribalyse-known",
+            "agribalyse-25621"
+        ],
+        "purchase_places": "Lisarow,NSW,Australia",
+        "id": "9300601768226",
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Salty snacks",
+        "allergens_from_user": "(en) en:sesame-seeds",
+        "nutrition_data_prepared": "",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/930/060/176/8226/ingredients_en.10.400.jpg",
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients": 1,
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "additives_old_tags": [],
+        "labels_hierarchy": [
+            "en:gluten-free",
+            "en:australian-made",
+            "en:GF"
+        ],
+        "ecoscore_tags": [
+            "b"
+        ],
+        "ingredients_from_palm_oil_n": 0,
+        "origins_hierarchy": [
+            "en:australia"
+        ],
+        "complete": 1,
+        "nutrition_score_beverage": 0,
+        "pnns_groups_2": "Salty and fatty products",
+        "product_quantity": 180,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/930/060/176/8226/front_en.8.100.jpg",
+        "ingredients_text_debug": "Cooked Chickpeas (72%), Canola Oil, Tahini (8%), (Sesame Seeds), Garlic, Salt, Extra Virgin Olive Oil, Lemon Juice Concentrate, Vinegar, Acidity Regulator (330), Thickener (415). CONTAINS SESAME ",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/930/060/176/8226/front_en.8.400.jpg",
+        "_id": "9300601768226",
+        "countries_tags": [
+            "en:australia"
+        ],
+        "serving_size": "60g",
+        "ingredients_hierarchy": [
+            "en:cooked-chickpeas",
+            "en:legume",
+            "en:chickpea",
+            "en:canola-oil",
+            "en:oil-and-fat",
+            "en:vegetable-oil-and-fat",
+            "en:rapeseed-oil",
+            "en:tahini",
+            "en:seed",
+            "en:sesame",
+            "en:sesame-paste",
+            "en:garlic",
+            "en:vegetable",
+            "en:root-vegetable",
+            "en:salt",
+            "en:extra-virgin-olive-oil",
+            "en:vegetable-oil",
+            "en:olive-oil",
+            "en:virgin-olive-oil",
+            "en:lemon-juice-concentrate",
+            "en:fruit",
+            "en:citrus-fruit",
+            "en:lemon",
+            "en:vinegar",
+            "en:acidity-regulator",
+            "en:thickener",
+            "en:sesame-seeds",
+            "en:330",
+            "en:415"
+        ],
+        "stores_tags": [
+            "coles"
+        ],
+        "additives_original_tags": [
+            "en:e330",
+            "en:e415"
+        ],
+        "nutriscore_score": -4,
+        "compared_to_category": "en:hummus",
+        "states_hierarchy": [
+            "en:to-be-checked",
+            "en:complete",
+            "en:nutrition-facts-completed",
+            "en:ingredients-completed",
+            "en:expiration-date-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-validated",
+            "en:photos-uploaded"
+        ],
+        "ingredients_n_tags": [
+            "13",
+            "11-20"
+        ],
+        "pnns_groups_1_tags": [
+            "salty-snacks",
+            "known"
+        ],
+        "additives_old_n": 0,
+        "packagings": [
+            {
+                "shape": "en:card",
+                "material": "en:cardboard"
+            },
+            {
+                "material": "en:plastic"
+            }
+        ],
+        "data_quality_errors_tags": [],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "brands_tags": [
+            "coles"
+        ],
+        "quantity": "180g (3x60g)",
+        "ingredients_ids_debug": [
+            "cooked-chickpeas",
+            "72",
+            "canola-oil",
+            "tahini",
+            "8",
+            "sesame-seeds",
+            "garlic",
+            "salt",
+            "extra-virgin-olive-oil",
+            "lemon-juice-concentrate",
+            "vinegar",
+            "acidity-regulator",
+            "330",
+            "thickener",
+            "415",
+            "contains-sesame"
+        ],
+        "vitamins_prev_tags": [],
+        "nutrition_score_warning_fruits_vegetables_nuts_estimate_from_ingredients_value": 8,
+        "traces": "en:nuts",
+        "ingredients_original_tags": [
+            "en:cooked-chickpeas",
+            "en:canola-oil",
+            "en:tahini",
+            "en:garlic",
+            "en:salt",
+            "en:extra-virgin-olive-oil",
+            "en:lemon-juice-concentrate",
+            "en:vinegar",
+            "en:acidity-regulator",
+            "en:thickener",
+            "en:sesame-seeds",
+            "en:330",
+            "en:415"
+        ],
+        "unknown_ingredients_n": 2,
+        "manufacturing_places_tags": [
+            "australia"
+        ],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "emb_codes": "",
+        "max_imgid": "4",
+        "nutriscore_score_opposite": 4,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/930/060/176/8226/front_en.8.200.jpg",
+        "nutriments": {
+            "salt_serving": 0.564,
+            "proteins": 6.8,
+            "energy_100g": 266,
+            "carbohydrates_unit": "g",
+            "saturated-fat_serving": 0.96,
+            "energy-kj_100g": 266,
+            "sodium_100g": 0.37592,
+            "sugars_100g": 0.4,
+            "sodium_value": 375.92,
+            "proteins_serving": 4.08,
+            "salt_100g": 0.9398,
+            "nova-group_serving": 4,
+            "energy_unit": "kJ",
+            "nutrition-score-fr_100g": -4,
+            "energy-kj_serving": 160,
+            "salt_unit": "mg",
+            "proteins_unit": "g",
+            "carbohydrates_value": 15.3,
+            "sugars_unit": "g",
+            "sugars_serving": 0.24,
+            "energy-kj_unit": "kJ",
+            "fat_unit": "g",
+            "salt": 0.9398,
+            "salt_value": 939.8,
+            "fiber_serving": 3.3,
+            "proteins_value": 6.8,
+            "saturated-fat_100g": 1.6,
+            "fat_serving": 11.2,
+            "fiber_100g": 5.5,
+            "saturated-fat": 1.6,
+            "fruits-vegetables-nuts-estimate-from-ingredients_100g": 8,
+            "fat_value": 18.7,
+            "nova-group": 4,
+            "energy": 266,
+            "fiber": 5.5,
+            "saturated-fat_value": 1.6,
+            "nova-group_100g": 4,
+            "fat_100g": 18.7,
+            "energy_serving": 160,
+            "saturated-fat_unit": "g",
+            "energy_value": 266,
+            "sodium_serving": 0.226,
+            "energy-kj_value": 266,
+            "fiber_value": 5.5,
+            "fiber_unit": "g",
+            "energy-kj": 266,
+            "proteins_100g": 6.8,
+            "sugars_value": 0.4,
+            "nutrition-score-fr": -4,
+            "sodium_unit": "mg",
+            "carbohydrates_serving": 9.18,
+            "carbohydrates_100g": 15.3,
+            "sodium": 0.37592,
+            "sugars": 0.4,
+            "carbohydrates": 15.3,
+            "fat": 18.7
+        },
+        "purchase_places_tags": [
+            "lisarow",
+            "nsw",
+            "australia"
+        ],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/930/060/176/8226/ingredients_en.10.200.jpg",
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/930/060/176/8226/nutrition_en.11.200.jpg"
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/9300650658615.json
+++ b/testdata/product/9300650658615.json
@@ -1,0 +1,762 @@
+{
+    "status": 1,
+    "code": "9300650658615",
+    "product": {
+        "lc": "en",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "traces_debug_tags": [],
+        "popularity_tags": [
+            "bottom-25-percent-scans-2019",
+            "bottom-20-percent-scans-2019",
+            "bottom-15-percent-scans-2019",
+            "top-90-percent-scans-2019",
+            "top-country-fr-scans-2019"
+        ],
+        "categories_tags": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:spreads",
+            "en:salted-spreads",
+            "en:plant-based-spreads",
+            "en:yeast-extract-spreads"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "product_name_fr": "",
+        "generic_name": "",
+        "origins_tags": [],
+        "languages_hierarchy": [
+            "en:english",
+            "en:french"
+        ],
+        "last_image_t": 1519765348,
+        "emb_codes_20141016": "",
+        "pnns_groups_2_tags": [
+            "salty-and-fatty-products",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "ingredients_text_with_allergens_en": "",
+        "correctors_tags": [
+            "teolemon",
+            "neptuno",
+            "autorotate-bot"
+        ],
+        "sortkey": 1562146757,
+        "product_name_en_debug_tags": [],
+        "categories_old": "Plant-based foods and beverages, Plant-based foods, Spreads, Salted spreads, Plant-based spreads, Yeast extract spreads",
+        "completeness": 0.683333333333333,
+        "categories_properties": {},
+        "labels_tags": [
+            "en:australian-made"
+        ],
+        "traces_from_user": "(en) ",
+        "informers_tags": [
+            "openfoodfacts-contributors",
+            "teolemon",
+            "molarambiguity",
+            "yuka.SGEweElvOHhoS1VNdHN3U3pneU40dmdxK3E2UmQweTRPOGNYSVE9PQ",
+            "kiliweb",
+            "neptuno",
+            "roboto-app"
+        ],
+        "generic_name_en_debug_tags": [],
+        "nutrition_grades_tags": [
+            "c"
+        ],
+        "vitamins_tags": [],
+        "lang": "en",
+        "origins_lc": "en",
+        "interface_version_modified": "20150316.jqm2",
+        "ingredients_text_en_debug_tags": [],
+        "unique_scans_n": 1,
+        "additives_tags": [],
+        "unknown_nutrients_tags": [],
+        "generic_name_en": "",
+        "stores_debug_tags": [],
+        "nova_group_debug": "no nova group when the product does not have ingredients",
+        "countries_hierarchy": [
+            "en:australia"
+        ],
+        "traces_tags": [],
+        "packaging_tags": [
+            "jar"
+        ],
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/930/065/065/8615/front_en.12.100.jpg",
+        "nutrient_levels": {
+            "sugars": "low",
+            "salt": "moderate",
+            "fat": "low",
+            "saturated-fat": "low"
+        },
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "created_t": 1396768379,
+        "nutriscore_data": {
+            "proteins": 0,
+            "negative_points": 4,
+            "sugars_points": 0,
+            "sodium_value": 400,
+            "score": 4,
+            "positive_points": 0,
+            "saturated_fat_value": 0,
+            "is_water": 0,
+            "proteins_points": 0,
+            "saturated_fat_points": 0,
+            "saturated_fat_ratio": 0,
+            "proteins_value": 0,
+            "saturated_fat_ratio_points": 0,
+            "fiber_points": 0,
+            "grade": "c",
+            "is_cheese": 0,
+            "energy": 25,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_value": 0,
+            "fiber": 0,
+            "energy_points": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils_points": 0,
+            "sodium_points": 4,
+            "is_fat": 0,
+            "energy_value": 25,
+            "is_beverage": 0,
+            "fiber_value": 0,
+            "fruits_vegetables_nuts_colza_walnut_olive_oils": 0,
+            "saturated_fat_ratio_value": 0,
+            "sugars_value": 1,
+            "saturated_fat": 0,
+            "sodium": 400,
+            "sugars": 1
+        },
+        "amino_acids_prev_tags": [],
+        "nutrition_grade_fr": "c",
+        "purchase_places_debug_tags": [],
+        "scans_n": 1,
+        "nucleotides_tags": [],
+        "ingredients_text_with_allergens_fr": "",
+        "images": {
+            "front_en": {
+                "y1": "35.49999999999998",
+                "y2": "236.50000000000003",
+                "rev": "12",
+                "x2": "361.1875",
+                "white_magic": "false",
+                "x1": "82.18749999999996",
+                "sizes": {
+                    "400": {
+                        "h": 371,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 93,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1302,
+                        "w": 1404
+                    },
+                    "200": {
+                        "h": 185,
+                        "w": 200
+                    }
+                },
+                "angle": "0",
+                "geometry": "1806x1302-532-230",
+                "normalize": "false",
+                "imgid": "1"
+            },
+            "3": {
+                "uploaded_t": 1396768435,
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 299
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2592,
+                        "w": 1936
+                    }
+                }
+            },
+            "ingredients_en": {
+                "y1": "-1",
+                "y2": "-1",
+                "rev": "19",
+                "x2": "-1",
+                "white_magic": null,
+                "x1": "-1",
+                "ocr": 1,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 1599,
+                        "w": 1200
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 150
+                    }
+                },
+                "angle": -270,
+                "orientation": "0",
+                "geometry": "0x0--4--3",
+                "normalize": null,
+                "imgid": "4"
+            },
+            "1": {
+                "uploaded_t": 1396768380,
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 299
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2592,
+                        "w": 1936
+                    }
+                }
+            },
+            "4": {
+                "uploaded_t": "1519765348",
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 1200,
+                        "w": 1599
+                    }
+                }
+            },
+            "front": {
+                "rev": "3",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 299
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2592,
+                        "w": 1936
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 149
+                    }
+                },
+                "normalize": null,
+                "geometry": "0x0--6--6",
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": 1396768401,
+                "uploader": "openfoodfacts-contributors",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 299
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 2592,
+                        "w": 1936
+                    }
+                }
+            },
+            "ingredients_fr": {
+                "y1": "-1",
+                "rev": "20",
+                "y2": "-1",
+                "x2": "-1",
+                "ocr": 1,
+                "white_magic": null,
+                "x1": "-1",
+                "sizes": {
+                    "400": {
+                        "h": 400,
+                        "w": 300
+                    },
+                    "100": {
+                        "h": 100,
+                        "w": 75
+                    },
+                    "full": {
+                        "h": 1599,
+                        "w": 1200
+                    },
+                    "200": {
+                        "h": 200,
+                        "w": 150
+                    }
+                },
+                "angle": -270,
+                "orientation": "0",
+                "normalize": null,
+                "geometry": "0x0--4--3",
+                "imgid": "4"
+            }
+        },
+        "editors_tags": [
+            "teolemon",
+            "kiliweb",
+            "autorotate-bot",
+            "molarambiguity",
+            "openfoodfacts-contributors",
+            "neptuno",
+            "roboto-app",
+            "yuka.SGEweElvOHhoS1VNdHN3U3pneU40dmdxK3E2UmQweTRPOGNYSVE9PQ"
+        ],
+        "manufacturing_places_debug_tags": [],
+        "allergens_tags": [],
+        "countries_lc": "en",
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "emb_codes_debug_tags": [],
+        "manufacturing_places": "",
+        "code": "9300650658615",
+        "codes_tags": [
+            "code-13",
+            "9300650658xxx",
+            "930065065xxxx",
+            "93006506xxxxx",
+            "9300650xxxxxx",
+            "930065xxxxxxx",
+            "93006xxxxxxxx",
+            "9300xxxxxxxxx",
+            "930xxxxxxxxxx",
+            "93xxxxxxxxxxx",
+            "9xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "roboto-app",
+        "labels": "en:australian-made",
+        "entry_dates_tags": [
+            "2014-04-06",
+            "2014-04",
+            "2014"
+        ],
+        "last_edit_dates_tags": [
+            "2019-07-03",
+            "2019-07",
+            "2019"
+        ],
+        "creator": "openfoodfacts-contributors",
+        "nutrition_data_prepared_per": "100g",
+        "amino_acids_tags": [],
+        "_keywords": [
+            "salted",
+            "extract",
+            "food",
+            "spread",
+            "beverage",
+            "plant-based",
+            "and",
+            "yeast",
+            "australian-made",
+            "vegemite"
+        ],
+        "link": "",
+        "ingredients_debug": [],
+        "labels_lc": "en",
+        "languages_codes": {
+            "fr": 1,
+            "en": 3
+        },
+        "packaging": "Jar",
+        "ingredients_text_en": "",
+        "packaging_debug_tags": [],
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/930/065/065/8615/front_en.12.400.jpg",
+        "popularity_key": 1,
+        "last_image_dates_tags": [
+            "2018-02-27",
+            "2018-02",
+            "2018"
+        ],
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/930/065/065/8615/front_en.12.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutrition-no-fiber",
+            "en:nutrition-no-fruits-vegetables-nuts",
+            "en:nutrition-no-fiber-or-fruits-vegetables-nuts",
+            "en:nutriscore-computed",
+            "en:ecoscore-not-computed"
+        ],
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "generic_name_fr_debug_tags": [],
+        "photographers_tags": [
+            "openfoodfacts-contributors",
+            "kiliweb"
+        ],
+        "product_name_fr_debug_tags": [],
+        "debug_param_sorted_langs": [
+            "en",
+            "fr"
+        ],
+        "last_modified_t": 1562146757,
+        "ingredients": [],
+        "product_name_debug_tags": [],
+        "nutriscore_grade": "c",
+        "stores": "",
+        "countries": "Australia",
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "cities_tags": [],
+        "brands": "Vegemite",
+        "categories": "Plant-based foods and beverages, Plant-based foods, Spreads, Salted spreads, Plant-based spreads, Yeast extract spreads",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-to-be-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-completed, en:categories-completed, en:brands-completed, en:packaging-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:photos-uploaded",
+        "ingredients_text_with_allergens": "",
+        "nutrition_grades": "c",
+        "nutrient_levels_tags": [
+            "en:fat-in-low-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-low-quantity",
+            "en:salt-in-moderate-quantity"
+        ],
+        "minerals_prev_tags": [],
+        "product_name": "Vegemite",
+        "ingredients_text": "",
+        "serving_size_debug_tags": [],
+        "origins": "",
+        "languages_tags": [
+            "en:english",
+            "en:french",
+            "en:2",
+            "en:multilingual"
+        ],
+        "data_quality_bugs_tags": [],
+        "ingredients_text_fr": "",
+        "lang_debug_tags": [],
+        "categories_lc": "en",
+        "allergens": "",
+        "image_ingredients_thumb_url": "https://static.openfoodfacts.net/images/products/930/065/065/8615/ingredients_en.19.100.jpg",
+        "ecoscore_data": {
+            "missing_agribalyse_match_warning": 1,
+            "status": "unknown",
+            "agribalyse": {
+                "warning": "missing_agribalyse_match"
+            },
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 0,
+                    "packagings": [
+                        {
+                            "shape": "en:jar",
+                            "material": "en:unknown",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "score": 0,
+                    "warning": "unscored_shape"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "epi_value": -5,
+                    "transportation_score_ch": 0,
+                    "value_ie": -5,
+                    "transportation_value_de": 0,
+                    "value_fr": -5,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "transportation_score_nl": 0,
+                    "value_lu": -5
+                },
+                "threatened_species": {
+                    "warning": "ingredients_missing"
+                }
+            },
+            "missing": {
+                "agb_category": 1,
+                "packagings": 1,
+                "ingredients": 1,
+                "labels": 1,
+                "origins": 1
+            }
+        },
+        "selected_images": {
+            "ingredients": {
+                "display": {
+                    "fr": "https://static.openfoodfacts.net/images/products/930/065/065/8615/ingredients_fr.20.400.jpg",
+                    "en": "https://static.openfoodfacts.net/images/products/930/065/065/8615/ingredients_en.19.400.jpg"
+                },
+                "thumb": {
+                    "fr": "https://static.openfoodfacts.net/images/products/930/065/065/8615/ingredients_fr.20.100.jpg",
+                    "en": "https://static.openfoodfacts.net/images/products/930/065/065/8615/ingredients_en.19.100.jpg"
+                },
+                "small": {
+                    "fr": "https://static.openfoodfacts.net/images/products/930/065/065/8615/ingredients_fr.20.200.jpg",
+                    "en": "https://static.openfoodfacts.net/images/products/930/065/065/8615/ingredients_en.19.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/930/065/065/8615/front_en.12.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/930/065/065/8615/front_en.12.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/930/065/065/8615/front_en.12.200.jpg"
+                }
+            }
+        },
+        "rev": "20",
+        "origins_old": "",
+        "last_editor": "autorotate-bot",
+        "additives_prev_original_tags": [],
+        "data_sources_tags": [
+            "app-yuka",
+            "apps"
+        ],
+        "ingredients_tags": [],
+        "product_name_en": "Vegemite",
+        "ingredients_from_palm_oil_tags": [],
+        "nutrition_data_prepared_per_debug_tags": [],
+        "categories_hierarchy": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:spreads",
+            "en:salted-spreads",
+            "en:plant-based-spreads",
+            "en:yeast-extract-spreads"
+        ],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "unknown",
+        "ingredients_percent_analysis": 1,
+        "nutrition_data": "on",
+        "languages": {
+            "en:english": 3,
+            "en:french": 1
+        },
+        "purchase_places": "",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-unknown",
+            "agribalyse-unknown"
+        ],
+        "id": "9300650658615",
+        "no_nutrition_data": "",
+        "pnns_groups_1": "Salty snacks",
+        "nutrition_data_prepared": "",
+        "allergens_from_user": "(en) ",
+        "additives_debug_tags": [],
+        "image_ingredients_url": "https://static.openfoodfacts.net/images/products/930/065/065/8615/ingredients_en.19.400.jpg",
+        "nutrition_score_warning_no_fiber": 1,
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "additives_old_tags": [],
+        "origins_hierarchy": [],
+        "ecoscore_tags": [
+            "unknown"
+        ],
+        "labels_hierarchy": [
+            "en:australian-made"
+        ],
+        "nutrition_score_beverage": 0,
+        "pnns_groups_2": "Salty and fatty products",
+        "ingredients_text_fr_debug_tags": [],
+        "complete": 0,
+        "product_quantity": 600,
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/930/065/065/8615/front_en.12.100.jpg",
+        "ingredients_text_debug": "",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/930/065/065/8615/front_en.12.400.jpg",
+        "_id": "9300650658615",
+        "countries_tags": [
+            "en:australia"
+        ],
+        "ingredients_hierarchy": [],
+        "additives_original_tags": [],
+        "stores_tags": [],
+        "nutriscore_score": 4,
+        "compared_to_category": "en:yeast-extract-spreads",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:photos-uploaded"
+        ],
+        "expiration_date_debug_tags": [],
+        "pnns_groups_1_tags": [
+            "salty-snacks",
+            "known"
+        ],
+        "packagings": [
+            {
+                "shape": "en:jar"
+            }
+        ],
+        "quantity": "600 g",
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "brands_tags": [
+            "vegemite"
+        ],
+        "data_quality_errors_tags": [],
+        "link_debug_tags": [],
+        "ingredients_ids_debug": [],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [],
+        "traces": "",
+        "data_sources": "App - yuka, Apps",
+        "manufacturing_places_tags": [],
+        "quantity_debug_tags": [],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "max_imgid": "4",
+        "emb_codes": "",
+        "nutrition_data_per_debug_tags": [],
+        "editors": [
+            "",
+            "teolemon"
+        ],
+        "allergens_debug_tags": [],
+        "nutriscore_score_opposite": -4,
+        "image_small_url": "https://static.openfoodfacts.net/images/products/930/065/065/8615/front_en.12.200.jpg",
+        "generic_name_fr": "",
+        "brands_debug_tags": [],
+        "nutriments": {
+            "proteins": 0,
+            "energy_100g": 25,
+            "carbohydrates_unit": "g",
+            "sodium_100g": 0.4,
+            "sugars_100g": 1,
+            "energy-kcal": 6,
+            "sodium_value": 0.4,
+            "salt_100g": 1,
+            "energy_unit": "kcal",
+            "nutrition-score-fr_100g": 4,
+            "salt_unit": "g",
+            "proteins_unit": "g",
+            "carbohydrates_value": 5,
+            "sugars_unit": "g",
+            "fat_unit": "g",
+            "salt_value": 1,
+            "salt": 1,
+            "proteins_value": 0,
+            "saturated-fat_100g": 0,
+            "energy-kcal_100g": 6,
+            "saturated-fat": 0,
+            "fat_value": 0,
+            "energy": 25,
+            "saturated-fat_value": 0,
+            "energy-kcal_value": 6,
+            "fat_100g": 0,
+            "saturated-fat_unit": "g",
+            "energy_value": 6,
+            "proteins_100g": 0,
+            "sugars_value": 1,
+            "sodium_unit": "g",
+            "nutrition-score-fr": 4,
+            "sodium": 0.4,
+            "carbohydrates_100g": 5,
+            "sugars": 1,
+            "carbohydrates": 5,
+            "energy-kcal_unit": "kcal",
+            "fat": 0
+        },
+        "purchase_places_tags": [],
+        "image_ingredients_small_url": "https://static.openfoodfacts.net/images/products/930/065/065/8615/ingredients_en.19.200.jpg",
+        "nutrition_score_warning_no_fruits_vegetables_nuts": 1,
+        "additives_tags_n": null
+    },
+    "status_verbose": "product found"
+}

--- a/testdata/product/9310155100335.json
+++ b/testdata/product/9310155100335.json
@@ -1,0 +1,629 @@
+{
+    "status": 1,
+    "code": "9310155100335",
+    "product": {
+        "lc": "en",
+        "traces_from_ingredients": "",
+        "category_properties": {},
+        "popularity_tags": [
+            "top-country-au-scans-2019",
+            "bottom-25-percent-scans-2020",
+            "bottom-20-percent-scans-2020",
+            "top-85-percent-scans-2020",
+            "top-90-percent-scans-2020",
+            "top-5000-au-scans-2020",
+            "top-10000-au-scans-2020",
+            "top-50000-au-scans-2020",
+            "top-100000-au-scans-2020",
+            "top-country-au-scans-2020"
+        ],
+        "categories_tags": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:cereals-and-potatoes",
+            "en:cereals-and-their-products",
+            "en:pastas",
+            "en:spaghetti"
+        ],
+        "traces_hierarchy": [],
+        "allergens_hierarchy": [],
+        "generic_name": "",
+        "origins_tags": [],
+        "languages_hierarchy": [
+            "en:english"
+        ],
+        "last_image_t": 1603337409,
+        "emb_codes_20141016": "",
+        "pnns_groups_2_tags": [
+            "cereals",
+            "known"
+        ],
+        "emb_codes_tags": [],
+        "correctors_tags": [
+            "archanox",
+            "kiliweb"
+        ],
+        "ingredients_text_with_allergens_en": "",
+        "sortkey": 1603337409,
+        "categories_old": "Plant-based foods and beverages, Plant-based foods, Cereals and potatoes, Cereals and their products, Pastas, Spaghetti",
+        "categories_properties": {},
+        "completeness": 0.575,
+        "labels_tags": [],
+        "traces_from_user": "(en) ",
+        "informers_tags": [
+            "thogan",
+            "teolemon",
+            "archanox",
+            "yuka.sY2b0xO6T85zoF3NwEKvlkhOYejmuWvDEhHhlVCB5_qMD4b5X-B_0rT4DKs",
+            "kiliweb"
+        ],
+        "nutrition_grades_tags": [
+            "unknown"
+        ],
+        "lang": "en",
+        "vitamins_tags": [],
+        "origins_lc": "en",
+        "interface_version_modified": "20150316.jqm2",
+        "additives_tags": [],
+        "unique_scans_n": 1,
+        "image_nutrition_url": "https://static.openfoodfacts.net/images/products/931/015/510/0335/nutrition_en.12.400.jpg",
+        "generic_name_en": "",
+        "unknown_nutrients_tags": [],
+        "nova_group_debug": "no nova group when the product does not have ingredients",
+        "countries_hierarchy": [
+            "en:australia"
+        ],
+        "traces_tags": [],
+        "packaging_tags": [],
+        "allergens_from_ingredients": "",
+        "image_thumb_url": "https://static.openfoodfacts.net/images/products/931/015/510/0335/front_en.10.100.jpg",
+        "nutrient_levels": {
+            "sugars": "low",
+            "fat": "low",
+            "saturated-fat": "low"
+        },
+        "nova_group_tags": [
+            "not-applicable"
+        ],
+        "created_t": 1374294199,
+        "amino_acids_prev_tags": [],
+        "scans_n": 2,
+        "nucleotides_tags": [],
+        "images": {
+            "nutrition_en": {
+                "y1": "-1",
+                "rev": "12",
+                "y2": "-1",
+                "x2": "-1",
+                "x1": "-1",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 162,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 40,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 285,
+                        "w": 704
+                    },
+                    "200": {
+                        "h": 81,
+                        "w": 200
+                    }
+                },
+                "angle": 0,
+                "normalize": null,
+                "geometry": "0x0--1--1",
+                "imgid": "3"
+            },
+            "front_en": {
+                "y1": "-1",
+                "y2": "-1",
+                "rev": "10",
+                "x2": "-1",
+                "white_magic": null,
+                "x1": "-1",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "200": {
+                        "h": 150,
+                        "w": 200
+                    }
+                },
+                "angle": 0,
+                "geometry": "0x0--1--1",
+                "normalize": null,
+                "imgid": "2"
+            },
+            "1": {
+                "uploaded_t": 1374294200,
+                "uploader": "thogan",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 720,
+                        "w": 960
+                    }
+                }
+            },
+            "front": {
+                "rev": "3",
+                "white_magic": null,
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "200": {
+                        "h": 150,
+                        "w": 200
+                    },
+                    "full": {
+                        "h": 720,
+                        "w": 960
+                    }
+                },
+                "normalize": null,
+                "geometry": "0x0--2--2",
+                "imgid": "1"
+            },
+            "2": {
+                "uploaded_t": 1603337407,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 300,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 75,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 300,
+                        "w": 400
+                    }
+                }
+            },
+            "3": {
+                "uploaded_t": 1603337409,
+                "uploader": "kiliweb",
+                "sizes": {
+                    "400": {
+                        "h": 162,
+                        "w": 400
+                    },
+                    "100": {
+                        "h": 40,
+                        "w": 100
+                    },
+                    "full": {
+                        "h": 285,
+                        "w": 704
+                    }
+                }
+            }
+        },
+        "editors_tags": [
+            "yuka.sY2b0xO6T85zoF3NwEKvlkhOYejmuWvDEhHhlVCB5_qMD4b5X-B_0rT4DKs",
+            "teolemon",
+            "kiliweb",
+            "thogan",
+            "archanox"
+        ],
+        "countries_lc": "en",
+        "allergens_tags": [],
+        "nucleotides_prev_tags": [],
+        "update_key": "key_1618065313",
+        "code": "9310155100335",
+        "manufacturing_places": "",
+        "codes_tags": [
+            "code-13",
+            "9310155100xxx",
+            "931015510xxxx",
+            "93101551xxxxx",
+            "9310155xxxxxx",
+            "931015xxxxxxx",
+            "93101xxxxxxxx",
+            "9310xxxxxxxxx",
+            "931xxxxxxxxxx",
+            "93xxxxxxxxxxx",
+            "9xxxxxxxxxxxx"
+        ],
+        "last_modified_by": "kiliweb",
+        "labels": "",
+        "entry_dates_tags": [
+            "2013-07-20",
+            "2013-07",
+            "2013"
+        ],
+        "last_edit_dates_tags": [
+            "2020-10-22",
+            "2020-10",
+            "2020"
+        ],
+        "creator": "thogan",
+        "nutrition_data_prepared_per": "100g",
+        "_keywords": [
+            "and",
+            "remo",
+            "beverage",
+            "spaghetti",
+            "potatoe",
+            "plant-based",
+            "food",
+            "pasta",
+            "san",
+            "their",
+            "cereal",
+            "product",
+            "thin"
+        ],
+        "amino_acids_tags": [],
+        "link": "",
+        "ingredients_debug": [],
+        "labels_lc": "en",
+        "languages_codes": {
+            "en": 3
+        },
+        "packaging": "",
+        "ingredients_text_en": "",
+        "minerals_tags": [],
+        "image_url": "https://static.openfoodfacts.net/images/products/931/015/510/0335/front_en.10.400.jpg",
+        "popularity_key": 8,
+        "last_image_dates_tags": [
+            "2020-10-22",
+            "2020-10",
+            "2020"
+        ],
+        "image_front_small_url": "https://static.openfoodfacts.net/images/products/931/015/510/0335/front_en.10.200.jpg",
+        "expiration_date": "",
+        "data_quality_warnings_tags": [],
+        "states_tags": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-to-be-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-to-be-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "misc_tags": [
+            "en:nutriscore-not-computed",
+            "en:nutrition-not-enough-data-to-compute-nutrition-score",
+            "en:nutriscore-missing-nutrition-data",
+            "en:nutriscore-missing-nutrition-data-sodium",
+            "en:ecoscore-not-computed"
+        ],
+        "countries_debug_tags": [],
+        "interface_version_created": "20120622",
+        "nutrition_data_per": "100g",
+        "photographers_tags": [
+            "thogan",
+            "kiliweb"
+        ],
+        "last_modified_t": 1603337409,
+        "ingredients": [],
+        "countries": "Australia",
+        "stores": "Woolworths, Coles",
+        "other_nutritional_substances_tags": [],
+        "ciqual_food_name_tags": [
+            "unknown"
+        ],
+        "cities_tags": [],
+        "brands": "San Remo",
+        "categories": "Plant-based foods and beverages, Plant-based foods, Cereals and potatoes, Cereals and their products, Pastas, Spaghetti",
+        "states": "en:to-be-completed, en:nutrition-facts-completed, en:ingredients-to-be-completed, en:expiration-date-to-be-completed, en:packaging-code-to-be-completed, en:characteristics-to-be-completed, en:categories-completed, en:brands-completed, en:packaging-to-be-completed, en:quantity-completed, en:product-name-completed, en:photos-to-be-validated, en:packaging-photo-to-be-selected, en:nutrition-photo-selected, en:ingredients-photo-to-be-selected, en:front-photo-selected, en:photos-uploaded",
+        "ingredients_text_with_allergens": "",
+        "nutrient_levels_tags": [
+            "en:fat-in-low-quantity",
+            "en:saturated-fat-in-low-quantity",
+            "en:sugars-in-low-quantity"
+        ],
+        "minerals_prev_tags": [],
+        "product_name": "Thin Spaghetti",
+        "ingredients_text": "",
+        "origins": "",
+        "languages_tags": [
+            "en:english",
+            "en:1"
+        ],
+        "data_quality_bugs_tags": [],
+        "allergens": "",
+        "categories_lc": "en",
+        "ecoscore_data": {
+            "missing_agribalyse_match_warning": 1,
+            "status": "unknown",
+            "agribalyse": {
+                "warning": "missing_agribalyse_match"
+            },
+            "adjustments": {
+                "production_system": {
+                    "warning": "no_label"
+                },
+                "origins_of_ingredients": {
+                    "transportation_value_fr": 0,
+                    "transportation_value_be": 0,
+                    "transportation_score_be": 0,
+                    "epi_score": 0,
+                    "transportation_score_ie": 0,
+                    "value_nl": -5,
+                    "value_es": -5,
+                    "transportation_value_ie": 0,
+                    "transportation_score_fr": 0,
+                    "transportation_value_lu": 0,
+                    "value_ch": -5,
+                    "transportation_score_es": 0,
+                    "value_de": -5,
+                    "value_it": -5,
+                    "transportation_score_lu": 0,
+                    "transportation_value_es": 0,
+                    "transportation_value_ch": 0,
+                    "aggregated_origins": [
+                        {
+                            "origin": "en:unknown",
+                            "percent": 100
+                        }
+                    ],
+                    "transportation_score_ch": 0,
+                    "epi_value": -5,
+                    "value_ie": -5,
+                    "value_fr": -5,
+                    "transportation_value_de": 0,
+                    "warning": "origins_are_100_percent_unknown",
+                    "value_be": -5,
+                    "transportation_score_it": 0,
+                    "transportation_score_de": 0,
+                    "origins_from_origins_field": [
+                        "en:unknown"
+                    ],
+                    "transportation_value_nl": 0,
+                    "transportation_value_it": 0,
+                    "value_lu": -5,
+                    "transportation_score_nl": 0
+                },
+                "packaging": {
+                    "value": -10,
+                    "non_recyclable_and_non_biodegradable_materials": 1,
+                    "packagings": [
+                        {
+                            "shape": "en:unknown",
+                            "material": "en:unknown",
+                            "non_recyclable_and_non_biodegradable": "maybe",
+                            "ecoscore_shape_ratio": 1,
+                            "ecoscore_material_score": 0
+                        }
+                    ],
+                    "score": 0,
+                    "warning": "unscored_shape"
+                },
+                "threatened_species": {
+                    "warning": "ingredients_missing"
+                }
+            },
+            "missing": {
+                "agb_category": 1,
+                "packagings": 1,
+                "labels": 1,
+                "ingredients": 1,
+                "origins": 1
+            }
+        },
+        "selected_images": {
+            "nutrition": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/931/015/510/0335/nutrition_en.12.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/931/015/510/0335/nutrition_en.12.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/931/015/510/0335/nutrition_en.12.200.jpg"
+                }
+            },
+            "front": {
+                "display": {
+                    "en": "https://static.openfoodfacts.net/images/products/931/015/510/0335/front_en.10.400.jpg"
+                },
+                "thumb": {
+                    "en": "https://static.openfoodfacts.net/images/products/931/015/510/0335/front_en.10.100.jpg"
+                },
+                "small": {
+                    "en": "https://static.openfoodfacts.net/images/products/931/015/510/0335/front_en.10.200.jpg"
+                }
+            }
+        },
+        "origins_old": "",
+        "rev": 12,
+        "last_editor": "kiliweb",
+        "additives_prev_original_tags": [],
+        "data_sources_tags": [
+            "app-yuka",
+            "apps"
+        ],
+        "ingredients_tags": [],
+        "image_nutrition_thumb_url": "https://static.openfoodfacts.net/images/products/931/015/510/0335/nutrition_en.12.100.jpg",
+        "labels_prev_tags": [],
+        "product_name_en": "Thin Spaghetti",
+        "ingredients_from_palm_oil_tags": [],
+        "categories_hierarchy": [
+            "en:plant-based-foods-and-beverages",
+            "en:plant-based-foods",
+            "en:cereals-and-potatoes",
+            "en:cereals-and-their-products",
+            "en:pastas",
+            "en:spaghetti"
+        ],
+        "ingredients_that_may_be_from_palm_oil_tags": [],
+        "ecoscore_grade": "unknown",
+        "labels_prev_hierarchy": [],
+        "languages": {
+            "en:english": 3
+        },
+        "ingredients_percent_analysis": 1,
+        "purchase_places": "",
+        "categories_properties_tags": [
+            "all-products",
+            "categories-known",
+            "agribalyse-food-code-unknown",
+            "agribalyse-proxy-food-code-unknown",
+            "ciqual-food-code-unknown",
+            "agribalyse-unknown"
+        ],
+        "id": "9310155100335",
+        "no_nutrition_data": null,
+        "pnns_groups_1": "Cereals and potatoes",
+        "allergens_from_user": "(en) ",
+        "additives_debug_tags": [],
+        "data_quality_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "additives_old_tags": [],
+        "origins_hierarchy": [],
+        "labels_hierarchy": [],
+        "ecoscore_tags": [
+            "unknown"
+        ],
+        "pnns_groups_2": "Cereals",
+        "nutrition_score_beverage": 0,
+        "complete": 0,
+        "product_quantity": "500",
+        "image_front_thumb_url": "https://static.openfoodfacts.net/images/products/931/015/510/0335/front_en.10.100.jpg",
+        "ingredients_text_debug": "",
+        "image_front_url": "https://static.openfoodfacts.net/images/products/931/015/510/0335/front_en.10.400.jpg",
+        "_id": "9310155100335",
+        "countries_tags": [
+            "en:australia"
+        ],
+        "ingredients_hierarchy": [],
+        "additives_original_tags": [],
+        "stores_tags": [
+            "woolworths",
+            "coles"
+        ],
+        "compared_to_category": "en:spaghetti",
+        "states_hierarchy": [
+            "en:to-be-completed",
+            "en:nutrition-facts-completed",
+            "en:ingredients-to-be-completed",
+            "en:expiration-date-to-be-completed",
+            "en:packaging-code-to-be-completed",
+            "en:characteristics-to-be-completed",
+            "en:categories-completed",
+            "en:brands-completed",
+            "en:packaging-to-be-completed",
+            "en:quantity-completed",
+            "en:product-name-completed",
+            "en:photos-to-be-validated",
+            "en:packaging-photo-to-be-selected",
+            "en:nutrition-photo-selected",
+            "en:ingredients-photo-to-be-selected",
+            "en:front-photo-selected",
+            "en:photos-uploaded"
+        ],
+        "pnns_groups_1_tags": [
+            "cereals-and-potatoes",
+            "known"
+        ],
+        "nutrition_score_debug": "missing sodium",
+        "packagings": [
+            {
+                "shape": "en:unknown",
+                "material": "en:unknown"
+            }
+        ],
+        "quantity": "500g",
+        "data_quality_errors_tags": [],
+        "brands_tags": [
+            "san-remo"
+        ],
+        "data_quality_info_tags": [
+            "en:ingredients-percent-analysis-ok"
+        ],
+        "ingredients_ids_debug": [],
+        "vitamins_prev_tags": [],
+        "ingredients_original_tags": [],
+        "traces": "",
+        "data_sources": "App - yuka, Apps",
+        "manufacturing_places_tags": [],
+        "emb_codes_orig": "",
+        "checkers_tags": [],
+        "max_imgid": "3",
+        "emb_codes": "",
+        "editors": [
+            "thogan",
+            "teolemon"
+        ],
+        "image_small_url": "https://static.openfoodfacts.net/images/products/931/015/510/0335/front_en.10.200.jpg",
+        "nutriments": {
+            "proteins": 12,
+            "fat_value": 2,
+            "energy_100g": 1528,
+            "energy": 1528,
+            "carbohydrates_unit": "g",
+            "sugars_100g": 2.48,
+            "energy-kcal": 365.2008,
+            "saturated-fat_value": 0.48,
+            "energy-kcal_value": 365.2008,
+            "energy_unit": "kcal",
+            "fat_100g": 2,
+            "proteins_unit": "g",
+            "saturated-fat_unit": "g",
+            "carbohydrates_value": 72,
+            "energy_value": 365.2008,
+            "sugars_unit": "g",
+            "fat_unit": "g",
+            "proteins_100g": 12,
+            "sugars_value": 2.48,
+            "carbohydrates_100g": 72,
+            "proteins_value": 12,
+            "saturated-fat_100g": 0.48,
+            "sugars": 2.48,
+            "energy-kcal_100g": 365.2008,
+            "carbohydrates": 72,
+            "saturated-fat": 0.48,
+            "energy-kcal_unit": "kcal",
+            "fat": 2
+        },
+        "purchase_places_tags": [],
+        "image_nutrition_small_url": "https://static.openfoodfacts.net/images/products/931/015/510/0335/nutrition_en.12.200.jpg",
+        "additives_tags_n": null
+    },
+    "status_verbose": "product found"
+}


### PR DESCRIPTION
This pull request makes use of `testdata` folder to store product payload to isolate the unmarshalling from the API component as long as making them faster. 

Also took the opportunity to switch `Rev` type from `string` to `json.Number` since it can be set as a string as well as an integer.