### PR TITLE
ci: Update deprecated action in release-please.yml and use 'go' as release type

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: simple
+          release-type: go
+          target-branch: develop


### PR DESCRIPTION
### What
Update deprecated GoogleCloudPlatform/release-please-action : https://github.com/openfoodfacts/.github/issues/39